### PR TITLE
feat(#114): add /actuator/health endpoint and Docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ RUN ./gradlew bootJar -x test
 
 FROM eclipse-temurin:21.0.6_7-jre-jammy
 WORKDIR /app
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
 RUN groupadd --system app && useradd --no-log-init --system --create-home --home-dir /app --gid app app
 COPY --from=builder /app/build/libs/*.jar app.jar
 RUN chown -R app:app /app

--- a/README.md
+++ b/README.md
@@ -125,6 +125,22 @@ Currently emitted by the server: `CHAT`, `JOIN`, `LEAVE`.
 
 ---
 
+## Health Endpoint
+
+Spring Boot Actuator exposes a liveness endpoint used by Docker, CI, and monitoring to confirm the service is up and its datastore is reachable.
+
+| Parameter | Value |
+|-----------|-------|
+| **URL** | `http://localhost:8080/actuator/health` |
+| **Method** | `GET` |
+| **Auth** | Not required (publicly accessible) |
+| **Response** | `200 OK` with `{"status":"UP"}` when the service and DB are healthy; `503` with `DOWN` otherwise |
+| **Details** | Only returned for authenticated callers (`management.endpoint.health.show-details=when-authorized`) |
+
+The `backend` service in `compose.yaml` polls this endpoint via `curl` and Docker marks the container unhealthy after repeated failures, triggering `restart: unless-stopped` to recover the process.
+
+---
+
 ## Error Handling
 
 ### Current Behavior

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,7 @@ repositories {
 }
 
 dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-restclient")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-webmvc")

--- a/compose.yaml
+++ b/compose.yaml
@@ -48,6 +48,12 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -fsS http://localhost:8080/actuator/health || exit 1" ]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
 
 volumes:
   postgres_data:

--- a/src/main/kotlin/org/machikoro/server/config/SecurityConfig.kt
+++ b/src/main/kotlin/org/machikoro/server/config/SecurityConfig.kt
@@ -12,7 +12,8 @@ class SecurityConfig {
 
     /**
      * Configure security filter chain.
-     * Permits unauthenticated access to WebSocket endpoints, static resources, and the root/index page.
+     * Permits unauthenticated access to WebSocket endpoints, static resources, the root/index page,
+     * and the `/actuator/health` endpoint so Docker, CI, and monitoring can poll it without credentials.
      * Requires authentication for API endpoints.
      * CSRF is disabled for WebSocket endpoints to allow SockJS fallback HTTP POST requests.
      * CSRF remains enabled for all other endpoints including API routes.
@@ -26,6 +27,7 @@ class SecurityConfig {
             .authorizeHttpRequests { auth ->
                 auth.requestMatchers("/", "/index.html", "/css/**", "/js/**", "/webjars/**").permitAll()
                 auth.requestMatchers("/ws", "/ws/**", "/ws-sockjs", "/ws-sockjs/**").permitAll()
+                auth.requestMatchers("/actuator/health", "/actuator/health/**").permitAll()
                 auth.requestMatchers("/api/**").authenticated()
                 auth.anyRequest().authenticated()
             }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,6 @@ spring.datasource.url=jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${D
 spring.datasource.username=${DB_USERNAME:}
 spring.datasource.password=${DB_PASSWORD:}
 spring.datasource.hikari.maximum-pool-size=10
+
+management.endpoints.web.exposure.include=health
+management.endpoint.health.show-details=when-authorized

--- a/src/test/kotlin/org/machikoro/server/config/HealthEndpointTest.kt
+++ b/src/test/kotlin/org/machikoro/server/config/HealthEndpointTest.kt
@@ -1,0 +1,33 @@
+package org.machikoro.server.config
+
+import org.junit.jupiter.api.Test
+import org.machikoro.server.SpringBootTestWithoutDataSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@SpringBootTestWithoutDataSource
+@AutoConfigureMockMvc
+@TestPropertySource(properties = ["management.health.db.enabled=false"])
+class HealthEndpointTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun healthEndpointIsAccessibleWithoutAuthentication() {
+        mockMvc.perform(get("/actuator/health"))
+            .andExpect(status().isOk)
+    }
+
+    @Test
+    fun healthEndpointReportsStatusUp() {
+        mockMvc.perform(get("/actuator/health"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value("UP"))
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `spring-boot-starter-actuator` and exposes `/actuator/health` unauthenticated so Docker, CI, and monitoring can poll it without credentials. Health details are only shown to authenticated callers (`show-details=when-authorized`).
- Wires a `healthcheck:` block on the `backend` service in `compose.yaml` that calls `curl -fsS http://localhost:8080/actuator/health`; combined with `restart: unless-stopped` this lets Docker recover an unhealthy container.
- Installs `curl` in the runtime stage of the `Dockerfile` (the `eclipse-temurin:21.0.6_7-jre-jammy` base has no HTTP client).
- Narrow security permit: only `/actuator/health` and `/actuator/health/**` are public — future actuator endpoints (metrics, env, beans, …) still require auth.
- Adds `HealthEndpointTest` using the existing `@SpringBootTestWithoutDataSource + @AutoConfigureMockMvc` pattern, asserting public access and `status=UP`. `management.health.db.enabled=false` is set for the test so it doesn't need a live DB.
- Documents the endpoint in `README.md`.

Closes #114. Supports the Sprint 2 goal "Health Endpoint implementiert" and contributes to "Game State Recovery bei Ausfall/Neustart des Backend Containers" — Docker now detects unhealthy backends and restarts them.

## Test plan
- [x] `./gradlew compileKotlin compileTestKotlin --warning-mode all` clean, no warnings
- [x] `./gradlew test --tests "org.machikoro.server.config.*" --tests "org.machikoro.server.controller.*" --tests "org.machikoro.server.ServerApplicationTests"` — 52/52 pass locally (HealthEndpointTest 2/2, SecurityConfigTests 9/9)
- [x] JaCoCo: `SecurityConfig` at 100% line coverage (13/13)
- [ ] Full CI suite green (including Testcontainers DAO tests that need Docker, skipped locally)
- [x] SonarCloud quality gate pass
- [ ] Manual check: `docker compose up -d --build` → `docker ps` shows `machikoro-server` as `healthy`; `curl http://localhost:8080/actuator/health` returns `{"status":"UP"}`