### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   sonar:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/SE2-Machi-Koro/Server/security/code-scanning/1](https://github.com/SE2-Machi-Koro/Server/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block that grants only the minimal scopes required by this workflow. Since this job checks out the repository and runs a SonarCloud Gradle analysis without performing GitHub write operations, `contents: read` is usually sufficient at the workflow or job level.

The best minimal fix without changing existing functionality is to add a `permissions` block at the workflow root (so it applies to all jobs) with `contents: read`. This satisfies CodeQL’s recommendation and constrains the `GITHUB_TOKEN` to read-only repository contents, which is adequate for `actions/checkout` and typical Sonar analysis. Concretely, in `.github/workflows/sonarcloud.yml`, insert:

```yaml
permissions:
  contents: read
```

after the `on:` block (line 9) and before `jobs:` (line 10). No additional imports or methods are needed; this is purely a YAML configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
