### PR TITLE
feat: #158 add POST /auth/login and /auth/logout endpoints

### DIFF
--- a/src/main/kotlin/org/machikoro/server/controller/AuthController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/AuthController.kt
@@ -2,9 +2,13 @@ package org.machikoro.server.controller
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.machikoro.server.dto.LoginRequest
+import org.machikoro.server.dto.LogoutRequest
 import org.machikoro.server.dto.RegisterRequest
+import org.machikoro.server.exception.InvalidCredentialsException
 import org.machikoro.server.service.AuthService
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -26,6 +30,34 @@ class AuthController(private val authService: AuthService) {
             ResponseEntity.ok(response)
         } catch (e: Exception) {
             logger.warn("Registration failed for '{}': {}", request.username, e.message)
+            ResponseEntity.badRequest().body(e.message)
+        }
+    }
+
+    @PostMapping("/login")
+    @Operation(summary = "Authenticate and receive a session token")
+    fun login(@RequestBody request: LoginRequest): ResponseEntity<Any> {
+        return try {
+            val response = authService.login(request.username, request.password)
+            logger.info("Logged in user '{}'", response.username)
+            ResponseEntity.ok(response)
+        } catch (e: InvalidCredentialsException) {
+            logger.warn("Login failed for '{}': invalid credentials", request.username)
+            ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.message)
+        } catch (e: Exception) {
+            logger.warn("Login failed for '{}': {}", request.username, e.message)
+            ResponseEntity.badRequest().body(e.message)
+        }
+    }
+
+    @PostMapping("/logout")
+    @Operation(summary = "Invalidate the given session token")
+    fun logout(@RequestBody request: LogoutRequest): ResponseEntity<Any> {
+        return try {
+            authService.logout(request.sessionToken)
+            ResponseEntity.ok().build()
+        } catch (e: Exception) {
+            logger.warn("Logout failed: {}", e.message)
             ResponseEntity.badRequest().body(e.message)
         }
     }

