### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,5 +1,8 @@
 name: SonarCloud Analysis
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/SE2-Machi-Koro/Server/security/code-scanning/5](https://github.com/SE2-Machi-Koro/Server/security/code-scanning/5)

In general, the fix is to explicitly declare a `permissions` block that restricts the `GITHUB_TOKEN` to the minimal scopes needed. This can be done at the top level of the workflow (applies to all jobs) or per job. For this workflow, the SonarCloud analysis only needs to read the repository contents; it does not push commits, create releases, or modify issues, so `contents: read` is sufficient as a safe baseline.

The best fix here is to add a top-level `permissions` section directly under the `name:` (and before `on:` or before `jobs:`) specifying `contents: read`. This documents that the workflow only needs read access and prevents it from accidentally gaining broader permissions if repository/organization defaults are more permissive or change later. Concretely, in `.github/workflows/sonarcloud.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 1 (the `name:` line) and before the existing `on:` block on line 3. No imports or additional methods are needed because this is a configuration-only change in the YAML workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
