### PR TITLE
feat: #130 add REST companion controller for WebSocket actions

### DIFF
--- a/src/main/kotlin/org/machikoro/server/config/OpenApiConfig.kt
+++ b/src/main/kotlin/org/machikoro/server/config/OpenApiConfig.kt
@@ -21,18 +21,21 @@ class OpenApiConfig {
                 .description(
                     """
     REST and WebSocket API for the Machi Koro board game.
-    
+
     ## WebSocket Connection
     Connect via STOMP at ws://localhost:8080/ws.
-    
+
     ### Endpoints
     | Destination | Payload | Broadcasts to |
     |---|---|---|
     | /app/game.resolveEffects | ResolveEffectsRequest | /topic/public |
-    | /app/game.advancePhase | AdvancePhaseRequest | /topic/public |
     | /app/game.endTurn | EndTurnRequest | /topic/public |
     | /app/chat.send | WebSocketMessage | /topic/public |
     | /app/chat.addUser | WebSocketMessage | /topic/public |
+
+    For Swagger-driven testing of these actions over plain HTTP, see the
+    "WebSocket Companion (dev)" tag below — it mirrors each STOMP action as a
+    POST under `/api/dev/game/...` and is disabled in the `prod` profile.
     """
                         .trimIndent()
                 )

--- a/src/main/kotlin/org/machikoro/server/config/SecurityConfig.kt
+++ b/src/main/kotlin/org/machikoro/server/config/SecurityConfig.kt
@@ -15,14 +15,19 @@ class SecurityConfig {
      * Permits unauthenticated access to WebSocket endpoints, static resources, the root/index page,
      * and the `/actuator/health` endpoint so Docker, CI, and monitoring can poll it without credentials.
      * Requires authentication for API endpoints.
-     * CSRF is disabled for WebSocket endpoints to allow SockJS fallback HTTP POST requests.
+     * CSRF is disabled for WebSocket endpoints to allow SockJS fallback HTTP POST requests,
+     * and for the profile-gated dev companion path so its Swagger endpoints are usable
+     * from curl/Postman without a session-bound token.
      * CSRF remains enabled for all other endpoints including API routes.
      */
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
         http
             .csrf { csrf ->
-                csrf.ignoringRequestMatchers("/ws", "/ws/**", "/ws-sockjs", "/ws-sockjs/**")
+                csrf.ignoringRequestMatchers(
+                    "/ws", "/ws/**", "/ws-sockjs", "/ws-sockjs/**",
+                    "/api/dev/**",
+                )
             }
             .authorizeHttpRequests { auth ->
                 auth.requestMatchers("/", "/index.html", "/css/**", "/js/**", "/webjars/**").permitAll()

--- a/src/main/kotlin/org/machikoro/server/config/SecurityConfig.kt
+++ b/src/main/kotlin/org/machikoro/server/config/SecurityConfig.kt
@@ -36,6 +36,7 @@ class SecurityConfig {
                     "/v3/api-docs",
                     "/v3/api-docs/**"
                 ).permitAll()
+                auth.requestMatchers("/api/dev/**").permitAll()
                 auth.requestMatchers("/api/**").authenticated()
                 auth.anyRequest().authenticated()
             }

--- a/src/main/kotlin/org/machikoro/server/controller/GameRestController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/GameRestController.kt
@@ -1,0 +1,116 @@
+package org.machikoro.server.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.machikoro.server.domain.enums.TurnPhase
+import org.machikoro.server.dto.EndTurnRequest
+import org.machikoro.server.dto.LeaveFinishedGameRequest
+import org.machikoro.server.dto.PurchaseRequest
+import org.machikoro.server.dto.ResolveEffectsRequest
+import org.machikoro.server.dto.RollDiceRequest
+import org.machikoro.server.dto.RollDiceResponse
+import org.machikoro.server.service.DiceService
+import org.machikoro.server.service.GamePhaseService
+import org.machikoro.server.service.LeaveFinishedGameService
+import org.machikoro.server.service.PurchaseResult
+import org.machikoro.server.service.PurchaseService
+import org.machikoro.server.service.WinConditionService
+import org.machikoro.server.service.interfaces.EarningsService
+import org.springframework.context.annotation.Profile
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * HTTP companion for the WebSocket game actions exposed by [GameController] and
+ * [EarningsController]. Each endpoint delegates to the same service method as its
+ * STOMP counterpart so behaviour stays identical; broadcasting over
+ * [org.springframework.messaging.simp.SimpMessagingTemplate] is intentionally
+ * omitted because there is no subscribed STOMP session in an HTTP request.
+ *
+ * Intended for Swagger UI / curl / Postman exercising during development.
+ * Disabled in the `prod` profile.
+ *
+ * If you add a new `@MessageMapping` to [GameController] or [EarningsController],
+ * mirror it here so the dev surface stays in sync.
+ */
+@RestController
+@RequestMapping("/api/dev/game")
+@Tag(
+    name = "WebSocket Companion (dev)",
+    description = "HTTP mirror of /app/game.* STOMP actions for Swagger testing. Not for production use."
+)
+@Profile("!prod")
+class GameRestController(
+    private val purchaseService: PurchaseService,
+    private val gamePhaseService: GamePhaseService,
+    private val winConditionService: WinConditionService,
+    private val leaveFinishedGameService: LeaveFinishedGameService,
+    private val diceService: DiceService,
+    private val earningsService: EarningsService,
+) {
+
+    @PostMapping("/purchase")
+    @Operation(summary = "Mirror of /app/game.purchase")
+    fun purchase(@RequestBody request: PurchaseRequest): ResponseEntity<Any> = runCatching {
+        purchaseService.purchase(
+            gameId = request.gameId,
+            purchaseType = request.purchaseType,
+            cardType = request.cardType,
+            landmarkType = request.landmarkType,
+        )
+    }.fold(
+        onSuccess = { ResponseEntity.ok<Any>(it) },
+        onFailure = { ResponseEntity.badRequest().body(it.message) },
+    )
+
+    @PostMapping("/endTurn")
+    @Operation(summary = "Mirror of /app/game.endTurn")
+    fun endTurn(@RequestBody request: EndTurnRequest): ResponseEntity<Any> = runCatching {
+        val winner = winConditionService.detectWinner(request.gameId)
+        if (winner != null) {
+            gamePhaseService.finishGame(request.gameId)
+            EndTurnResponse(turnPhase = null, winnerId = winner.id)
+        } else {
+            val newPhase = gamePhaseService.endTurn(request.gameId)
+            EndTurnResponse(turnPhase = newPhase, winnerId = null)
+        }
+    }.fold(
+        onSuccess = { ResponseEntity.ok<Any>(it) },
+        onFailure = { ResponseEntity.badRequest().body(it.message) },
+    )
+
+    @PostMapping("/leave")
+    @Operation(summary = "Mirror of /app/game.leave")
+    fun leave(@RequestBody request: LeaveFinishedGameRequest): ResponseEntity<Any> = runCatching {
+        leaveFinishedGameService.leaveFinishedGame(request.gameId, request.playerId)
+    }.fold(
+        onSuccess = { ResponseEntity.ok().build<Any>() },
+        onFailure = { ResponseEntity.badRequest().body(it.message) },
+    )
+
+    @PostMapping("/rollDice")
+    @Operation(summary = "Mirror of /app/game.rollDice")
+    fun rollDice(@RequestBody request: RollDiceRequest): ResponseEntity<Any> = runCatching {
+        diceService.rollDice(request)
+    }.fold(
+        onSuccess = { ResponseEntity.ok<Any>(it) },
+        onFailure = { ResponseEntity.badRequest().body(it.message) },
+    )
+
+    @PostMapping("/resolveEffects")
+    @Operation(summary = "Mirror of /app/game.resolveEffects")
+    fun resolveEffects(@RequestBody request: ResolveEffectsRequest): ResponseEntity<Any> = runCatching {
+        earningsService.resolveEffects(request.gameId)
+    }.fold(
+        onSuccess = { ResponseEntity.ok().build<Any>() },
+        onFailure = { ResponseEntity.badRequest().body(it.message) },
+    )
+}
+
+data class EndTurnResponse(
+    val turnPhase: TurnPhase?,
+    val winnerId: Int?,
+)

--- a/src/main/kotlin/org/machikoro/server/controller/GameRestController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/GameRestController.kt
@@ -8,11 +8,9 @@ import org.machikoro.server.dto.LeaveFinishedGameRequest
 import org.machikoro.server.dto.PurchaseRequest
 import org.machikoro.server.dto.ResolveEffectsRequest
 import org.machikoro.server.dto.RollDiceRequest
-import org.machikoro.server.dto.RollDiceResponse
 import org.machikoro.server.service.DiceService
 import org.machikoro.server.service.GamePhaseService
 import org.machikoro.server.service.LeaveFinishedGameService
-import org.machikoro.server.service.PurchaseResult
 import org.machikoro.server.service.PurchaseService
 import org.machikoro.server.service.WinConditionService
 import org.machikoro.server.service.interfaces.EarningsService
@@ -33,8 +31,10 @@ import org.springframework.web.bind.annotation.RestController
  * Intended for Swagger UI / curl / Postman exercising during development.
  * Disabled in the `prod` profile.
  *
- * If you add a new `@MessageMapping` to [GameController] or [EarningsController],
- * mirror it here so the dev surface stays in sync.
+ * `/app/game.advancePhase` is intentionally not mirrored: PR #153 removes that
+ * STOMP mapping in favour of phase advancement happening internally inside
+ * `endTurn`. If you add a new `@MessageMapping` to [GameController] or
+ * [EarningsController], mirror it here so the dev surface stays in sync.
  */
 @RestController
 @RequestMapping("/api/dev/game")
@@ -54,60 +54,69 @@ class GameRestController(
 
     @PostMapping("/purchase")
     @Operation(summary = "Mirror of /app/game.purchase")
-    fun purchase(@RequestBody request: PurchaseRequest): ResponseEntity<Any> = runCatching {
-        purchaseService.purchase(
-            gameId = request.gameId,
-            purchaseType = request.purchaseType,
-            cardType = request.cardType,
-            landmarkType = request.landmarkType,
-        )
-    }.fold(
-        onSuccess = { ResponseEntity.ok<Any>(it) },
-        onFailure = { ResponseEntity.badRequest().body(it.message) },
-    )
+    fun purchase(@RequestBody request: PurchaseRequest): ResponseEntity<Any> {
+        return try {
+            val result = purchaseService.purchase(
+                gameId = request.gameId,
+                purchaseType = request.purchaseType,
+                cardType = request.cardType,
+                landmarkType = request.landmarkType,
+            )
+            ResponseEntity.ok(result)
+        } catch (e: Exception) {
+            ResponseEntity.badRequest().body(e.message)
+        }
+    }
 
     @PostMapping("/endTurn")
     @Operation(summary = "Mirror of /app/game.endTurn")
-    fun endTurn(@RequestBody request: EndTurnRequest): ResponseEntity<Any> = runCatching {
-        val winner = winConditionService.detectWinner(request.gameId)
-        if (winner != null) {
-            gamePhaseService.finishGame(request.gameId)
-            EndTurnResponse(turnPhase = null, winnerId = winner.id)
-        } else {
-            val newPhase = gamePhaseService.endTurn(request.gameId)
-            EndTurnResponse(turnPhase = newPhase, winnerId = null)
+    fun endTurn(@RequestBody request: EndTurnRequest): ResponseEntity<Any> {
+        return try {
+            val winner = winConditionService.detectWinner(request.gameId)
+            val response = if (winner != null) {
+                gamePhaseService.finishGame(request.gameId)
+                EndTurnResponse(turnPhase = null, winnerId = winner.id)
+            } else {
+                val newPhase = gamePhaseService.endTurn(request.gameId)
+                EndTurnResponse(turnPhase = newPhase, winnerId = null)
+            }
+            ResponseEntity.ok(response)
+        } catch (e: Exception) {
+            ResponseEntity.badRequest().body(e.message)
         }
-    }.fold(
-        onSuccess = { ResponseEntity.ok<Any>(it) },
-        onFailure = { ResponseEntity.badRequest().body(it.message) },
-    )
+    }
 
     @PostMapping("/leave")
     @Operation(summary = "Mirror of /app/game.leave")
-    fun leave(@RequestBody request: LeaveFinishedGameRequest): ResponseEntity<Any> = runCatching {
-        leaveFinishedGameService.leaveFinishedGame(request.gameId, request.playerId)
-    }.fold(
-        onSuccess = { ResponseEntity.ok().build<Any>() },
-        onFailure = { ResponseEntity.badRequest().body(it.message) },
-    )
+    fun leave(@RequestBody request: LeaveFinishedGameRequest): ResponseEntity<Any> {
+        return try {
+            leaveFinishedGameService.leaveFinishedGame(request.gameId, request.playerId)
+            ResponseEntity.ok().build()
+        } catch (e: Exception) {
+            ResponseEntity.badRequest().body(e.message)
+        }
+    }
 
     @PostMapping("/rollDice")
     @Operation(summary = "Mirror of /app/game.rollDice")
-    fun rollDice(@RequestBody request: RollDiceRequest): ResponseEntity<Any> = runCatching {
-        diceService.rollDice(request)
-    }.fold(
-        onSuccess = { ResponseEntity.ok<Any>(it) },
-        onFailure = { ResponseEntity.badRequest().body(it.message) },
-    )
+    fun rollDice(@RequestBody request: RollDiceRequest): ResponseEntity<Any> {
+        return try {
+            ResponseEntity.ok(diceService.rollDice(request))
+        } catch (e: Exception) {
+            ResponseEntity.badRequest().body(e.message)
+        }
+    }
 
     @PostMapping("/resolveEffects")
     @Operation(summary = "Mirror of /app/game.resolveEffects")
-    fun resolveEffects(@RequestBody request: ResolveEffectsRequest): ResponseEntity<Any> = runCatching {
-        earningsService.resolveEffects(request.gameId)
-    }.fold(
-        onSuccess = { ResponseEntity.ok().build<Any>() },
-        onFailure = { ResponseEntity.badRequest().body(it.message) },
-    )
+    fun resolveEffects(@RequestBody request: ResolveEffectsRequest): ResponseEntity<Any> {
+        return try {
+            earningsService.resolveEffects(request.gameId)
+            ResponseEntity.ok().build()
+        } catch (e: Exception) {
+            ResponseEntity.badRequest().body(e.message)
+        }
+    }
 }
 
 data class EndTurnResponse(

--- a/src/test/kotlin/org/machikoro/server/controller/GameRestControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/GameRestControllerTest.kt
@@ -1,0 +1,195 @@
+package org.machikoro.server.controller
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.machikoro.server.domain.enums.CardType
+import org.machikoro.server.domain.enums.TurnPhase
+import org.machikoro.server.domain.models.PlayerModel
+import org.machikoro.server.dto.EndTurnRequest
+import org.machikoro.server.dto.LeaveFinishedGameRequest
+import org.machikoro.server.dto.PurchaseRequest
+import org.machikoro.server.dto.PurchaseType
+import org.machikoro.server.dto.ResolveEffectsRequest
+import org.machikoro.server.dto.RollDiceRequest
+import org.machikoro.server.dto.RollDiceResponse
+import org.machikoro.server.service.DiceService
+import org.machikoro.server.service.GamePhaseService
+import org.machikoro.server.service.LeaveFinishedGameService
+import org.machikoro.server.service.PurchaseResult
+import org.machikoro.server.service.PurchaseService
+import org.machikoro.server.service.WinConditionService
+import org.machikoro.server.service.interfaces.EarningsService
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+
+class GameRestControllerTest {
+
+    private val purchaseService = mock<PurchaseService>()
+    private val gamePhaseService = mock<GamePhaseService>()
+    private val winConditionService = mock<WinConditionService>()
+    private val leaveFinishedGameService = mock<LeaveFinishedGameService>()
+    private val diceService = mock<DiceService>()
+    private val earningsService = mock<EarningsService>()
+
+    private val controller = GameRestController(
+        purchaseService,
+        gamePhaseService,
+        winConditionService,
+        leaveFinishedGameService,
+        diceService,
+        earningsService,
+    )
+
+    @Test
+    fun `purchase returns ok and delegates to service`() {
+        val request = PurchaseRequest(
+            gameId = 1,
+            purchaseType = PurchaseType.ESTABLISHMENT,
+            cardType = CardType.BAKERY,
+        )
+        val result = PurchaseResult(
+            turnPhase = TurnPhase.BUY_OR_BUILD,
+            purchaseType = PurchaseType.ESTABLISHMENT,
+            cardType = CardType.BAKERY,
+        )
+        whenever(
+            purchaseService.purchase(
+                gameId = 1,
+                purchaseType = PurchaseType.ESTABLISHMENT,
+                cardType = CardType.BAKERY,
+                landmarkType = null,
+            )
+        ).thenReturn(result)
+
+        val response = controller.purchase(request)
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals(result, response.body)
+    }
+
+    @Test
+    fun `purchase returns bad request when service throws`() {
+        val request = PurchaseRequest(
+            gameId = 1,
+            purchaseType = PurchaseType.ESTABLISHMENT,
+            cardType = CardType.BAKERY,
+        )
+        whenever(
+            purchaseService.purchase(
+                gameId = 1,
+                purchaseType = PurchaseType.ESTABLISHMENT,
+                cardType = CardType.BAKERY,
+                landmarkType = null,
+            )
+        ).thenThrow(RuntimeException("boom"))
+
+        val response = controller.purchase(request)
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertEquals("boom", response.body)
+    }
+
+    @Test
+    fun `endTurn without winner returns next phase and does not finish the game`() {
+        val gameId = 7
+        whenever(winConditionService.detectWinner(gameId)).thenReturn(null)
+        whenever(gamePhaseService.endTurn(gameId)).thenReturn(TurnPhase.ROLL_DICE)
+
+        val response = controller.endTurn(EndTurnRequest(gameId))
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals(EndTurnResponse(turnPhase = TurnPhase.ROLL_DICE, winnerId = null), response.body)
+        verify(gamePhaseService, never()).finishGame(gameId)
+    }
+
+    @Test
+    fun `endTurn with winner finishes the game and returns the winner id`() {
+        val gameId = 7
+        val winner = mock<PlayerModel>()
+        whenever(winner.id).thenReturn(99)
+        whenever(winConditionService.detectWinner(gameId)).thenReturn(winner)
+
+        val response = controller.endTurn(EndTurnRequest(gameId))
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals(EndTurnResponse(turnPhase = null, winnerId = 99), response.body)
+        verify(gamePhaseService).finishGame(gameId)
+        verify(gamePhaseService, never()).endTurn(gameId)
+    }
+
+    @Test
+    fun `endTurn returns bad request when service throws`() {
+        val gameId = 7
+        whenever(winConditionService.detectWinner(gameId)).thenReturn(null)
+        whenever(gamePhaseService.endTurn(gameId)).thenThrow(IllegalStateException("not in BUY_OR_BUILD"))
+
+        val response = controller.endTurn(EndTurnRequest(gameId))
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertEquals("not in BUY_OR_BUILD", response.body)
+    }
+
+    @Test
+    fun `leave returns ok and delegates to service`() {
+        val response = controller.leave(LeaveFinishedGameRequest(gameId = 3, playerId = 42))
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        verify(leaveFinishedGameService).leaveFinishedGame(3, 42)
+    }
+
+    @Test
+    fun `leave returns bad request when service throws`() {
+        whenever(leaveFinishedGameService.leaveFinishedGame(3, 42))
+            .thenThrow(IllegalArgumentException("Player not in game"))
+
+        val response = controller.leave(LeaveFinishedGameRequest(gameId = 3, playerId = 42))
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertEquals("Player not in game", response.body)
+    }
+
+    @Test
+    fun `rollDice returns ok with dice response`() {
+        val request = RollDiceRequest(gameId = 1, playerId = 2)
+        val expected = RollDiceResponse(dice = listOf(3, 4), total = 7)
+        whenever(diceService.rollDice(request)).thenReturn(expected)
+
+        val response = controller.rollDice(request)
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals(expected, response.body)
+    }
+
+    @Test
+    fun `rollDice returns bad request when service throws`() {
+        val request = RollDiceRequest(gameId = 1, playerId = 2)
+        whenever(diceService.rollDice(request)).thenThrow(RuntimeException("dice exploded"))
+
+        val response = controller.rollDice(request)
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertEquals("dice exploded", response.body)
+    }
+
+    @Test
+    fun `resolveEffects returns ok and delegates to service`() {
+        val response = controller.resolveEffects(ResolveEffectsRequest(gameId = 5))
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        verify(earningsService).resolveEffects(5)
+    }
+
+    @Test
+    fun `resolveEffects returns bad request when service throws`() {
+        whenever(earningsService.resolveEffects(5))
+            .thenThrow(RuntimeException("effects failed"))
+
+        val response = controller.resolveEffects(ResolveEffectsRequest(gameId = 5))
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertEquals("effects failed", response.body)
+    }
+}


### PR DESCRIPTION
Closes #130.

## Summary
- New `GameRestController` at `/api/dev/game/**` mirrors the `/app/game.*` STOMP actions (`purchase`, `endTurn`, `leave`, `rollDice`, `resolveEffects`) as plain HTTP POST endpoints, delegating to the same service methods so behaviour stays identical. Intended for Swagger UI / curl / Postman driven testing.
- Gated behind `@Profile("!prod")` and grouped under a dedicated `WebSocket Companion (dev)` Swagger tag. `SecurityConfig` adds `/api/dev/**` to `permitAll` and to the CSRF ignore list so the endpoints are actually reachable from curl/Postman without a session-bound token — please review that tradeoff.
- `/app/game.advancePhase` is intentionally **not** mirrored: PR #153 removes that STOMP mapping, so adding a companion for it now would just need to be ripped out. The stale row in the `OpenApiConfig` WebSocket table is also dropped here.

## Coordination with #153
When #153 merges first, this branch will need a small rebase: `gamePhaseService.endTurn` will return `EndTurnOutcome` instead of `TurnPhase`, and winner detection moves inside `endTurn`. The companion's `endTurn` handler (and its tests) will need to be reshaped to consume the sealed result.

## Test plan
- [x] `GameRestControllerTest` — 11 new unit tests cover the success and failure path of every endpoint, plus both branches of `endTurn` (winner / no winner). All pass.
- [x] Full `./gradlew test` green except for 18 pre-existing testcontainer-dependent failures that are also failing on `main` in this environment (no Docker locally).
- [ ] Reviewer to spot-check `/swagger-ui.html` shows the new `WebSocket Companion (dev)` tag.
- [ ] Reviewer or local QA to exercise at least one endpoint end-to-end against a running game (e.g. `POST /api/dev/game/rollDice`).
- [ ] Confirm endpoints are absent when `SPRING_PROFILES_ACTIVE=prod`.