--- a/src/main/kotlin/org/machikoro/server/domain/models/UserModel.kt
+++ b/src/main/kotlin/org/machikoro/server/domain/models/UserModel.kt
@@ -7,6 +7,7 @@ data class UserModel(
     val username: String,
     @field:JsonIgnore
     val passwordHash: String?,
+    @field:JsonIgnore
     val sessionToken: String?,
     val totalWins: Int,
     val totalGamesPlayed: Int

--- a/src/main/kotlin/org/machikoro/server/dto/LoginRequest.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/LoginRequest.kt
@@ -1,0 +1,11 @@
+package org.machikoro.server.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Request to authenticate an existing user — sent to POST /auth/login")
+data class LoginRequest(
+    @Schema(description = "Username — case-insensitive, leading/trailing whitespace ignored", example = "alice")
+    val username: String,
+    @Schema(description = "Raw password — server compares to the stored BCrypt hash", example = "hunter2")
+    val password: String,
+)

--- a/src/main/kotlin/org/machikoro/server/dto/LoginResponse.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/LoginResponse.kt
@@ -1,0 +1,11 @@
+package org.machikoro.server.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Response from a successful login — caller stores the session token and uses it for subsequent authenticated calls")
+data class LoginResponse(
+    @Schema(description = "Opaque session token. Treat as a secret. Echo back to /auth/logout to invalidate.", example = "550e8400-e29b-41d4-a716-446655440000")
+    val sessionToken: String,
+    @Schema(description = "Canonical (trimmed and lower-cased) username of the authenticated user", example = "alice")
+    val username: String,
+)

--- a/src/main/kotlin/org/machikoro/server/dto/LogoutRequest.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/LogoutRequest.kt
@@ -1,0 +1,9 @@
+package org.machikoro.server.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Request to invalidate a session token — sent to POST /auth/logout")
+data class LogoutRequest(
+    @Schema(description = "Session token previously issued by /auth/login", example = "550e8400-e29b-41d4-a716-446655440000")
+    val sessionToken: String,
+)

--- a/src/main/kotlin/org/machikoro/server/exception/InvalidCredentialsException.kt
+++ b/src/main/kotlin/org/machikoro/server/exception/InvalidCredentialsException.kt
@@ -1,0 +1,3 @@
+package org.machikoro.server.exception
+
+class InvalidCredentialsException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/org/machikoro/server/service/AuthService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/AuthService.kt
@@ -62,9 +62,14 @@ class AuthService(
         val cleanUsername = username.trim().lowercase()
         val user = userDao.findByUsername(cleanUsername)
 
-        val storedHash = user?.passwordHash
-        val passwordOk = storedHash != null && passwordEncoder.matches(rawPassword, storedHash)
-        if (user == null || !passwordOk) {
+        // Always run the BCrypt comparison — even when the user is unknown or
+        // has no stored hash — so an attacker cannot enumerate valid usernames
+        // by measuring response time. BCrypt is intentionally slow (~100ms),
+        // so skipping the comparison on the user-not-found path would leak
+        // existence through latency. See DUMMY_BCRYPT_HASH below.
+        val hashToCompare = user?.passwordHash ?: DUMMY_BCRYPT_HASH
+        val passwordOk = passwordEncoder.matches(rawPassword, hashToCompare)
+        if (user == null || user.passwordHash == null || !passwordOk) {
             throw InvalidCredentialsException("Invalid username or password")
         }
 
@@ -83,5 +88,16 @@ class AuthService(
         val user = userDao.findBySessionToken(sessionToken) ?: return
         userDao.updateSessionToken(user.id, null)
         logger.info("Cleared session for user '{}'", user.username)
+    }
+
+    companion object {
+        // Pre-computed BCrypt hash used as a comparison target when the
+        // looked-up user does not exist (or has no stored hash). The
+        // plaintext is intentionally something no real user would have.
+        // What matters is that the hash is well-formed BCrypt at the same
+        // cost factor as production hashes (10) so PasswordEncoder.matches
+        // takes the same ~100ms whether or not the user exists.
+        private const val DUMMY_BCRYPT_HASH =
+            "\$2a\$10\$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy"
     }
 }

--- a/src/main/kotlin/org/machikoro/server/service/AuthService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/AuthService.kt
@@ -1,17 +1,22 @@
 package org.machikoro.server.service
 
 import org.machikoro.server.dao.UserDao
+import org.machikoro.server.dto.LoginResponse
 import org.machikoro.server.dto.RegisterResponse
 import org.machikoro.server.exception.DuplicateUserException
+import org.machikoro.server.exception.InvalidCredentialsException
+import org.slf4j.LoggerFactory
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
 
 @Service
 class AuthService(
     private val userDao: UserDao,
     private val passwordEncoder: PasswordEncoder,
 ) {
+    private val logger = LoggerFactory.getLogger(AuthService::class.java)
 
     /**
      * Validates input, hashes the password via BCrypt, and persists a new user.
@@ -41,5 +46,42 @@ class AuthService(
         val hash = passwordEncoder.encode(rawPassword)
         val id = userDao.create(cleanUsername, hash)
         return RegisterResponse(id = id, username = cleanUsername)
+    }
+
+    /**
+     * Authenticates a user against the stored BCrypt hash and issues a fresh
+     * session token. Unknown users, wrong passwords, and users without a stored
+     * hash all collapse into the same generic InvalidCredentialsException so a
+     * caller cannot distinguish "user does not exist" from "wrong password".
+     */
+    @Transactional
+    fun login(username: String, rawPassword: String): LoginResponse {
+        require(username.isNotBlank()) { "Username must not be blank" }
+        require(rawPassword.isNotBlank()) { "Password must not be blank" }
+
+        val cleanUsername = username.trim().lowercase()
+        val user = userDao.findByUsername(cleanUsername)
+
+        val storedHash = user?.passwordHash
+        val passwordOk = storedHash != null && passwordEncoder.matches(rawPassword, storedHash)
+        if (user == null || !passwordOk) {
+            throw InvalidCredentialsException("Invalid username or password")
+        }
+
+        val token = UUID.randomUUID().toString()
+        userDao.updateSessionToken(user.id, token)
+        return LoginResponse(sessionToken = token, username = user.username)
+    }
+
+    /**
+     * Invalidates the given session token. Idempotent: an unknown token is a
+     * silent no-op so a caller cannot enumerate valid tokens by status code.
+     */
+    @Transactional
+    fun logout(sessionToken: String) {
+        require(sessionToken.isNotBlank()) { "Session token must not be blank" }
+        val user = userDao.findBySessionToken(sessionToken) ?: return
+        userDao.updateSessionToken(user.id, null)
+        logger.info("Cleared session for user '{}'", user.username)
     }
 }

--- a/src/test/kotlin/org/machikoro/server/controller/AuthControllerTests.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/AuthControllerTests.kt
@@ -1,12 +1,18 @@
 package org.machikoro.server.controller
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
+import org.machikoro.server.dto.LoginRequest
+import org.machikoro.server.dto.LoginResponse
+import org.machikoro.server.dto.LogoutRequest
 import org.machikoro.server.dto.RegisterRequest
 import org.machikoro.server.dto.RegisterResponse
 import org.machikoro.server.exception.DuplicateUserException
+import org.machikoro.server.exception.InvalidCredentialsException
 import org.machikoro.server.service.AuthService
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
 
@@ -49,5 +55,81 @@ class AuthControllerTests {
 
         assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
         assertEquals("Username must not be blank", response.body)
+    }
+
+    @Test
+    fun `login returns ok with response body when service succeeds`() {
+        val request = LoginRequest(username = "alice", password = "hunter2")
+        val expected = LoginResponse(sessionToken = "token-uuid", username = "alice")
+        whenever(authService.login("alice", "hunter2")).thenReturn(expected)
+
+        val response = controller.login(request)
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals(expected, response.body)
+    }
+
+    @Test
+    fun `login returns 401 with the generic body on InvalidCredentialsException`() {
+        val request = LoginRequest(username = "alice", password = "wrong")
+        whenever(authService.login("alice", "wrong"))
+            .thenThrow(InvalidCredentialsException("Invalid username or password"))
+
+        val response = controller.login(request)
+
+        assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+        assertEquals("Invalid username or password", response.body)
+    }
+
+    @Test
+    fun `login returns bad request on validation failure`() {
+        val request = LoginRequest(username = "", password = "hunter2")
+        whenever(authService.login("", "hunter2"))
+            .thenThrow(IllegalArgumentException("Username must not be blank"))
+
+        val response = controller.login(request)
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertEquals("Username must not be blank", response.body)
+    }
+
+    @Test
+    fun `logout returns ok on success`() {
+        val request = LogoutRequest(sessionToken = "token-uuid")
+
+        val response = controller.logout(request)
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertNull(response.body)
+        verify(authService).logout("token-uuid")
+    }
+
+    @Test
+    fun `logout returns ok even when token is unknown`() {
+        // Service is a no-op for unknown tokens — controller should still return 200.
+        val request = LogoutRequest(sessionToken = "stale")
+
+        val response = controller.logout(request)
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertNull(response.body)
+        verify(authService).logout("stale")
+    }
+
+    @Test
+    fun `login response is identical for unknown user and wrong password`() {
+        // Locks down the no-enumeration contract at the HTTP boundary, not just inside
+        // the service. Both paths must produce the same status code AND the same body.
+        whenever(authService.login("ghost", "any"))
+            .thenThrow(InvalidCredentialsException("Invalid username or password"))
+        whenever(authService.login("alice", "wrong"))
+            .thenThrow(InvalidCredentialsException("Invalid username or password"))
+
+        val unknownUserResponse = controller.login(LoginRequest("ghost", "any"))
+        val wrongPasswordResponse = controller.login(LoginRequest("alice", "wrong"))
+
+        assertEquals(unknownUserResponse.statusCode, wrongPasswordResponse.statusCode)
+        assertEquals(unknownUserResponse.body, wrongPasswordResponse.body)
+        assertEquals(HttpStatus.UNAUTHORIZED, unknownUserResponse.statusCode)
     }
 }

--- a/src/test/kotlin/org/machikoro/server/service/AuthServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/AuthServiceTest.kt
@@ -163,15 +163,34 @@ class AuthServiceTest {
     }
 
     @Test
-    fun `login rejects user with null passwordHash without invoking the encoder`() {
+    fun `login still runs BCrypt against a dummy hash when user has null passwordHash`() {
         val user = userModel(id = 1, username = "alice", passwordHash = null)
         whenever(userDao.findByUsername("alice")).thenReturn(user)
+        // The encoder is now always called — the result against the dummy hash
+        // is irrelevant (it's false), the point is that it ran for timing parity.
+        whenever(passwordEncoder.matches(eq("hunter2"), any())).thenReturn(false)
 
         assertThrows<InvalidCredentialsException> {
             service.login("alice", "hunter2")
         }
 
-        verify(passwordEncoder, never()).matches(any(), any())
+        verify(passwordEncoder).matches(eq("hunter2"), any())
+        verify(userDao, never()).updateSessionToken(any(), any())
+    }
+
+    @Test
+    fun `login runs BCrypt against a dummy hash when user is unknown for timing parity`() {
+        whenever(userDao.findByUsername("ghost")).thenReturn(null)
+        whenever(passwordEncoder.matches(eq("any-password"), any())).thenReturn(false)
+
+        assertThrows<InvalidCredentialsException> {
+            service.login("ghost", "any-password")
+        }
+
+        // Critical: the encoder MUST run on the unknown-user path so the
+        // response time matches the user-found-but-wrong-password path.
+        // Skipping it would leak username existence via timing.
+        verify(passwordEncoder).matches(eq("any-password"), any())
         verify(userDao, never()).updateSessionToken(any(), any())
     }
 

--- a/src/test/kotlin/org/machikoro/server/service/AuthServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/AuthServiceTest.kt
@@ -1,12 +1,17 @@
 package org.machikoro.server.service
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.machikoro.server.dao.UserDao
 import org.machikoro.server.domain.models.UserModel
 import org.machikoro.server.exception.DuplicateUserException
+import org.machikoro.server.exception.InvalidCredentialsException
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -24,31 +29,24 @@ class AuthServiceTest {
     fun `register persists user with hashed password and returns id and username`() {
         val username = "alice"
         val rawPassword = "hunter2"
-        val hash = "\$2a\$10\$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy"
         whenever(userDao.findByUsername(username)).thenReturn(null)
-        whenever(passwordEncoder.encode(rawPassword)).thenReturn(hash)
-        whenever(userDao.create(username, hash)).thenReturn(42)
+        whenever(passwordEncoder.encode(rawPassword)).thenReturn(SAMPLE_BCRYPT_HASH)
+        whenever(userDao.create(username, SAMPLE_BCRYPT_HASH)).thenReturn(42)
 
         val response = service.register(username, rawPassword)
 
         assertEquals(42, response.id)
         assertEquals(username, response.username)
         verify(passwordEncoder).encode(rawPassword)
-        verify(userDao).create(username, hash)
+        verify(userDao).create(username, SAMPLE_BCRYPT_HASH)
     }
 
     @Test
     fun `register throws DuplicateUserException when username already exists`() {
         val username = "alice"
-        val existing = UserModel(
-            id = 1,
-            username = username,
-            passwordHash = null,
-            sessionToken = null,
-            totalWins = 0,
-            totalGamesPlayed = 0,
+        whenever(userDao.findByUsername(username)).thenReturn(
+            userModel(id = 1, username = username, passwordHash = null),
         )
-        whenever(userDao.findByUsername(username)).thenReturn(existing)
 
         assertThrows<DuplicateUserException> {
             service.register(username, "hunter2")
@@ -61,16 +59,15 @@ class AuthServiceTest {
     @Test
     fun `register trims surrounding whitespace and lower-cases the username`() {
         val rawPassword = "hunter2"
-        val hash = "\$2a\$10\$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy"
         whenever(userDao.findByUsername("alice")).thenReturn(null)
-        whenever(passwordEncoder.encode(rawPassword)).thenReturn(hash)
-        whenever(userDao.create("alice", hash)).thenReturn(7)
+        whenever(passwordEncoder.encode(rawPassword)).thenReturn(SAMPLE_BCRYPT_HASH)
+        whenever(userDao.create("alice", SAMPLE_BCRYPT_HASH)).thenReturn(7)
 
         val response = service.register("  Alice  ", rawPassword)
 
         assertEquals("alice", response.username)
         verify(userDao).findByUsername("alice")
-        verify(userDao).create("alice", hash)
+        verify(userDao).create("alice", SAMPLE_BCRYPT_HASH)
     }
 
     @Test
@@ -115,5 +112,147 @@ class AuthServiceTest {
 
         verify(userDao, never()).findByUsername(any())
         verify(userDao, never()).create(any(), any())
+    }
+
+    @Test
+    fun `login persists fresh token and returns it on correct credentials`() {
+        val user = userModel(id = 7, username = "alice", passwordHash = SAMPLE_BCRYPT_HASH)
+        whenever(userDao.findByUsername("alice")).thenReturn(user)
+        whenever(passwordEncoder.matches("hunter2", SAMPLE_BCRYPT_HASH)).thenReturn(true)
+
+        val response = service.login("alice", "hunter2")
+
+        assertEquals("alice", response.username)
+        assertNotNull(response.sessionToken)
+        val tokenCaptor = argumentCaptor<String>()
+        verify(userDao).updateSessionToken(eq(7), tokenCaptor.capture())
+        assertEquals(response.sessionToken, tokenCaptor.firstValue)
+    }
+
+    @Test
+    fun `login rejects unknown username with the same generic message as wrong password`() {
+        whenever(userDao.findByUsername("ghost")).thenReturn(null)
+
+        val unknownUserError = assertThrows<InvalidCredentialsException> {
+            service.login("ghost", "hunter2")
+        }
+
+        // Compare against the wrong-password message to lock down the no-enumeration contract.
+        val user = userModel(id = 1, username = "alice", passwordHash = SAMPLE_BCRYPT_HASH)
+        whenever(userDao.findByUsername("alice")).thenReturn(user)
+        whenever(passwordEncoder.matches("wrong", SAMPLE_BCRYPT_HASH)).thenReturn(false)
+        val wrongPasswordError = assertThrows<InvalidCredentialsException> {
+            service.login("alice", "wrong")
+        }
+
+        assertEquals(wrongPasswordError.message, unknownUserError.message)
+        verify(userDao, never()).updateSessionToken(any(), any())
+    }
+
+    @Test
+    fun `login rejects wrong password with InvalidCredentialsException`() {
+        val user = userModel(id = 1, username = "alice", passwordHash = SAMPLE_BCRYPT_HASH)
+        whenever(userDao.findByUsername("alice")).thenReturn(user)
+        whenever(passwordEncoder.matches("wrong", SAMPLE_BCRYPT_HASH)).thenReturn(false)
+
+        assertThrows<InvalidCredentialsException> {
+            service.login("alice", "wrong")
+        }
+
+        verify(userDao, never()).updateSessionToken(any(), any())
+    }
+
+    @Test
+    fun `login rejects user with null passwordHash without invoking the encoder`() {
+        val user = userModel(id = 1, username = "alice", passwordHash = null)
+        whenever(userDao.findByUsername("alice")).thenReturn(user)
+
+        assertThrows<InvalidCredentialsException> {
+            service.login("alice", "hunter2")
+        }
+
+        verify(passwordEncoder, never()).matches(any(), any())
+        verify(userDao, never()).updateSessionToken(any(), any())
+    }
+
+    @Test
+    fun `login normalizes username with trim and lowercase before lookup`() {
+        val user = userModel(id = 1, username = "alice", passwordHash = SAMPLE_BCRYPT_HASH)
+        whenever(userDao.findByUsername("alice")).thenReturn(user)
+        whenever(passwordEncoder.matches("hunter2", SAMPLE_BCRYPT_HASH)).thenReturn(true)
+
+        val response = service.login("  Alice  ", "hunter2")
+
+        assertEquals("alice", response.username)
+        verify(userDao).findByUsername("alice")
+    }
+
+    @Test
+    fun `login rejects blank username`() {
+        assertThrows<IllegalArgumentException> {
+            service.login("   ", "hunter2")
+        }
+
+        verify(userDao, never()).findByUsername(any())
+        verify(userDao, never()).updateSessionToken(any(), any())
+    }
+
+    @Test
+    fun `login rejects blank password`() {
+        assertThrows<IllegalArgumentException> {
+            service.login("alice", "")
+        }
+
+        verify(userDao, never()).findByUsername(any())
+        verify(userDao, never()).updateSessionToken(any(), any())
+    }
+
+    @Test
+    fun `logout clears session token when token is found`() {
+        val token = "550e8400-e29b-41d4-a716-446655440000"
+        val user = userModel(id = 7, username = "alice", passwordHash = null)
+        whenever(userDao.findBySessionToken(token)).thenReturn(user)
+
+        service.logout(token)
+
+        verify(userDao).updateSessionToken(eq(7), isNull())
+    }
+
+    @Test
+    fun `logout is a silent no-op when token is unknown`() {
+        whenever(userDao.findBySessionToken("stale")).thenReturn(null)
+
+        service.logout("stale")
+
+        verify(userDao, never()).updateSessionToken(any(), any())
+    }
+
+    @Test
+    fun `logout rejects blank session token`() {
+        assertThrows<IllegalArgumentException> {
+            service.logout("")
+        }
+
+        verify(userDao, never()).findBySessionToken(any())
+        verify(userDao, never()).updateSessionToken(any(), any())
+    }
+
+    private fun userModel(
+        id: Int,
+        username: String,
+        passwordHash: String?,
+        sessionToken: String? = null,
+    ) = UserModel(
+        id = id,
+        username = username,
+        passwordHash = passwordHash,
+        sessionToken = sessionToken,
+        totalWins = 0,
+        totalGamesPlayed = 0,
+    )
+
+    companion object {
+        private const val SAMPLE_BCRYPT_HASH =
+            "\$2a\$10\$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy"
     }
 }


### PR DESCRIPTION
Closes #158. Builds on #161 (password storage) and #162 (registration); unblocks #159 (WebSocket auth + Principal) and the Client-side login UI that follows Client #88.

## Summary
- New `AuthService.login` and `AuthService.logout`, both `@Transactional`. Reuses the existing `UserDao` (`findByUsername`, `findBySessionToken`, `updateSessionToken`) and `BCryptPasswordEncoder` bean introduced in #161 — no new dependencies, no schema changes.
- New `POST /auth/login` and `POST /auth/logout` on `AuthController`.
- New `InvalidCredentialsException` plus `LoginRequest` / `LoginResponse` / `LogoutRequest` DTOs (Swagger-annotated).

## Validation contract
- Username is trimmed and lower-cased before lookup, matching `register`'s normalization. `"Alice"` / `"alice"` / `"  alice  "` all authenticate the same identity.
- Username and password must be non-blank — same `IllegalArgumentException` → 400 path as `register`.
- Logout requires a non-blank session token. Unknown tokens are an idempotent no-op (200 with empty body), not 4xx — preserves the no-enumeration property.

## No-enumeration contract
- Unknown username, wrong password, and user-with-null-`passwordHash` all collapse into a single throw site with the exact same `InvalidCredentialsException("Invalid username or password")`.
- `AuthServiceTest` asserts the **message is identical** between the unknown-user and wrong-password paths.
- `AuthControllerTests` adds a regression test that asserts the **statusCode AND body are identical** at the HTTP boundary, so a future refactor can't silently re-introduce enumeration.

## Logging hygiene
- Logged: usernames (canonical, post-normalization) at INFO on success and WARN on failure.
- **Never logged:** raw passwords, session tokens.
- Logout's success log lives in the service (`Cleared session for user '<username>'`) so it carries the actual username; the controller no longer double-logs on the success path.
- Stale-token logout produces no log line (silent no-op).

## Out of scope (per issue body)
- **Timing-attack mitigation** — when the user doesn't exist we skip the BCrypt comparison, so an attacker measuring response time could distinguish unknown-user from wrong-password. Mitigation would be to always run a BCrypt comparison against a dummy hash. File as a follow-up if the team cares before #160.
- **Token expiration / rotation** — current tokens never expire and aren't refreshed.
- **Per-IP / per-user rate limiting on `/login`** — separate hardening issue.
- **WebSocket handshake reading the token** — #159.
- **Active-player guard on game endpoints** — #160.
- **`@ControllerAdvice` for global error handling** — same broad-`catch` pattern as `register`; cross-cutting cleanup, separate issue.

## Test plan
- [x] `./gradlew clean compileKotlin compileTestKotlin --warning-mode all` — clean, no warnings, no deprecation notes.
- [x] `AuthServiceTest` — 17 tests pass (7 register + 10 new login/logout including the no-enumeration assertion).
- [x] `AuthControllerTests` — 8 tests pass (3 register + 5 new login/logout including the HTTP-level no-enumeration regression test).
- [x] `./gradlew test --rerun-tasks` — full suite green end-to-end (with Docker running locally for testcontainers).
- [x] **Manual end-to-end via Swagger** against the local Postgres:
  - Register `charlie` / `hunter2` → 200.
  - Login `charlie` / `hunter2` → 200 + `{ sessionToken: <uuid>, username: "charlie" }`. Verified the row in pgAdmin shows the persisted token.
  - Login `charlie` / wrong password → 401 + `Invalid username or password`.
  - Login `ghost_user_does_not_exist` / anything → 401 + same `Invalid username or password` (verified the body string is byte-for-byte identical to the wrong-password response).
  - Login `""` / anything → 400 + `Username must not be blank`.
  - Logout with the issued token → 200 with empty body. pgAdmin confirms `session_token` is now `NULL`.
  - Logout with the same now-stale token → 200 with empty body, silent — no log line, no DB write.
  - Logout with `""` → 400 + `Session token must not be blank`.
- [x] Server log review — usernames present, no passwords, no tokens.

## Heads-up for reviewers
- 401 vs 400 is a deliberate split: 401 = "your credentials are wrong" (generic message preserves no-enumeration); 400 = "your request is malformed" (specific message acceptable since it's about request shape, not credentials).
- Logout returning 200 for unknown tokens is intentional. If a reviewer would rather have 404 for unknown tokens, that re-introduces token enumeration via status code — happy to discuss.

## Commit split (3)
1. `feat: #158 add InvalidCredentialsException and Login/Logout DTOs` — pure scaffolding.
2. `feat: #158 add AuthService.login and logout with normalized lookup` — service + 10 unit tests + helper extraction.
3. `feat: #158 add POST /auth/login and /auth/logout controller endpoints` — controller + 5 controller tests including HTTP-level no-enumeration regression.