### PR TITLE
docs: #127 Added open api docs config

### DIFF
--- a/src/main/kotlin/org/machikoro/server/config/OpenApiConfig.kt
+++ b/src/main/kotlin/org/machikoro/server/config/OpenApiConfig.kt
@@ -25,10 +25,6 @@ class OpenApiConfig {
     ## WebSocket Connection
     Connect via STOMP at ws://localhost:8080/ws.
     
-    ### How to connect (JS example)
-    const client = new StompJs.Client({ brokerURL: 'ws://localhost:8080/ws' });
-    client.activate();
-    
     ### Endpoints
     | Destination | Payload | Broadcasts to |
     |---|---|---|

--- a/src/main/kotlin/org/machikoro/server/config/OpenApiConfig.kt
+++ b/src/main/kotlin/org/machikoro/server/config/OpenApiConfig.kt
@@ -1,0 +1,51 @@
+package org.machikoro.server.config
+
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.tags.Tag
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Sets up OpenAPI docs shown in Swagger UI
+ */
+@Configuration
+class OpenApiConfig {
+
+    @Bean
+    fun openApi(): OpenAPI = OpenAPI()
+        .info(
+            Info()
+                .title("Machi Koro API")
+                .version("1.0.0")
+                .description(
+                    """
+    REST and WebSocket API for the Machi Koro board game.
+    
+    ## WebSocket Connection
+    Connect via STOMP at ws://localhost:8080/ws.
+    
+    ### How to connect (JS example)
+    const client = new StompJs.Client({ brokerURL: 'ws://localhost:8080/ws' });
+    client.activate();
+    
+    ### Endpoints
+    | Destination | Payload | Broadcasts to |
+    |---|---|---|
+    | /app/game.resolveEffects | ResolveEffectsRequest | /topic/public |
+    | /app/game.advancePhase | AdvancePhaseRequest | /topic/public |
+    | /app/game.endTurn | EndTurnRequest | /topic/public |
+    | /app/chat.send | WebSocketMessage | /topic/public |
+    | /app/chat.addUser | WebSocketMessage | /topic/public |
+    """
+                        .trimIndent()
+                )
+        )
+        .tags(
+            listOf(
+                Tag().name("WebSocket")
+                    .description("WebSocket endpoints documented manually — not auto-scanned by Springdoc"),
+                Tag().name("Game").description("Game management endpoints")
+            )
+        )
+}

--- a/src/main/kotlin/org/machikoro/server/config/SecurityConfig.kt
+++ b/src/main/kotlin/org/machikoro/server/config/SecurityConfig.kt
@@ -28,6 +28,14 @@ class SecurityConfig {
                 auth.requestMatchers("/", "/index.html", "/css/**", "/js/**", "/webjars/**").permitAll()
                 auth.requestMatchers("/ws", "/ws/**", "/ws-sockjs", "/ws-sockjs/**").permitAll()
                 auth.requestMatchers("/actuator/health", "/actuator/health/**").permitAll()
+                auth.requestMatchers(
+                    "/swagger-ui.html",
+                    "/swagger-ui/**",
+                    "/api-docs",
+                    "/api-docs/**",
+                    "/v3/api-docs",
+                    "/v3/api-docs/**"
+                ).permitAll()
                 auth.requestMatchers("/api/**").authenticated()
                 auth.anyRequest().authenticated()
             }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,6 +3,11 @@ spring.docker.compose.enabled=false
 
 server.port=${SERVER_PORT:8080}
 
+# Swagger/Open API documentation
+springdoc.api-docs.path=/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.swagger-ui.operationsSorter=method
+
 websocket.allowed-origins=${WEBSOCKET_ALLOWED_ORIGINS:http://localhost:8080,http://localhost:3000}
 machikoro.db.init.enabled=true
 


### PR DESCRIPTION
Added the springdocs open api properties to the application.properties
Implemented OpenApiConfig.kt which sets up the docs. 
Extended the SecurityConfig.kt to permit the swagger endpoint

Endpoint is reachable at:
http://localhost:8080/swagger-ui/index.html