### PR TITLE
56 native websockets endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ The server implements **real-time bidirectional communication** between frontend
 - Instant message delivery across all connected clients
 - Automatic game state synchronization
 - Real-time notifications and events
-- SockJS fallback for browser compatibility
+- SockJS fallback for browser compatibility and testing
 
 ### Endpoint Details
 
 | Parameter | Value |
 |-----------|-------|
-| **URL** | `http://localhost:8080/ws` (SockJS), `ws://localhost:8080/ws` (native WebSocket) |
-| **Protocol** | STOMP over WebSocket with SockJS fallback |
+| **URL** | `ws://localhost:8080/ws` (native WebSocket), `http://localhost:8080/ws-sockjs` (SockJS) |
+| **Protocol** | STOMP over native WebSocket, with a separate SockJS fallback endpoint |
 | **Port** | 8080 |
 
 ### Message Broker Configuration
@@ -271,8 +271,8 @@ src/main/kotlin/org/machikoro/server/
 ### JavaScript/SockJS Example
 
 ```javascript
-// Initialize WebSocket connection
-const socket = new SockJS('/ws');
+// Initialize SockJS connection for browser fallback/testing
+const socket = new SockJS('/ws-sockjs');
 const stompClient = Stomp.over(socket);
 
 // Connect and subscribe

--- a/src/main/kotlin/org/machikoro/server/config/SecurityConfig.kt
+++ b/src/main/kotlin/org/machikoro/server/config/SecurityConfig.kt
@@ -21,11 +21,11 @@ class SecurityConfig {
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
         http
             .csrf { csrf ->
-                csrf.ignoringRequestMatchers("/ws", "/ws/**")
+                csrf.ignoringRequestMatchers("/ws", "/ws/**", "/ws-sockjs", "/ws-sockjs/**")
             }
             .authorizeHttpRequests { auth ->
                 auth.requestMatchers("/", "/index.html", "/css/**", "/js/**", "/webjars/**").permitAll()
-                auth.requestMatchers("/ws", "/ws/**").permitAll()
+                auth.requestMatchers("/ws", "/ws/**", "/ws-sockjs", "/ws-sockjs/**").permitAll()
                 auth.requestMatchers("/api/**").authenticated()
                 auth.anyRequest().authenticated()
             }

--- a/src/main/kotlin/org/machikoro/server/config/WebSocketConfig.kt
+++ b/src/main/kotlin/org/machikoro/server/config/WebSocketConfig.kt
@@ -11,6 +11,11 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @EnableWebSocketMessageBroker
 class WebSocketConfig : WebSocketMessageBrokerConfigurer {
 
+    companion object {
+        const val NATIVE_WS_ENDPOINT = "/ws"
+        const val SOCKJS_WS_ENDPOINT = "/ws-sockjs"
+    }
+
     @Value("\${websocket.allowed-origins:http://localhost:8080,http://localhost:3000}")
     internal lateinit var allowedOrigins: String
 
@@ -25,14 +30,17 @@ class WebSocketConfig : WebSocketMessageBrokerConfigurer {
 
     /**
      * Register STOMP endpoints for WebSocket connections.
-     * Registers the /ws endpoint with CORS configured via property and SockJS fallback support.
+     * Registers a native WebSocket endpoint for Android clients and a separate SockJS endpoint
+     * for browser/testing flows that still rely on fallback transports.
      * Allowed origins are configured via the 'websocket.allowed-origins' property.
      */
     override fun registerStompEndpoints(registry: StompEndpointRegistry) {
         val origins = allowedOrigins.split(",").map { it.trim() }.toTypedArray()
-        registry.addEndpoint("/ws")
+        registry.addEndpoint(NATIVE_WS_ENDPOINT)
+            .setAllowedOrigins(*origins)
+
+        registry.addEndpoint(SOCKJS_WS_ENDPOINT)
             .setAllowedOrigins(*origins)
             .withSockJS()
     }
 }
-

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -196,7 +196,7 @@
             usernamePage.classList.add('hidden');
             chatPage.classList.remove('hidden');
 
-            var socket = new SockJS('/ws');
+            var socket = new SockJS('/ws-sockjs');
             stompClient = Stomp.over(socket);
 
             stompClient.connect({}, onConnected, onError);
@@ -287,4 +287,3 @@
 </script>
 </body>
 </html>
-

--- a/src/test/kotlin/org/machikoro/server/config/SecurityConfigTests.kt
+++ b/src/test/kotlin/org/machikoro/server/config/SecurityConfigTests.kt
@@ -45,9 +45,15 @@ class SecurityConfigTests {
     }
 
     @Test
+    fun nativeWebsocketEndpointShouldNotRequireAuthentication() {
+        mockMvc.perform(get("/ws-sockjs/non-existing"))
+            .andExpect(status().isNotFound)
+    }
+
+    @Test
     fun websocketPostWithoutCsrfShouldBePermitted() {
         // SockJS uses POST for xhr_send; CSRF is disabled for /ws/** to allow this
-        mockMvc.perform(post("/ws/non-existing"))
+        mockMvc.perform(post("/ws-sockjs/non-existing"))
             .andExpect(status().isNotFound)
     }
 

--- a/src/test/kotlin/org/machikoro/server/config/WebSocketConfigTests.kt
+++ b/src/test/kotlin/org/machikoro/server/config/WebSocketConfigTests.kt
@@ -26,20 +26,24 @@ class WebSocketConfigTests {
     }
 
     @Test
-    fun registerStompEndpointsShouldConfigureWsEndpointWithSockJs() {
+    fun registerStompEndpointsShouldConfigureNativeAndSockJsEndpoints() {
         val registry = mock(StompEndpointRegistry::class.java)
-        val endpointRegistration = mock(StompWebSocketEndpointRegistration::class.java)
+        val nativeEndpointRegistration = mock(StompWebSocketEndpointRegistration::class.java)
+        val sockJsEndpointRegistration = mock(StompWebSocketEndpointRegistration::class.java)
         val sockJsRegistration = mock(SockJsServiceRegistration::class.java)
 
-        `when`(registry.addEndpoint("/ws")).thenReturn(endpointRegistration)
-        `when`(endpointRegistration.setAllowedOrigins("http://localhost:8080", "http://localhost:3000")).thenReturn(endpointRegistration)
-        `when`(endpointRegistration.withSockJS()).thenReturn(sockJsRegistration)
+        `when`(registry.addEndpoint(WebSocketConfig.NATIVE_WS_ENDPOINT)).thenReturn(nativeEndpointRegistration)
+        `when`(registry.addEndpoint(WebSocketConfig.SOCKJS_WS_ENDPOINT)).thenReturn(sockJsEndpointRegistration)
+        `when`(nativeEndpointRegistration.setAllowedOrigins("http://localhost:8080", "http://localhost:3000")).thenReturn(nativeEndpointRegistration)
+        `when`(sockJsEndpointRegistration.setAllowedOrigins("http://localhost:8080", "http://localhost:3000")).thenReturn(sockJsEndpointRegistration)
+        `when`(sockJsEndpointRegistration.withSockJS()).thenReturn(sockJsRegistration)
 
         config.registerStompEndpoints(registry)
 
-        verify(registry).addEndpoint("/ws")
-        verify(endpointRegistration).setAllowedOrigins("http://localhost:8080", "http://localhost:3000")
-        verify(endpointRegistration).withSockJS()
+        verify(registry).addEndpoint(WebSocketConfig.NATIVE_WS_ENDPOINT)
+        verify(registry).addEndpoint(WebSocketConfig.SOCKJS_WS_ENDPOINT)
+        verify(nativeEndpointRegistration).setAllowedOrigins("http://localhost:8080", "http://localhost:3000")
+        verify(sockJsEndpointRegistration).setAllowedOrigins("http://localhost:8080", "http://localhost:3000")
+        verify(sockJsEndpointRegistration).withSockJS()
     }
 }
-


### PR DESCRIPTION
This PR separates native WebSocket and SockJS traffic so Android clients can connect successfully without breaking the browser demo/testing flow.

#### Changes:

- expose native STOMP-over-WebSocket on /ws
- move SockJS fallback/browser flow to /ws-sockjs
- allow both endpoint paths in security config
- update the browser demo page to use /ws-sockjs
- update tests to cover the new endpoint split
- document the expected native and SockJS connection URLs

#### Verified:

- native Android client connects, sends, receives, and disconnects cleanly
- browser flow on localhost:8080 still works with messages exchanged between two users
- focused WebSocket/security tests pass