### PR TITLE
73 broadcast game end event

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
     implementation("org.jetbrains.exposed:exposed-jdbc:$exposedVersion")
     implementation("org.jetbrains.exposed:exposed-dao:$exposedVersion")
     implementation("org.springframework.boot:spring-boot-starter-jdbc")
+    implementation("androidx.room3:room3-common-jvm:3.0.0-alpha02")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     developmentOnly("org.springframework.boot:spring-boot-docker-compose")
     runtimeOnly("org.postgresql:postgresql")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,6 @@ dependencies {
     implementation("org.jetbrains.exposed:exposed-jdbc:$exposedVersion")
     implementation("org.jetbrains.exposed:exposed-dao:$exposedVersion")
     implementation("org.springframework.boot:spring-boot-starter-jdbc")
-    implementation("androidx.room3:room3-common-jvm:3.0.0-alpha02")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     developmentOnly("org.springframework.boot:spring-boot-docker-compose")
     runtimeOnly("org.postgresql:postgresql")

--- a/src/main/kotlin/org/machikoro/server/controller/GameController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/GameController.kt
@@ -6,6 +6,7 @@ import org.machikoro.server.dto.EndTurnRequest
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.WebSocketMessage
 import org.machikoro.server.service.GamePhaseService
+import org.machikoro.server.service.WinConditionService
 import org.slf4j.LoggerFactory
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.handler.annotation.Payload
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Controller
 class GameController(
     private val gamePhaseService: GamePhaseService,
     private val messagingTemplate: SimpMessagingTemplate,
+    private val winConditionService: WinConditionService
 ) {
     private val logger = LoggerFactory.getLogger(GameController::class.java)
 

--- a/src/main/kotlin/org/machikoro/server/controller/GameController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/GameController.kt
@@ -31,6 +31,14 @@ class GameController(
 
     @MessageMapping("/game.endTurn")
     fun endTurn(@Payload request: EndTurnRequest) {
+        val winner = winConditionService.detectWinner(request.gameId)
+
+        if (winner != null) {
+            logger.info("Game ${request.gameId} has ended. Winner: ${winner.id}")
+
+            broadcastWinner(winner)
+            return
+        }
         val newPhase = gamePhaseService.endTurn(request.gameId)
         logger.info("Ended turn for game ${request.gameId}, new phase $newPhase")
         broadcastPhase(newPhase)

--- a/src/main/kotlin/org/machikoro/server/controller/GameController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/GameController.kt
@@ -35,7 +35,7 @@ class GameController(
 
         if (winner != null) {
             logger.info("Game ${request.gameId} has ended. Winner: ${winner.id}")
-
+            gamePhaseService.finishGame(request.gameId)
             broadcastWinner(winner)
             return
         }

--- a/src/main/kotlin/org/machikoro/server/controller/GameController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/GameController.kt
@@ -1,6 +1,7 @@
 package org.machikoro.server.controller
 
 import org.machikoro.server.domain.enums.TurnPhase
+import org.machikoro.server.domain.models.PlayerModel
 import org.machikoro.server.dto.AdvancePhaseRequest
 import org.machikoro.server.dto.EndTurnRequest
 import org.machikoro.server.dto.MessageType
@@ -43,6 +44,17 @@ class GameController(
                 sender = "server",
                 payload = mapOf("turnPhase" to newPhase.name),
             ),
+        )
+    }
+
+    private fun broadcastWinner(winner: PlayerModel) {
+        messagingTemplate.convertAndSend(
+            "/topic/public",
+            WebSocketMessage(
+                type = MessageType.GAME_END,
+                sender = "server",
+                payload = mapOf("winnerId" to winner.id)
+            )
         )
     }
 }

--- a/src/main/kotlin/org/machikoro/server/service/GamePhaseService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/GamePhaseService.kt
@@ -2,6 +2,7 @@ package org.machikoro.server.service
 
 import org.machikoro.server.dao.GameDao
 import org.machikoro.server.dao.PlayerDao
+import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.enums.TurnPhase
 import org.springframework.stereotype.Service
 
@@ -46,5 +47,9 @@ class GamePhaseService(
 
         gameDao.advanceTurn(gameId, nextTurnIndex, nextRoundNumber)
         return TurnPhase.ROLL_DICE
+    }
+
+    fun finishGame(gameId: Int) {
+        gameDao.updateStatus(gameId, GameStatus.FINISHED)
     }
 }

--- a/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
@@ -3,11 +3,13 @@ package org.machikoro.server.controller
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.machikoro.server.domain.enums.TurnPhase
+import org.machikoro.server.domain.models.PlayerModel
 import org.machikoro.server.dto.AdvancePhaseRequest
 import org.machikoro.server.dto.EndTurnRequest
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.WebSocketMessage
 import org.machikoro.server.service.GamePhaseService
+import org.machikoro.server.service.WinConditionService
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -19,7 +21,8 @@ class GameControllerTest {
 
     private val gamePhaseService = mock<GamePhaseService>()
     private val messagingTemplate = mock<SimpMessagingTemplate>()
-    private val controller = GameController(gamePhaseService, messagingTemplate)
+    private val winConditionService = mock<WinConditionService>()
+    private val controller = GameController(gamePhaseService, messagingTemplate, winConditionService)
 
     @Test
     fun `advancePhase delegates to service with the requested game id`() {
@@ -60,6 +63,7 @@ class GameControllerTest {
     @Test
     fun `endTurn broadcasts resulting phase as GAME_ACTION on topic public`() {
         val gameId = 42
+        whenever(winConditionService.detectWinner(gameId)).thenReturn(null)
         whenever(gamePhaseService.endTurn(gameId)).thenReturn(TurnPhase.ROLL_DICE)
 
         controller.endTurn(EndTurnRequest(gameId))
@@ -72,4 +76,24 @@ class GameControllerTest {
         assertEquals("server", message.sender)
         assertEquals(mapOf("turnPhase" to "ROLL_DICE"), message.payload)
     }
+
+    @Test
+    fun `endTurn broadcasts GAME_END when winner exists`() {
+        val gameId = 42
+        val winner = mock<PlayerModel>()
+
+        whenever(winner.id).thenReturn(1)
+        whenever(winConditionService.detectWinner(gameId)).thenReturn(winner)
+
+        controller.endTurn(EndTurnRequest(gameId))
+
+        val captor = argumentCaptor<WebSocketMessage>()
+        verify(messagingTemplate).convertAndSend(eq("/topic/public"), captor.capture())
+
+        val message = captor.firstValue
+        assertEquals(MessageType.GAME_END, message.type)
+        assertEquals("server", message.sender)
+        assertEquals(mapOf("winnerId" to 1), message.payload)
+    }
+
 }

--- a/src/test/kotlin/org/machikoro/server/service/GamePhaseServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GamePhaseServiceTest.kt
@@ -193,4 +193,12 @@ class GamePhaseServiceTest {
         verify(gameDao, never()).advanceTurn(any(), any(), any())
         verifyNoMoreInteractions(playerDao)
     }
+    @Test
+    fun `finishGame updates game status to FINISHED`() {
+        val gameId = 123
+
+        service.finishGame(gameId)
+
+        verify(gameDao).updateStatus(gameId, GameStatus.FINISHED)
+    }
 }


### PR DESCRIPTION
Implemented game end detection on the server and broadcasting of the winner to all connected clients.

Changes:
- Added winner detection in GameController.endTurn
- Broadcast GAME_END event when player wins, closes #73 
- Included winnerId in the WebSocket message payload
- Prevented further game progression after a winner is detected
- Added finishGame() method in GamePhaseService to update game status, closes #71 
- Added corresponding unit tests for new functionality

Behavior:
- After BUY_OR_BUILD phase, when a player ends their turn:
  if a winner exists - GAME_END is broadcast and game stops,
  otherwise - game continues normally with next round

Result:
- Clients can now react to GAME_END and display win/lose screens
- Game state is no longer updated after game end
- Ensures event is sent only once
