### PR TITLE
fix: force Node.js 24 for JavaScript actions across all CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     types: [opened, synchronize, reopened]
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -3,6 +3,9 @@ name: SonarCloud Analysis
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 on:
   push:
     branches:


### PR DESCRIPTION
Node.js 20 deprecation warnings were surfacing in CI. The fix sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` at the workflow level to suppress them.

## Changes

- **`.github/workflows/ci.yml`** — added top-level `env` with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"`
- **`.github/workflows/sonarcloud.yml`** — same env var added; previously missing, leaving `actions/checkout`, `actions/setup-java`, and `actions/cache` on the old Node.js runtime

```yaml
env:
  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
```