### PR TITLE
feat: add GamePhaseService for turn phase state machine

### DIFF
--- a/src/main/kotlin/org/machikoro/server/service/GamePhaseService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/GamePhaseService.kt
@@ -1,0 +1,19 @@
+package org.machikoro.server.service
+
+import org.machikoro.server.domain.TurnPhase
+import org.springframework.stereotype.Service
+
+@Service
+class GamePhaseService {
+
+    /** Returns the next phase in the Machi Koro turn cycle. */
+    fun nextPhase(currentPhase: TurnPhase): TurnPhase = when (currentPhase) {
+        TurnPhase.ROLL_DICE -> TurnPhase.RESOLVE_EFFECTS
+        TurnPhase.RESOLVE_EFFECTS -> TurnPhase.BUY_OR_BUILD
+        TurnPhase.BUY_OR_BUILD -> TurnPhase.END_TURN
+        TurnPhase.END_TURN -> TurnPhase.ROLL_DICE
+    }
+
+    /** Returns the phase that begins every new turn. */
+    fun initialPhase(): TurnPhase = TurnPhase.ROLL_DICE
+}

--- a/src/test/kotlin/org/machikoro/server/service/GamePhaseServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GamePhaseServiceTest.kt
@@ -1,0 +1,60 @@
+package org.machikoro.server.service
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.machikoro.server.domain.TurnPhase
+
+class GamePhaseServiceTest {
+
+    private val service = GamePhaseService()
+
+    @Test
+    fun `initial phase is ROLL_DICE`() {
+        assertEquals(TurnPhase.ROLL_DICE, service.initialPhase())
+    }
+
+    @Test
+    fun `ROLL_DICE advances to RESOLVE_EFFECTS`() {
+        assertEquals(TurnPhase.RESOLVE_EFFECTS, service.nextPhase(TurnPhase.ROLL_DICE))
+    }
+
+    @Test
+    fun `RESOLVE_EFFECTS advances to BUY_OR_BUILD`() {
+        assertEquals(TurnPhase.BUY_OR_BUILD, service.nextPhase(TurnPhase.RESOLVE_EFFECTS))
+    }
+
+    @Test
+    fun `BUY_OR_BUILD advances to END_TURN`() {
+        assertEquals(TurnPhase.END_TURN, service.nextPhase(TurnPhase.BUY_OR_BUILD))
+    }
+
+    @Test
+    fun `END_TURN cycles back to ROLL_DICE`() {
+        assertEquals(TurnPhase.ROLL_DICE, service.nextPhase(TurnPhase.END_TURN))
+    }
+
+    @Test
+    fun `nextPhase handles every TurnPhase value`() {
+        TurnPhase.entries.forEach { phase ->
+            service.nextPhase(phase)
+        }
+    }
+
+    @Test
+    fun `full cycle completes correctly`() {
+        var phase = service.initialPhase()
+        assertEquals(TurnPhase.ROLL_DICE, phase)
+
+        phase = service.nextPhase(phase)
+        assertEquals(TurnPhase.RESOLVE_EFFECTS, phase)
+
+        phase = service.nextPhase(phase)
+        assertEquals(TurnPhase.BUY_OR_BUILD, phase)
+
+        phase = service.nextPhase(phase)
+        assertEquals(TurnPhase.END_TURN, phase)
+
+        phase = service.nextPhase(phase)
+        assertEquals(TurnPhase.ROLL_DICE, phase)
+    }
+}


### PR DESCRIPTION
Sub-issue of #46, closes #84

Adds a stateless `GamePhaseService` that implements the Machi Koro turn phase cycle.

#### Changes

- New `GamePhaseService` in `service/` package with two methods:
  - `nextPhase(currentPhase)` — returns the next phase in the cycle
  - `initialPhase()` — returns `ROLL_DICE` as the starting phase
- Phase cycle: `ROLL_DICE` → `RESOLVE_EFFECTS` → `BUY_OR_BUILD` → `END_TURN` → `ROLL_DICE`

#### Verified

- 7 unit tests covering all individual transitions, exhaustiveness, and full cycle
- All existing tests still pass