### PR TITLE
feat: trigger win check after landmark purchase (#149)

### DIFF
--- a/src/main/kotlin/org/machikoro/server/controller/GameController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/GameController.kt
@@ -7,6 +7,7 @@ import org.machikoro.server.dto.EndTurnRequest
 import org.machikoro.server.dto.LeaveFinishedGameRequest
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.PurchaseRequest
+import org.machikoro.server.dto.PurchaseType
 import org.machikoro.server.dto.RollDiceRequest
 import org.machikoro.server.dto.WebSocketMessage
 import org.machikoro.server.service.DiceService
@@ -41,6 +42,17 @@ class GameController(
             landmarkType = request.landmarkType,
         )
         logger.info("Processed {} purchase for game {}", result.purchaseType, request.gameId)
+
+        if (result.purchaseType == PurchaseType.LANDMARK) {
+            val winner = winConditionService.detectWinner(request.gameId)
+            if (winner != null) {
+                logger.info("Game ${request.gameId} has ended. Winner: ${winner.id}")
+                gamePhaseService.finishGame(request.gameId)
+                broadcastWinner(request.gameId, winner)
+                return
+            }
+        }
+
         broadcastPurchase(request.gameId, result)
     }
 

--- a/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
@@ -26,6 +26,7 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.messaging.simp.SimpMessagingTemplate
@@ -123,6 +124,7 @@ class GameControllerTest {
                 landmarkType = LandmarkType.TRAIN_STATION,
             )
         )
+        whenever(winConditionService.detectWinner(gameId)).thenReturn(null)
 
         controller.purchase(PurchaseRequest(gameId, PurchaseType.LANDMARK, landmarkType = LandmarkType.TRAIN_STATION))
 
@@ -140,6 +142,54 @@ class GameControllerTest {
             ),
             message.payload,
         )
+    }
+
+    @Test
+    fun `purchase broadcasts GAME_END and finishes game when landmark purchase wins`() {
+        val gameId = 42
+        whenever(
+            purchaseService.purchase(gameId, PurchaseType.LANDMARK, null, LandmarkType.RADIO_TOWER)
+        ).thenReturn(
+            PurchaseResult(
+                turnPhase = TurnPhase.BUY_OR_BUILD,
+                purchaseType = PurchaseType.LANDMARK,
+                landmarkType = LandmarkType.RADIO_TOWER,
+            )
+        )
+        val winner = mock<PlayerModel>()
+        whenever(winner.id).thenReturn(7)
+        whenever(winConditionService.detectWinner(gameId)).thenReturn(winner)
+
+        controller.purchase(PurchaseRequest(gameId, PurchaseType.LANDMARK, landmarkType = LandmarkType.RADIO_TOWER))
+
+        verify(gamePhaseService).finishGame(gameId)
+
+        val captor = argumentCaptor<WebSocketMessage>()
+        verify(messagingTemplate).convertAndSend(eq("/topic/game/$gameId"), captor.capture())
+
+        val message = captor.firstValue
+        assertEquals(MessageType.GAME_END, message.type)
+        assertEquals("server", message.sender)
+        assertEquals(mapOf("winnerId" to 7), message.payload)
+    }
+
+    @Test
+    fun `purchase does not invoke win check for establishment purchases`() {
+        val gameId = 42
+        whenever(
+            purchaseService.purchase(gameId, PurchaseType.ESTABLISHMENT, CardType.BAKERY, null)
+        ).thenReturn(
+            PurchaseResult(
+                turnPhase = TurnPhase.BUY_OR_BUILD,
+                purchaseType = PurchaseType.ESTABLISHMENT,
+                cardType = CardType.BAKERY,
+            )
+        )
+
+        controller.purchase(PurchaseRequest(gameId, PurchaseType.ESTABLISHMENT, cardType = CardType.BAKERY))
+
+        verify(winConditionService, never()).detectWinner(any())
+        verify(gamePhaseService, never()).finishGame(any())
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
@@ -27,6 +27,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.messaging.simp.SimpMessagingTemplate
@@ -165,7 +166,7 @@ class GameControllerTest {
         verify(gamePhaseService).finishGame(gameId)
 
         val captor = argumentCaptor<WebSocketMessage>()
-        verify(messagingTemplate).convertAndSend(eq("/topic/game/$gameId"), captor.capture())
+        verify(messagingTemplate, times(1)).convertAndSend(eq("/topic/game/$gameId"), captor.capture())
 
         val message = captor.firstValue
         assertEquals(MessageType.GAME_END, message.type)


### PR DESCRIPTION
## Summary
- After a successful `LANDMARK` purchase, `GameController.purchase` now calls `winConditionService.detectWinner(gameId)`. If a winner is found, it transitions the game to `FINISHED` via `gamePhaseService.finishGame(...)`, broadcasts `GAME_END` to `/topic/game/{gameId}`, and skips the regular `GAME_ACTION` purchase broadcast.
- Establishment purchases are unaffected — no win check is invoked.
- Mirrors the existing `endTurn` win-detection pattern (`GameController.kt:67-75`) so the codebase has one consistent shape for in-controller win detection.

Fixes #149's gap where a player who built their 4th landmark via `/game.purchase` had to also call `/game.endTurn` before the game actually ended.

Closes #149.

## Test plan
- [x] `./gradlew test --tests GameControllerTest --tests WinConditionServiceTest --tests GamePhaseServiceTest --tests DiceServiceTests --tests GameStateGuardTest` — green (15/15 in `GameControllerTest`)
- [x] `./gradlew compileKotlin compileTestKotlin --warning-mode all` — 0 warnings, 0 errors

## Test changes (`GameControllerTest`)
- Updated existing `purchase broadcasts resulting purchase payload as GAME_ACTION on game topic` to stub `winConditionService.detectWinner(gameId) returns null`, exercising the not-won landmark path.
- New `purchase broadcasts GAME_END and finishes game when landmark purchase wins` — verifies `gamePhaseService.finishGame(gameId)` is called, the captured message is `GAME_END` with `winnerId`, and `times(1)` on `convertAndSend` locks in that the regular `GAME_ACTION` purchase broadcast is **not** sent.
- New `purchase does not invoke win check for establishment purchases` — verifies neither `winConditionService.detectWinner` nor `gamePhaseService.finishGame` is invoked for `ESTABLISHMENT` purchases.

## Out of scope
- The `endTurn` win-detection path — already correct, untouched.
- Game-end cleanup / lobby return / session disposal (#62, #65, #66, #76).
- Sister sub-issue #150 (block dice rolls in FINISHED games) — already merged via #151.