### PR TITLE
feat: #162 add POST /auth/register endpoint

### DIFF
--- a/src/main/kotlin/org/machikoro/server/config/SecurityConfig.kt
+++ b/src/main/kotlin/org/machikoro/server/config/SecurityConfig.kt
@@ -17,14 +17,19 @@ class SecurityConfig {
      * Permits unauthenticated access to WebSocket endpoints, static resources, the root/index page,
      * and the `/actuator/health` endpoint so Docker, CI, and monitoring can poll it without credentials.
      * Requires authentication for API endpoints.
-     * CSRF is disabled for WebSocket endpoints to allow SockJS fallback HTTP POST requests.
+     * CSRF is disabled for WebSocket endpoints to allow SockJS fallback HTTP POST requests
+     * and for the public auth endpoints since clients (e.g. the Android app) post JSON
+     * without a session-bound CSRF token.
      * CSRF remains enabled for all other endpoints including API routes.
      */
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
         http
             .csrf { csrf ->
-                csrf.ignoringRequestMatchers("/ws", "/ws/**", "/ws-sockjs", "/ws-sockjs/**")
+                csrf.ignoringRequestMatchers(
+                    "/ws", "/ws/**", "/ws-sockjs", "/ws-sockjs/**",
+                    "/auth/**",
+                )
             }
             .authorizeHttpRequests { auth ->
                 auth.requestMatchers("/", "/index.html", "/css/**", "/js/**", "/webjars/**").permitAll()
@@ -38,6 +43,7 @@ class SecurityConfig {
                     "/v3/api-docs",
                     "/v3/api-docs/**"
                 ).permitAll()
+                auth.requestMatchers("/auth/**").permitAll()
                 auth.requestMatchers("/api/**").authenticated()
                 auth.anyRequest().authenticated()
             }

--- a/src/main/kotlin/org/machikoro/server/controller/AuthController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/AuthController.kt
@@ -1,0 +1,27 @@
+package org.machikoro.server.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.machikoro.server.dto.RegisterRequest
+import org.machikoro.server.service.AuthService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/auth")
+@Tag(name = "Authentication", description = "User registration, login, and session management")
+class AuthController(private val authService: AuthService) {
+
+    @PostMapping("/register")
+    @Operation(summary = "Register a new user with username and password")
+    fun register(@RequestBody request: RegisterRequest): ResponseEntity<Any> {
+        return try {
+            ResponseEntity.ok(authService.register(request.username, request.password))
+        } catch (e: Exception) {
+            ResponseEntity.badRequest().body(e.message)
+        }
+    }
+}

--- a/src/main/kotlin/org/machikoro/server/controller/AuthController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/AuthController.kt
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.machikoro.server.dto.RegisterRequest
 import org.machikoro.server.service.AuthService
+import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -14,13 +15,17 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/auth")
 @Tag(name = "Authentication", description = "User registration, login, and session management")
 class AuthController(private val authService: AuthService) {
+    private val logger = LoggerFactory.getLogger(AuthController::class.java)
 
     @PostMapping("/register")
     @Operation(summary = "Register a new user with username and password")
     fun register(@RequestBody request: RegisterRequest): ResponseEntity<Any> {
         return try {
-            ResponseEntity.ok(authService.register(request.username, request.password))
+            val response = authService.register(request.username, request.password)
+            logger.info("Registered user '{}'", response.username)
+            ResponseEntity.ok(response)
         } catch (e: Exception) {
+            logger.warn("Registration failed for '{}': {}", request.username, e.message)
             ResponseEntity.badRequest().body(e.message)
         }
     }

--- a/src/main/kotlin/org/machikoro/server/dto/RegisterRequest.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/RegisterRequest.kt
@@ -1,0 +1,11 @@
+package org.machikoro.server.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Request to register a new user — sent to POST /auth/register")
+data class RegisterRequest(
+    @Schema(description = "Desired username, 1-50 characters", example = "alice")
+    val username: String,
+    @Schema(description = "Raw password — server hashes via BCrypt before persisting", example = "hunter2")
+    val password: String,
+)

--- a/src/main/kotlin/org/machikoro/server/dto/RegisterResponse.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/RegisterResponse.kt
@@ -1,0 +1,11 @@
+package org.machikoro.server.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Response from a successful registration — does not include password or session token")
+data class RegisterResponse(
+    @Schema(description = "Newly created user id", example = "42")
+    val id: Int,
+    @Schema(description = "Registered username", example = "alice")
+    val username: String,
+)

--- a/src/main/kotlin/org/machikoro/server/exception/DuplicateUserException.kt
+++ b/src/main/kotlin/org/machikoro/server/exception/DuplicateUserException.kt
@@ -1,0 +1,3 @@
+package org.machikoro.server.exception
+
+class DuplicateUserException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/org/machikoro/server/service/AuthService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/AuthService.kt
@@ -17,19 +17,29 @@ class AuthService(
      * Validates input, hashes the password via BCrypt, and persists a new user.
      * The findByUsername + create pair runs in one transaction so a duplicate
      * inserted between the two calls will roll back rather than leak through.
+     *
+     * Username is trimmed and lower-cased before persistence so "Alice", "alice",
+     * and " alice " all map to the same account. Password is left untouched so
+     * surrounding whitespace stays significant to the caller.
      */
     @Transactional
     fun register(username: String, rawPassword: String): RegisterResponse {
-        require(username.isNotBlank()) { "Username must not be blank" }
-        require(rawPassword.isNotBlank()) { "Password must not be blank" }
-        require(username.length <= 50) { "Username must be at most 50 characters" }
+        val cleanUsername = username.trim().lowercase()
 
-        if (userDao.findByUsername(username) != null) {
-            throw DuplicateUserException("Username '$username' is already taken")
+        require(cleanUsername.isNotBlank()) { "Username must not be blank" }
+        require(cleanUsername.length <= 50) { "Username must be at most 50 characters" }
+        require(rawPassword.isNotBlank()) { "Password must not be blank" }
+        // BCrypt silently truncates inputs longer than 72 bytes; reject up front
+        // so clients see a clear error rather than a confusing "your password
+        // worked but only the first 72 bytes" surprise later.
+        require(rawPassword.length <= 72) { "Password must be at most 72 characters" }
+
+        if (userDao.findByUsername(cleanUsername) != null) {
+            throw DuplicateUserException("Username '$cleanUsername' is already taken")
         }
 
         val hash = passwordEncoder.encode(rawPassword)
-        val id = userDao.create(username, hash)
-        return RegisterResponse(id = id, username = username)
+        val id = userDao.create(cleanUsername, hash)
+        return RegisterResponse(id = id, username = cleanUsername)
     }
 }

--- a/src/main/kotlin/org/machikoro/server/service/AuthService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/AuthService.kt
@@ -1,0 +1,35 @@
+package org.machikoro.server.service
+
+import org.machikoro.server.dao.UserDao
+import org.machikoro.server.dto.RegisterResponse
+import org.machikoro.server.exception.DuplicateUserException
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class AuthService(
+    private val userDao: UserDao,
+    private val passwordEncoder: PasswordEncoder,
+) {
+
+    /**
+     * Validates input, hashes the password via BCrypt, and persists a new user.
+     * The findByUsername + create pair runs in one transaction so a duplicate
+     * inserted between the two calls will roll back rather than leak through.
+     */
+    @Transactional
+    fun register(username: String, rawPassword: String): RegisterResponse {
+        require(username.isNotBlank()) { "Username must not be blank" }
+        require(rawPassword.isNotBlank()) { "Password must not be blank" }
+        require(username.length <= 50) { "Username must be at most 50 characters" }
+
+        if (userDao.findByUsername(username) != null) {
+            throw DuplicateUserException("Username '$username' is already taken")
+        }
+
+        val hash = passwordEncoder.encode(rawPassword)
+        val id = userDao.create(username, hash)
+        return RegisterResponse(id = id, username = username)
+    }
+}

--- a/src/test/kotlin/org/machikoro/server/controller/AuthControllerTests.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/AuthControllerTests.kt
@@ -1,0 +1,53 @@
+package org.machikoro.server.controller
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.machikoro.server.dto.RegisterRequest
+import org.machikoro.server.dto.RegisterResponse
+import org.machikoro.server.exception.DuplicateUserException
+import org.machikoro.server.service.AuthService
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+
+class AuthControllerTests {
+
+    private val authService = mock<AuthService>()
+    private val controller = AuthController(authService)
+
+    @Test
+    fun `register returns ok with response body when service succeeds`() {
+        val request = RegisterRequest(username = "alice", password = "hunter2")
+        val expected = RegisterResponse(id = 42, username = "alice")
+        whenever(authService.register("alice", "hunter2")).thenReturn(expected)
+
+        val response = controller.register(request)
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals(expected, response.body)
+    }
+
+    @Test
+    fun `register returns bad request when username already taken`() {
+        val request = RegisterRequest(username = "alice", password = "hunter2")
+        whenever(authService.register("alice", "hunter2"))
+            .thenThrow(DuplicateUserException("Username 'alice' is already taken"))
+
+        val response = controller.register(request)
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertEquals("Username 'alice' is already taken", response.body)
+    }
+
+    @Test
+    fun `register returns bad request on validation failure`() {
+        val request = RegisterRequest(username = "", password = "hunter2")
+        whenever(authService.register("", "hunter2"))
+            .thenThrow(IllegalArgumentException("Username must not be blank"))
+
+        val response = controller.register(request)
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertEquals("Username must not be blank", response.body)
+    }
+}

--- a/src/test/kotlin/org/machikoro/server/service/AuthServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/AuthServiceTest.kt
@@ -1,0 +1,93 @@
+package org.machikoro.server.service
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.machikoro.server.dao.UserDao
+import org.machikoro.server.domain.models.UserModel
+import org.machikoro.server.exception.DuplicateUserException
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.security.crypto.password.PasswordEncoder
+
+class AuthServiceTest {
+
+    private val userDao = mock<UserDao>()
+    private val passwordEncoder = mock<PasswordEncoder>()
+
+    private val service = AuthService(userDao, passwordEncoder)
+
+    @Test
+    fun `register persists user with hashed password and returns id and username`() {
+        val username = "alice"
+        val rawPassword = "hunter2"
+        val hash = "\$2a\$10\$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy"
+        whenever(userDao.findByUsername(username)).thenReturn(null)
+        whenever(passwordEncoder.encode(rawPassword)).thenReturn(hash)
+        whenever(userDao.create(username, hash)).thenReturn(42)
+
+        val response = service.register(username, rawPassword)
+
+        assertEquals(42, response.id)
+        assertEquals(username, response.username)
+        verify(passwordEncoder).encode(rawPassword)
+        verify(userDao).create(username, hash)
+    }
+
+    @Test
+    fun `register throws DuplicateUserException when username already exists`() {
+        val username = "alice"
+        val existing = UserModel(
+            id = 1,
+            username = username,
+            passwordHash = null,
+            sessionToken = null,
+            totalWins = 0,
+            totalGamesPlayed = 0,
+        )
+        whenever(userDao.findByUsername(username)).thenReturn(existing)
+
+        assertThrows<DuplicateUserException> {
+            service.register(username, "hunter2")
+        }
+
+        verify(passwordEncoder, never()).encode(any())
+        verify(userDao, never()).create(eq(username), any())
+    }
+
+    @Test
+    fun `register rejects blank username`() {
+        assertThrows<IllegalArgumentException> {
+            service.register("   ", "hunter2")
+        }
+
+        verify(userDao, never()).findByUsername(any())
+        verify(userDao, never()).create(any(), any())
+    }
+
+    @Test
+    fun `register rejects blank password`() {
+        assertThrows<IllegalArgumentException> {
+            service.register("alice", "")
+        }
+
+        verify(userDao, never()).findByUsername(any())
+        verify(userDao, never()).create(any(), any())
+    }
+
+    @Test
+    fun `register rejects username longer than 50 characters`() {
+        val tooLong = "a".repeat(51)
+
+        assertThrows<IllegalArgumentException> {
+            service.register(tooLong, "hunter2")
+        }
+
+        verify(userDao, never()).findByUsername(any())
+        verify(userDao, never()).create(any(), any())
+    }
+}

--- a/src/test/kotlin/org/machikoro/server/service/AuthServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/AuthServiceTest.kt
@@ -7,7 +7,6 @@ import org.machikoro.server.dao.UserDao
 import org.machikoro.server.domain.models.UserModel
 import org.machikoro.server.exception.DuplicateUserException
 import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -56,7 +55,34 @@ class AuthServiceTest {
         }
 
         verify(passwordEncoder, never()).encode(any())
-        verify(userDao, never()).create(eq(username), any())
+        verify(userDao, never()).create(any(), any())
+    }
+
+    @Test
+    fun `register trims surrounding whitespace and lower-cases the username`() {
+        val rawPassword = "hunter2"
+        val hash = "\$2a\$10\$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy"
+        whenever(userDao.findByUsername("alice")).thenReturn(null)
+        whenever(passwordEncoder.encode(rawPassword)).thenReturn(hash)
+        whenever(userDao.create("alice", hash)).thenReturn(7)
+
+        val response = service.register("  Alice  ", rawPassword)
+
+        assertEquals("alice", response.username)
+        verify(userDao).findByUsername("alice")
+        verify(userDao).create("alice", hash)
+    }
+
+    @Test
+    fun `register rejects passwords longer than 72 characters`() {
+        val tooLong = "x".repeat(73)
+
+        assertThrows<IllegalArgumentException> {
+            service.register("alice", tooLong)
+        }
+
+        verify(userDao, never()).findByUsername(any())
+        verify(userDao, never()).create(any(), any())
     }
 
     @Test


### PR DESCRIPTION
Closes #162. Builds on #161; unblocks #158 (login).

## Summary
- New `AuthController` with `POST /auth/register` taking `{username, password}` and returning `{id, username}` on success. Mounted at `/auth/register` (no `/api` prefix, consistent with `/lobby`).
- New `AuthService.register` runs `findByUsername` + `create` inside `@Transactional` so a duplicate inserted between the two calls rolls back rather than leaks through. Hashes the raw password via the `BCryptPasswordEncoder` bean introduced in #161.
- New `DuplicateUserException`, `RegisterRequest`, `RegisterResponse` DTOs. `RegisterResponse` deliberately omits `passwordHash` / `sessionToken` / stat counters so the response can't grow new fields by accident — same defensive reasoning that produced `@field:JsonIgnore` on `UserModel.passwordHash` in #161.
- `SecurityConfig` permits `/auth/**` and adds it to the CSRF ignore list. `/auth/**` (not `/auth/register`) is forward-compatible so #158 can add login/logout without touching this file.

## Validation contract
- Username is **trimmed and lower-cased** before validation, dedup, and persistence — `"Alice"`, `"alice"`, and `"  alice  "` all map to the same account. Stops two visually-identical accounts from co-existing because the DB unique index is byte-for-byte.
- Username must be non-blank and ≤ 50 characters (matches the column width).
- Password must be non-blank and ≤ 72 characters. The 72-cap is BCrypt's silent-truncation point — we reject up front for a clear error rather than letting a long password "work" with only the first 72 bytes mattering.
- Password is **not** trimmed; surrounding whitespace stays significant.

## Out of scope
- Login / logout / token issuance — #158.
- Password strength rules, lockouts, rate limiting, account recovery — file follow-ups if wanted.
- Client-side UI — Client repo issue once #162 and #158 are stable.
- Replacing the controller's `catch (e: Exception)` blanket with a `@ControllerAdvice` — same pattern as `LobbyController`; worth a separate cross-cutting issue.

## Test plan
- [x] `./gradlew clean compileKotlin compileTestKotlin` — clean, no warnings.
- [x] `AuthServiceTest` — 7 unit tests pass: happy path, duplicate, blank username, blank password, oversized username, trim+lowercase normalization, oversized password.
- [x] `AuthControllerTests` — 3 unit tests pass: success, duplicate response, validation-failure response.
- [x] `SecurityConfigTests` — still passes after the broadened CSRF ignore list and new permit rule.
- [x] Full `./gradlew test` — same 18 testcontainer-dependent failures as `main`, no new ones.
- [x] **Manual end-to-end:** registered users via Swagger UI against the `compose-dev.yaml` Postgres, verified rows in pgAdmin with BCrypt-shaped `password_hash` populated. Confirmed:
  - 200 + `{id, username}` on happy path.
  - 400 + `Username '<x>' is already taken` on duplicate.
  - 400 + `Username must not be blank` on empty username.
  - 400 + `Password must be at most 72 characters` on a 73-char password.
  - `"  Alice  "` registers as `alice`.
  - WARN log on failure shows `username + reason`, INFO log on success — no password ever logged.
- [ ] Reviewer to spot-check the new `Authentication` tag in Swagger UI.

## Heads-up for reviewers
This PR widens CSRF for `/auth/**`. That's a deliberate call so non-browser clients (Android, curl, Postman) can register without a session-bound CSRF token. Documented in the KDoc on `securityFilterChain`. If you'd rather keep CSRF strict, the alternative is requiring clients to fetch a token first — happy to revisit.

## Heads-up for whoever pulls this branch locally
`SchemaUtils.create` (chosen in #161) does not add missing columns to existing tables, so a long-lived dev volume with a pre-#161 `users` table needs either `docker compose down -v` or a one-shot `ALTER TABLE users ADD COLUMN password_hash VARCHAR(60)`. CI testcontainers always start fresh so they're unaffected.