### PR TITLE
59 implement buying phase flow and turn transition

### DIFF
--- a/src/main/kotlin/org/machikoro/server/controller/GameController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/GameController.kt
@@ -1,6 +1,8 @@
 package org.machikoro.server.controller
 
+import org.machikoro.server.domain.enums.TurnPhase
 import org.machikoro.server.dto.AdvancePhaseRequest
+import org.machikoro.server.dto.EndTurnRequest
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.WebSocketMessage
 import org.machikoro.server.service.GamePhaseService
@@ -21,7 +23,17 @@ class GameController(
     fun advancePhase(@Payload request: AdvancePhaseRequest) {
         val newPhase = gamePhaseService.advancePhase(request.gameId)
         logger.info("Advanced game ${request.gameId} to phase $newPhase")
+        broadcastPhase(newPhase)
+    }
 
+    @MessageMapping("/game.endTurn")
+    fun endTurn(@Payload request: EndTurnRequest) {
+        val newPhase = gamePhaseService.endTurn(request.gameId)
+        logger.info("Ended turn for game ${request.gameId}, new phase $newPhase")
+        broadcastPhase(newPhase)
+    }
+
+    private fun broadcastPhase(newPhase: TurnPhase) {
         messagingTemplate.convertAndSend(
             "/topic/public",
             WebSocketMessage(

--- a/src/main/kotlin/org/machikoro/server/dto/EndTurnRequest.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/EndTurnRequest.kt
@@ -1,0 +1,5 @@
+package org.machikoro.server.dto
+
+data class EndTurnRequest(
+    val gameId: Int,
+)

--- a/src/main/kotlin/org/machikoro/server/service/GamePhaseService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/GamePhaseService.kt
@@ -1,12 +1,14 @@
 package org.machikoro.server.service
 
 import org.machikoro.server.dao.GameDao
+import org.machikoro.server.dao.PlayerDao
 import org.machikoro.server.domain.enums.TurnPhase
 import org.springframework.stereotype.Service
 
 @Service
 class GamePhaseService(
     private val gameDao: GameDao,
+    private val playerDao: PlayerDao,
 ) {
 
     /** Returns the next phase in the Machi Koro turn cycle. */
@@ -25,5 +27,23 @@ class GamePhaseService(
         val next = nextPhase(gameDao.getPhase(gameId))
         gameDao.updateTurnPhase(gameId, next)
         return next
+    }
+
+    /** Ends the active player's buy-or-build window and starts the next turn. */
+    fun endTurn(gameId: Int): TurnPhase {
+        val game = gameDao.findById(gameId)
+            ?: error("Game $gameId not found")
+        check(game.turnPhase == TurnPhase.BUY_OR_BUILD) { "Game is not in BUY_OR_BUILD phase" }
+
+        val players = playerDao.findByGameId(gameId)
+        check(players.isNotEmpty()) { "Game $gameId has no players" }
+
+        gameDao.updateTurnPhase(gameId, TurnPhase.END_TURN)
+
+        val nextTurnIndex = (game.currentTurnIndex + 1) % players.size
+        val nextRoundNumber = if (nextTurnIndex == 0) game.roundNumber + 1 else game.roundNumber
+
+        gameDao.advanceTurn(gameId, nextTurnIndex, nextRoundNumber)
+        return TurnPhase.ROLL_DICE
     }
 }

--- a/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.machikoro.server.domain.enums.TurnPhase
 import org.machikoro.server.dto.AdvancePhaseRequest
+import org.machikoro.server.dto.EndTurnRequest
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.WebSocketMessage
 import org.machikoro.server.service.GamePhaseService
@@ -44,5 +45,31 @@ class GameControllerTest {
         assertEquals(MessageType.GAME_ACTION, message.type)
         assertEquals("server", message.sender)
         assertEquals(mapOf("turnPhase" to "RESOLVE_EFFECTS"), message.payload)
+    }
+
+    @Test
+    fun `endTurn delegates to service with the requested game id`() {
+        val gameId = 42
+        whenever(gamePhaseService.endTurn(gameId)).thenReturn(TurnPhase.ROLL_DICE)
+
+        controller.endTurn(EndTurnRequest(gameId))
+
+        verify(gamePhaseService).endTurn(gameId)
+    }
+
+    @Test
+    fun `endTurn broadcasts resulting phase as GAME_ACTION on topic public`() {
+        val gameId = 42
+        whenever(gamePhaseService.endTurn(gameId)).thenReturn(TurnPhase.ROLL_DICE)
+
+        controller.endTurn(EndTurnRequest(gameId))
+
+        val captor = argumentCaptor<WebSocketMessage>()
+        verify(messagingTemplate).convertAndSend(eq("/topic/public"), captor.capture())
+
+        val message = captor.firstValue
+        assertEquals(MessageType.GAME_ACTION, message.type)
+        assertEquals("server", message.sender)
+        assertEquals(mapOf("turnPhase" to "ROLL_DICE"), message.payload)
     }
 }

--- a/src/test/kotlin/org/machikoro/server/service/EarningsIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/EarningsIntegrationTest.kt
@@ -110,6 +110,7 @@ class EarningsIntegrationTest : AbstractDBSetup() {
         assertEquals(5, p1.coins)
         assertEquals(4, p2.coins)
         assertEquals(TurnPhase.BUY_OR_BUILD, game.turnPhase)
+        assertEquals(0, game.currentTurnIndex)
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/service/GamePhaseServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GamePhaseServiceTest.kt
@@ -1,17 +1,25 @@
 package org.machikoro.server.service
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.Test
 import org.machikoro.server.dao.GameDao
+import org.machikoro.server.dao.PlayerDao
+import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.enums.TurnPhase
+import org.machikoro.server.domain.models.GameModel
+import org.machikoro.server.domain.models.PlayerModel
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class GamePhaseServiceTest {
 
     private val gameDao = mock<GameDao>()
-    private val service = GamePhaseService(gameDao)
+    private val playerDao = mock<PlayerDao>()
+    private val service = GamePhaseService(gameDao, playerDao)
 
     @Test
     fun `initial phase is ROLL_DICE`() {
@@ -83,5 +91,85 @@ class GamePhaseServiceTest {
 
         assertEquals(TurnPhase.ROLL_DICE, result)
         verify(gameDao).updateTurnPhase(gameId, TurnPhase.ROLL_DICE)
+    }
+
+    @Test
+    fun `endTurn updates phase and rotates to next player`() {
+        val gameId = 21
+        whenever(gameDao.findById(gameId)).thenReturn(
+            GameModel(
+                id = gameId,
+                status = GameStatus.IN_PROGRESS,
+                hostUserId = 1,
+                currentTurnIndex = 0,
+                turnPhase = TurnPhase.BUY_OR_BUILD,
+                lastDiceRoll = 5,
+                roundNumber = 1
+            )
+        )
+        whenever(playerDao.findByGameId(gameId)).thenReturn(
+            listOf(
+                PlayerModel(1, gameId, 10, 0, 3),
+                PlayerModel(2, gameId, 11, 1, 3)
+            )
+        )
+
+        val result = service.endTurn(gameId)
+
+        assertEquals(TurnPhase.ROLL_DICE, result)
+        verify(gameDao).updateTurnPhase(gameId, TurnPhase.END_TURN)
+        verify(gameDao).advanceTurn(gameId, 1, 1)
+    }
+
+    @Test
+    fun `endTurn wraps back to first player and increments round`() {
+        val gameId = 22
+        whenever(gameDao.findById(gameId)).thenReturn(
+            GameModel(
+                id = gameId,
+                status = GameStatus.IN_PROGRESS,
+                hostUserId = 1,
+                currentTurnIndex = 1,
+                turnPhase = TurnPhase.BUY_OR_BUILD,
+                lastDiceRoll = 6,
+                roundNumber = 3
+            )
+        )
+        whenever(playerDao.findByGameId(gameId)).thenReturn(
+            listOf(
+                PlayerModel(1, gameId, 10, 0, 3),
+                PlayerModel(2, gameId, 11, 1, 3)
+            )
+        )
+
+        val result = service.endTurn(gameId)
+
+        assertEquals(TurnPhase.ROLL_DICE, result)
+        verify(gameDao).updateTurnPhase(gameId, TurnPhase.END_TURN)
+        verify(gameDao).advanceTurn(gameId, 0, 4)
+    }
+
+    @Test
+    fun `endTurn rejects games outside buy or build phase`() {
+        val gameId = 23
+        whenever(gameDao.findById(gameId)).thenReturn(
+            GameModel(
+                id = gameId,
+                status = GameStatus.IN_PROGRESS,
+                hostUserId = 1,
+                currentTurnIndex = 0,
+                turnPhase = TurnPhase.RESOLVE_EFFECTS,
+                lastDiceRoll = 4,
+                roundNumber = 2
+            )
+        )
+
+        assertThrows<IllegalStateException> {
+            service.endTurn(gameId)
+        }
+
+        verify(gameDao, never()).updateTurnPhase(gameId, TurnPhase.END_TURN)
+        verify(gameDao, never()).advanceTurn(gameId, 0, 2)
+        verifyNoMoreInteractions(playerDao)
     }
 }


### PR DESCRIPTION
#### Summary
Implemented the backend turn-transition flow for the buy-or-build phase.

#### What Changed

- Added backend service logic to end a turn from BUY_OR_BUILD
- Added websocket endpoint support for the client End Turn action
- Rotates to the next player after ending the turn
- Resets the next turn back to ROLL_DICE
- Keeps END_TURN in the phase model
- Added tests for service flow, websocket handling, and active-player stability when entering BUY_OR_BUILD

#### Notes
- This PR only covers turn flow and phase transitions
- It does not implement purchasing cards or landmarks yet
- Purchase execution and validation will be handled in later issues