### PR TITLE
feat(#70): detect win condition via WinConditionService

### DIFF
--- a/src/main/kotlin/org/machikoro/server/service/WinConditionService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/WinConditionService.kt
@@ -1,0 +1,22 @@
+package org.machikoro.server.service
+
+import org.machikoro.server.dao.PlayerDao
+import org.machikoro.server.dao.PlayerLandmarkDao
+import org.machikoro.server.domain.models.PlayerModel
+import org.springframework.stereotype.Service
+
+@Service
+class WinConditionService(
+    private val playerDao: PlayerDao,
+    private val playerLandmarkDao: PlayerLandmarkDao,
+) {
+
+    /** True iff the given player has built all landmarks. */
+    fun hasPlayerWon(playerId: Int): Boolean =
+        playerLandmarkDao.allBuilt(playerId)
+
+    /** Returns the winner in the given game, or null if nobody has won yet. */
+    fun detectWinner(gameId: Int): PlayerModel? =
+        playerDao.findByGameId(gameId)
+            .firstOrNull { hasPlayerWon(it.id) }
+}

--- a/src/test/kotlin/org/machikoro/server/service/WinConditionServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/WinConditionServiceTest.kt
@@ -1,0 +1,82 @@
+package org.machikoro.server.service
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.machikoro.server.dao.PlayerDao
+import org.machikoro.server.dao.PlayerLandmarkDao
+import org.machikoro.server.domain.models.PlayerModel
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class WinConditionServiceTest {
+
+    private val playerDao = mock<PlayerDao>()
+    private val playerLandmarkDao = mock<PlayerLandmarkDao>()
+    private val service = WinConditionService(playerDao, playerLandmarkDao)
+
+    private fun player(id: Int, gameId: Int = 1) =
+        PlayerModel(id = id, gameId = gameId, userId = id * 10, turnOrder = id, coins = 3)
+
+    @Test
+    fun `hasPlayerWon returns true when all landmarks are built`() {
+        val playerId = 42
+        whenever(playerLandmarkDao.allBuilt(playerId)).thenReturn(true)
+
+        assertTrue(service.hasPlayerWon(playerId))
+    }
+
+    @Test
+    fun `hasPlayerWon returns false when not all landmarks are built`() {
+        val playerId = 42
+        whenever(playerLandmarkDao.allBuilt(playerId)).thenReturn(false)
+
+        assertFalse(service.hasPlayerWon(playerId))
+    }
+
+    @Test
+    fun `detectWinner returns null for a game with no players`() {
+        val gameId = 1
+        whenever(playerDao.findByGameId(gameId)).thenReturn(emptyList())
+
+        assertNull(service.detectWinner(gameId))
+    }
+
+    @Test
+    fun `detectWinner returns null when no player has built all landmarks`() {
+        val gameId = 1
+        whenever(playerDao.findByGameId(gameId)).thenReturn(listOf(player(1), player(2)))
+        whenever(playerLandmarkDao.allBuilt(1)).thenReturn(false)
+        whenever(playerLandmarkDao.allBuilt(2)).thenReturn(false)
+
+        assertNull(service.detectWinner(gameId))
+    }
+
+    @Test
+    fun `detectWinner returns the winning player`() {
+        val gameId = 1
+        val winner = player(2)
+        whenever(playerDao.findByGameId(gameId)).thenReturn(listOf(player(1), winner, player(3)))
+        whenever(playerLandmarkDao.allBuilt(1)).thenReturn(false)
+        whenever(playerLandmarkDao.allBuilt(2)).thenReturn(true)
+
+        assertEquals(winner, service.detectWinner(gameId))
+    }
+
+    @Test
+    fun `detectWinner short-circuits and does not check players after the first winner`() {
+        val gameId = 1
+        whenever(playerDao.findByGameId(gameId)).thenReturn(listOf(player(1), player(2), player(3)))
+        whenever(playerLandmarkDao.allBuilt(1)).thenReturn(false)
+        whenever(playerLandmarkDao.allBuilt(2)).thenReturn(true)
+
+        val result = service.detectWinner(gameId)
+
+        assertEquals(2, result?.id)
+        verify(playerLandmarkDao, never()).allBuilt(3)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `WinConditionService` (detection-only) — `hasPlayerWon(playerId)` and `detectWinner(gameId): PlayerModel?`, built on top of the existing `PlayerLandmarkDao.allBuilt`.
- Scope is deliberately limited to issue #70. State transitions to `FINISHED` (#71), broadcast (#73), action-blocking (#74), etc. are intentionally **not** wired up here — this PR is the detection primitive those issues will plug into.
- Follows the `GamePhaseService` pattern: `@Service`, constructor injection, unit-tested with JUnit 5 + mockito-kotlin.

Closes #70.

## Acceptance criteria mapping
- [x] Server checks landmark count — `hasPlayerWon` delegates to `PlayerLandmarkDao.allBuilt`, which verifies every landmark row is `isBuilt = true` (rows seeded by `initForPlayer`, so "all built" ≡ "all 4 built").
- [x] Win detected when 4 landmarks exist — same mechanism.
- [x] Correct player identified as winner — `detectWinner(gameId)` iterates `playerDao.findByGameId(gameId)` and returns the first `PlayerModel` that passes `hasPlayerWon`.

## Test plan
- [x] `./gradlew test --tests "org.machikoro.server.service.WinConditionServiceTest"` — 6/6 pass
- [x] `./gradlew compileKotlin compileTestKotlin` — no warnings
- [x] CI green (Sonar quality gate, JaCoCo coverage)
- Test cases: happy path (winner returned), no players, no winner among many, short-circuit (later players not checked after a winner is found), both `hasPlayerWon` branches.