### PR TITLE
Fix: Update appleboy/ssh-action to valid version tag v1.0.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         run: ./gradlew shadowJar
 
       - name: Deploy via SSH
-        uses: appleboy/ssh-action@036598dec4f7b97be1f6e1e2de87082d8fc01cc3
+        uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}


### PR DESCRIPTION
This pull request makes a minor update to the CI workflow by changing the version of the `appleboy/ssh-action` used for deployment.

- CI/CD Workflow Update:
  * Updated the `appleboy/ssh-action` in `.github/workflows/ci.yml` from a specific commit hash to the tagged version `v1.0.3` for better maintainability and clarity.