### PR TITLE
chore: fail CI if SonarCloud quality gate fails

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ sonar {
         property("sonar.organization", "se2-machi-koro")
         property("sonar.host.url", "https://sonarcloud.io")
         property("sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml")
+        property("sonar.qualitygate.wait", "true")
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds SonarCloud quality gate check to CI pipeline so builds fail when code quality thresholds aren't met

## Test plan
- [x] CI pipeline runs SonarCloud analysis
- [x] Build fails if quality gate is not passed