### PR TITLE
feat(#74): guard endTurn + have GameStateGuard return the loaded game

### DIFF
--- a/src/main/kotlin/org/machikoro/server/service/GamePhaseService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/GamePhaseService.kt
@@ -33,6 +33,7 @@ class GamePhaseService(
 
     /** Ends the active player's buy-or-build window and starts the next turn. */
     fun endTurn(gameId: Int): TurnPhase {
+        gameStateGuard.ensureGameIsRunning(gameId)
         val game = gameDao.findById(gameId)
             ?: error("Game $gameId not found")
         check(game.turnPhase == TurnPhase.BUY_OR_BUILD) { "Game is not in BUY_OR_BUILD phase" }

--- a/src/main/kotlin/org/machikoro/server/service/GamePhaseService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/GamePhaseService.kt
@@ -25,17 +25,15 @@ class GamePhaseService(
 
     /** Advances a game to the next phase and persists it. */
     fun advancePhase(gameId: Int): TurnPhase {
-        gameStateGuard.ensureGameIsRunning(gameId)
-        val next = nextPhase(gameDao.getPhase(gameId))
+        val game = gameStateGuard.ensureGameIsRunning(gameId)
+        val next = nextPhase(game.turnPhase)
         gameDao.updateTurnPhase(gameId, next)
         return next
     }
 
     /** Ends the active player's buy-or-build window and starts the next turn. */
     fun endTurn(gameId: Int): TurnPhase {
-        gameStateGuard.ensureGameIsRunning(gameId)
-        val game = gameDao.findById(gameId)
-            ?: error("Game $gameId not found")
+        val game = gameStateGuard.ensureGameIsRunning(gameId)
         check(game.turnPhase == TurnPhase.BUY_OR_BUILD) { "Game is not in BUY_OR_BUILD phase" }
 
         val players = playerDao.findByGameId(gameId)

--- a/src/main/kotlin/org/machikoro/server/service/GameStateGuard.kt
+++ b/src/main/kotlin/org/machikoro/server/service/GameStateGuard.kt
@@ -2,6 +2,7 @@ package org.machikoro.server.service
 
 import org.machikoro.server.dao.GameDao
 import org.machikoro.server.domain.enums.GameStatus
+import org.machikoro.server.domain.models.GameModel
 import org.machikoro.server.exception.CustomWebSocketException
 import org.machikoro.server.exception.GameNotFoundException
 import org.springframework.stereotype.Service
@@ -12,11 +13,14 @@ class GameStateGuard(
 ) {
 
     /**
-     * Ensures the given game is still active. Throws [CustomWebSocketException] with
-     * errorCode `GAME_FINISHED` if the game has already ended, or [GameNotFoundException]
-     * if the id is unknown. Intended to be called at the top of any gameplay action.
+     * Loads the given game and ensures it is still active. Returns the loaded
+     * [GameModel] so callers can avoid a second DAO round-trip.
+     *
+     * Throws [CustomWebSocketException] with errorCode `GAME_FINISHED` if the
+     * game has already ended, or [GameNotFoundException] if the id is unknown.
+     * Intended to be called at the top of any gameplay action.
      */
-    fun ensureGameIsRunning(gameId: Int) {
+    fun ensureGameIsRunning(gameId: Int): GameModel {
         val game = gameDao.findById(gameId)
             ?: throw GameNotFoundException("Game $gameId not found")
         if (game.status == GameStatus.FINISHED) {
@@ -25,5 +29,6 @@ class GameStateGuard(
                 message = "Game $gameId has already ended",
             )
         }
+        return game
     }
 }

--- a/src/test/kotlin/org/machikoro/server/service/GamePhaseServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GamePhaseServiceTest.kt
@@ -135,6 +135,7 @@ class GamePhaseServiceTest {
         val result = service.endTurn(gameId)
 
         assertEquals(TurnPhase.ROLL_DICE, result)
+        verify(gameStateGuard).ensureGameIsRunning(gameId)
         verify(gameDao).updateTurnPhase(gameId, TurnPhase.END_TURN)
         verify(gameDao).advanceTurn(gameId, 1, 1)
     }
@@ -188,6 +189,22 @@ class GamePhaseServiceTest {
 
         verify(gameDao, never()).updateTurnPhase(gameId, TurnPhase.END_TURN)
         verify(gameDao, never()).advanceTurn(gameId, 0, 2)
+        verifyNoMoreInteractions(playerDao)
+    }
+
+    @Test
+    fun `endTurn rejects FINISHED games and does not advance`() {
+        val gameId = 88
+        whenever(gameStateGuard.ensureGameIsRunning(gameId))
+            .thenThrow(CustomWebSocketException("GAME_FINISHED", "Game $gameId has already ended"))
+
+        val ex = assertThrows<CustomWebSocketException> {
+            service.endTurn(gameId)
+        }
+        assertEquals("GAME_FINISHED", ex.errorCode)
+        verify(gameDao, never()).findById(gameId)
+        verify(gameDao, never()).updateTurnPhase(any(), any())
+        verify(gameDao, never()).advanceTurn(any(), any(), any())
         verifyNoMoreInteractions(playerDao)
     }
 }

--- a/src/test/kotlin/org/machikoro/server/service/GamePhaseServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GamePhaseServiceTest.kt
@@ -11,6 +11,7 @@ import org.machikoro.server.domain.models.GameModel
 import org.machikoro.server.domain.models.PlayerModel
 import org.machikoro.server.exception.CustomWebSocketException
 import org.mockito.kotlin.any
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -23,6 +24,17 @@ class GamePhaseServiceTest {
     private val playerDao = mock<PlayerDao>()
     private val gameStateGuard = mock<GameStateGuard>()
     private val service = GamePhaseService(gameDao, playerDao, gameStateGuard)
+
+    private fun gameInPhase(id: Int, phase: TurnPhase, currentTurnIndex: Int = 0, roundNumber: Int = 1) =
+        GameModel(
+            id = id,
+            status = GameStatus.IN_PROGRESS,
+            hostUserId = 1,
+            currentTurnIndex = currentTurnIndex,
+            turnPhase = phase,
+            lastDiceRoll = null,
+            roundNumber = roundNumber,
+        )
 
     @Test
     fun `initial phase is ROLL_DICE`() {
@@ -77,7 +89,8 @@ class GamePhaseServiceTest {
     @Test
     fun `advancePhase reads current phase and persists the next one`() {
         val gameId = 42
-        whenever(gameDao.getPhase(gameId)).thenReturn(TurnPhase.ROLL_DICE)
+        whenever(gameStateGuard.ensureGameIsRunning(gameId))
+            .thenReturn(gameInPhase(gameId, TurnPhase.ROLL_DICE))
 
         val result = service.advancePhase(gameId)
 
@@ -89,7 +102,8 @@ class GamePhaseServiceTest {
     @Test
     fun `advancePhase wraps END_TURN back to ROLL_DICE`() {
         val gameId = 7
-        whenever(gameDao.getPhase(gameId)).thenReturn(TurnPhase.END_TURN)
+        whenever(gameStateGuard.ensureGameIsRunning(gameId))
+            .thenReturn(gameInPhase(gameId, TurnPhase.END_TURN))
 
         val result = service.advancePhase(gameId)
 
@@ -107,57 +121,39 @@ class GamePhaseServiceTest {
             service.advancePhase(gameId)
         }
         assertEquals("GAME_FINISHED", ex.errorCode)
-        verify(gameDao, never()).getPhase(gameId)
         verify(gameDao, never()).updateTurnPhase(any(), any())
     }
 
     @Test
     fun `endTurn updates phase and rotates to next player`() {
         val gameId = 21
-        whenever(gameDao.findById(gameId)).thenReturn(
-            GameModel(
-                id = gameId,
-                status = GameStatus.IN_PROGRESS,
-                hostUserId = 1,
-                currentTurnIndex = 0,
-                turnPhase = TurnPhase.BUY_OR_BUILD,
-                lastDiceRoll = 5,
-                roundNumber = 1
-            )
-        )
+        whenever(gameStateGuard.ensureGameIsRunning(gameId))
+            .thenReturn(gameInPhase(gameId, TurnPhase.BUY_OR_BUILD, currentTurnIndex = 0, roundNumber = 1))
         whenever(playerDao.findByGameId(gameId)).thenReturn(
             listOf(
                 PlayerModel(1, gameId, 10, 0, 3),
-                PlayerModel(2, gameId, 11, 1, 3)
+                PlayerModel(2, gameId, 11, 1, 3),
             )
         )
 
         val result = service.endTurn(gameId)
 
         assertEquals(TurnPhase.ROLL_DICE, result)
-        verify(gameStateGuard).ensureGameIsRunning(gameId)
-        verify(gameDao).updateTurnPhase(gameId, TurnPhase.END_TURN)
-        verify(gameDao).advanceTurn(gameId, 1, 1)
+        val ordered = inOrder(gameStateGuard, gameDao)
+        ordered.verify(gameStateGuard).ensureGameIsRunning(gameId)
+        ordered.verify(gameDao).updateTurnPhase(gameId, TurnPhase.END_TURN)
+        ordered.verify(gameDao).advanceTurn(gameId, 1, 1)
     }
 
     @Test
     fun `endTurn wraps back to first player and increments round`() {
         val gameId = 22
-        whenever(gameDao.findById(gameId)).thenReturn(
-            GameModel(
-                id = gameId,
-                status = GameStatus.IN_PROGRESS,
-                hostUserId = 1,
-                currentTurnIndex = 1,
-                turnPhase = TurnPhase.BUY_OR_BUILD,
-                lastDiceRoll = 6,
-                roundNumber = 3
-            )
-        )
+        whenever(gameStateGuard.ensureGameIsRunning(gameId))
+            .thenReturn(gameInPhase(gameId, TurnPhase.BUY_OR_BUILD, currentTurnIndex = 1, roundNumber = 3))
         whenever(playerDao.findByGameId(gameId)).thenReturn(
             listOf(
                 PlayerModel(1, gameId, 10, 0, 3),
-                PlayerModel(2, gameId, 11, 1, 3)
+                PlayerModel(2, gameId, 11, 1, 3),
             )
         )
 
@@ -171,24 +167,15 @@ class GamePhaseServiceTest {
     @Test
     fun `endTurn rejects games outside buy or build phase`() {
         val gameId = 23
-        whenever(gameDao.findById(gameId)).thenReturn(
-            GameModel(
-                id = gameId,
-                status = GameStatus.IN_PROGRESS,
-                hostUserId = 1,
-                currentTurnIndex = 0,
-                turnPhase = TurnPhase.RESOLVE_EFFECTS,
-                lastDiceRoll = 4,
-                roundNumber = 2
-            )
-        )
+        whenever(gameStateGuard.ensureGameIsRunning(gameId))
+            .thenReturn(gameInPhase(gameId, TurnPhase.RESOLVE_EFFECTS, currentTurnIndex = 0, roundNumber = 2))
 
         assertThrows<IllegalStateException> {
             service.endTurn(gameId)
         }
 
         verify(gameDao, never()).updateTurnPhase(gameId, TurnPhase.END_TURN)
-        verify(gameDao, never()).advanceTurn(gameId, 0, 2)
+        verify(gameDao, never()).advanceTurn(any(), any(), any())
         verifyNoMoreInteractions(playerDao)
     }
 
@@ -202,7 +189,6 @@ class GamePhaseServiceTest {
             service.endTurn(gameId)
         }
         assertEquals("GAME_FINISHED", ex.errorCode)
-        verify(gameDao, never()).findById(gameId)
         verify(gameDao, never()).updateTurnPhase(any(), any())
         verify(gameDao, never()).advanceTurn(any(), any(), any())
         verifyNoMoreInteractions(playerDao)

--- a/src/test/kotlin/org/machikoro/server/service/GameStateGuardTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GameStateGuardTest.kt
@@ -1,7 +1,7 @@
 package org.machikoro.server.service
 
-import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.machikoro.server.dao.GameDao
@@ -29,19 +29,21 @@ class GameStateGuardTest {
     )
 
     @Test
-    fun `ensureGameIsRunning succeeds when status is IN_PROGRESS`() {
+    fun `ensureGameIsRunning returns the loaded game when status is IN_PROGRESS`() {
         val gameId = 1
-        whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.IN_PROGRESS))
+        val loaded = game(gameId, GameStatus.IN_PROGRESS)
+        whenever(gameDao.findById(gameId)).thenReturn(loaded)
 
-        assertDoesNotThrow { guard.ensureGameIsRunning(gameId) }
+        assertSame(loaded, guard.ensureGameIsRunning(gameId))
     }
 
     @Test
-    fun `ensureGameIsRunning succeeds when status is WAITING`() {
+    fun `ensureGameIsRunning returns the loaded game when status is WAITING`() {
         val gameId = 1
-        whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.WAITING))
+        val loaded = game(gameId, GameStatus.WAITING)
+        whenever(gameDao.findById(gameId)).thenReturn(loaded)
 
-        assertDoesNotThrow { guard.ensureGameIsRunning(gameId) }
+        assertSame(loaded, guard.ensureGameIsRunning(gameId))
     }
 
     @Test


### PR DESCRIPTION
Stacked on #122. Will auto-retarget to \`main\` once #122 merges.

## Summary
Two-commit follow-up to #122:

1. **`feat(#74): also guard endTurn against FINISHED games`** — calls \`GameStateGuard.ensureGameIsRunning\` at the top of \`endTurn\`, mirroring \`advancePhase\`. Without this, FINISHED games could still rotate turns. Adds a unit test that proves a thrown \`GAME_FINISHED\` short-circuits before any DAO interaction.

2. **\`refactor(#74): have GameStateGuard return the loaded game\`** — \`ensureGameIsRunning\` now returns the \`GameModel\` it loaded, so callers don't re-read the game.
   - \`advancePhase\`: 3 DAO calls → 2 (drops \`gameDao.getPhase\`)
   - \`endTurn\`: 5 DAO calls → 4 (drops the local \`findById\` + \`error()\`)
   - Side benefit: missing games in \`endTurn\` now consistently throw \`GameNotFoundException\` via the guard instead of \`IllegalStateException\` via \`error()\`.

## Why both in one PR
The guard call in \`endTurn\` (commit 1) introduced an N+1 — guard's \`findById\` then \`endTurn\`'s own \`findById\`. Commit 2 fixes that root cause rather than leaving it as a TODO. Splitting into two commits keeps the wiring change reviewable on its own.

## Test plan
- [x] \`./gradlew test --tests "org.machikoro.server.service.GameStateGuardTest"\` — 4/4 pass (success tests now \`assertSame\` on the returned model)
- [x] \`./gradlew test --tests "org.machikoro.server.service.GamePhaseServiceTest"\` — 11/11 pass (guard stubbed to return a \`GameModel\`; \`endTurn updates phase and rotates to next player\` uses \`inOrder()\` to lock in guard → updateTurnPhase → advanceTurn ordering)
- [x] \`./gradlew compileKotlin compileTestKotlin\` — no warnings
- [x] CI green (Sonar quality gate, JaCoCo coverage)

## Notes for reviewers
- Base is \`feat/74-block-actions-after-game-end\` (PR #122) — diff is just the two new commits on top of #122.
- Added a small \`gameInPhase(...)\` helper in \`GamePhaseServiceTest\` to stop repeating the 7-field \`GameModel(...)\` literal.