### PR TITLE
Feature/session recovery logic

### DIFF
--- a/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
@@ -29,6 +29,7 @@ class LobbyWebSocketController(
      */
     @MessageMapping("/lobby.create")
     @SendTo("/topic/public")
+    @Suppress("UNUSED_PARAMETER") // Spring requires a @Payload parameter to deserialize the STOMP frame body
     fun createLobby(
         @Payload message: WebSocketMessage,
         headerAccessor: SimpMessageHeaderAccessor,

--- a/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
@@ -1,6 +1,6 @@
 package org.machikoro.server.controller
 
-import org.machikoro.server.dao.UserDao
+import org.machikoro.server.auth.UserPrincipal
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.WebSocketMessage
 import org.machikoro.server.service.LobbyService
@@ -8,12 +8,12 @@ import org.slf4j.LoggerFactory
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.messaging.handler.annotation.SendTo
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.stereotype.Controller
 
 @Controller
 class LobbyWebSocketController(
     private val lobbyService: LobbyService,
-    private val userDao: UserDao
 ) {
     private val logger = LoggerFactory.getLogger(LobbyWebSocketController::class.java)
 
@@ -22,16 +22,23 @@ class LobbyWebSocketController(
      *
      * Client sends a message to /app/lobby.create.
      * Server creates a new lobby and broadcasts the created lobby data to /topic/public.
+     *
+     * Identity is read from the [UserPrincipal] that [org.machikoro.server.auth.StompAuthChannelInterceptor]
+     * attaches at CONNECT time — [WebSocketMessage.sender] is ignored to prevent
+     * username spoofing.
      */
     @MessageMapping("/lobby.create")
     @SendTo("/topic/public")
-    fun createLobby(@Payload message: WebSocketMessage): WebSocketMessage {
-        logger.info("User ${message.sender} requested lobby creation")
+    fun createLobby(
+        @Payload message: WebSocketMessage,
+        headerAccessor: SimpMessageHeaderAccessor,
+    ): WebSocketMessage {
+        val principal = headerAccessor.user as? UserPrincipal
+            ?: throw RuntimeException("Authenticated principal not found — connection may not have completed STOMP handshake")
 
-        val user = userDao.findByUsername(message.sender)
-            ?: throw RuntimeException("User ${message.sender} not found")
+        logger.info("User '{}' requested lobby creation", principal.username)
 
-        val lobby = lobbyService.createLobby(user.id)
+        val lobby = lobbyService.createLobby(principal.userId)
 
         return WebSocketMessage(
             type = MessageType.LOBBY_CREATED,

--- a/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
@@ -1,5 +1,7 @@
 package org.machikoro.server.controller
 
+import io.micrometer.core.instrument.Metrics
+import io.micrometer.core.instrument.Timer
 import org.machikoro.server.dao.UserDao
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.SyncGameRequest
@@ -16,6 +18,7 @@ import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.messaging.simp.SimpMessageType
 import org.springframework.stereotype.Controller
 import org.slf4j.LoggerFactory
+import java.util.concurrent.TimeUnit
 
 @Controller
 class WebSocketController(
@@ -26,6 +29,12 @@ class WebSocketController(
     private val messagingTemplate: SimpMessagingTemplate,
 ) {
     private val logger = LoggerFactory.getLogger(WebSocketController::class.java)
+
+    companion object {
+        private const val SYNC_SUCCESS_METRIC = "machikoro.reconnect.sync.success.total"
+        private const val SYNC_FAILURE_METRIC = "machikoro.reconnect.sync.failure.total"
+        private const val SYNC_LATENCY_METRIC = "machikoro.reconnect.sync.latency.ms"
+    }
 
     /**
      * Handle incoming chat messages and broadcast to all subscribers.
@@ -78,7 +87,12 @@ class WebSocketController(
                 val syncGameId = gameSyncService.findActiveInProgressGameId(user.id)
 
                 if (syncGameId != null && sessionId != null) {
-                    publishSync(sessionId, user.id, syncGameId)
+                    emitSyncWithTelemetry(
+                        source = "chat.addUser",
+                        sessionId = sessionId,
+                        userId = user.id,
+                        gameId = syncGameId,
+                    )
                 }
             }
         }
@@ -94,21 +108,74 @@ class WebSocketController(
         @Payload request: SyncGameRequest,
         headerAccessor: SimpMessageHeaderAccessor,
     ) {
-        val sessionId = headerAccessor.sessionId ?: return
-        val userId = connectionTracker.getUserId(sessionId) ?: return
+        val sessionId = headerAccessor.sessionId
+        if (sessionId == null) {
+            recordSyncFailure(source = "game.sync", reason = "missing_session")
+            return
+        }
+
+        val userId = connectionTracker.getUserId(sessionId)
+        if (userId == null) {
+            recordSyncFailure(source = "game.sync", reason = "unknown_session")
+            return
+        }
 
         if (request.gameId != null && !gameSyncService.isUserInGame(userId, request.gameId)) {
             logger.warn("SYNC rejected for userId={} on unrelated gameId={}", userId, request.gameId)
+            recordSyncFailure(source = "game.sync", reason = "unauthorized_game")
             return
         }
 
         val resolvedGameId = request.gameId ?: gameSyncService.findActiveInProgressGameId(userId)
         if (resolvedGameId == null || !gameSyncService.isInProgress(resolvedGameId)) {
             logger.info("SYNC skipped for userId={} - no active in-progress game", userId)
+            recordSyncFailure(source = "game.sync", reason = "no_active_game")
             return
         }
 
-        publishSync(sessionId, userId, resolvedGameId)
+        emitSyncWithTelemetry(
+            source = "game.sync",
+            sessionId = sessionId,
+            userId = userId,
+            gameId = resolvedGameId,
+        )
+    }
+
+    private fun emitSyncWithTelemetry(
+        source: String,
+        sessionId: String,
+        userId: Int,
+        gameId: Int,
+    ) {
+        val startedNs = System.nanoTime()
+        runCatching { publishSync(sessionId, userId, gameId) }
+            .onSuccess {
+                val elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedNs)
+                Metrics.counter(SYNC_SUCCESS_METRIC, "source", source).increment()
+                Timer.builder(SYNC_LATENCY_METRIC)
+                    .tag("source", source)
+                    .register(Metrics.globalRegistry)
+                    .record(elapsedMs, TimeUnit.MILLISECONDS)
+            }
+            .onFailure { ex ->
+                logger.warn(
+                    "SYNC publish failed (source={}, sessionId={}, userId={}, gameId={})",
+                    source,
+                    sessionId,
+                    userId,
+                    gameId,
+                    ex,
+                )
+                recordSyncFailure(source = source, reason = "publish_failed")
+            }
+    }
+
+    private fun recordSyncFailure(source: String, reason: String) {
+        Metrics.counter(
+            SYNC_FAILURE_METRIC,
+            "source", source,
+            "reason", reason,
+        ).increment()
     }
 
     private fun publishSync(sessionId: String, userId: Int, gameId: Int) {
@@ -127,6 +194,7 @@ class WebSocketController(
                 content = "State sync for reconnecting player",
                 payload = mapOf(
                     "targetUserId" to userId,
+                    "targetSessionId" to sessionId,
                     "state" to snapshot,
                 ),
                 gameId = gameId,

--- a/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
@@ -13,6 +13,7 @@ import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.messaging.handler.annotation.SendTo
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.messaging.simp.SimpMessageType
 import org.springframework.stereotype.Controller
 import org.slf4j.LoggerFactory
 
@@ -76,8 +77,8 @@ class WebSocketController(
 
                 val syncGameId = gameSyncService.findActiveInProgressGameId(user.id)
 
-                if (syncGameId != null) {
-                    publishSync(user.id, syncGameId)
+                if (syncGameId != null && sessionId != null) {
+                    publishSync(sessionId, user.id, syncGameId)
                 }
             }
         }
@@ -102,13 +103,19 @@ class WebSocketController(
             return
         }
 
-        publishSync(userId, resolvedGameId)
+        publishSync(sessionId, userId, resolvedGameId)
     }
 
-    private fun publishSync(userId: Int, gameId: Int) {
+    private fun publishSync(sessionId: String, userId: Int, gameId: Int) {
         val snapshot = gameSyncService.buildSnapshot(gameId)
-        messagingTemplate.convertAndSend(
-            "/topic/game/$gameId",
+        val headers = SimpMessageHeaderAccessor.create(SimpMessageType.MESSAGE).apply {
+            setSessionId(sessionId)
+            setLeaveMutable(true)
+        }.messageHeaders
+
+        messagingTemplate.convertAndSendToUser(
+            sessionId,
+            "/queue/game-sync",
             WebSocketMessage(
                 type = MessageType.SYNC,
                 sender = "server",
@@ -118,7 +125,8 @@ class WebSocketController(
                     "state" to snapshot,
                 ),
                 gameId = gameId,
-            )
+            ),
+            headers,
         )
     }
 }

--- a/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
@@ -3,6 +3,7 @@ package org.machikoro.server.controller
 import org.machikoro.server.dao.UserDao
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.WebSocketMessage
+import org.machikoro.server.exception.GameStartedException
 import org.machikoro.server.service.GameSyncService
 import org.machikoro.server.service.LobbyService
 import org.machikoro.server.service.WebSocketConnectionTracker
@@ -53,10 +54,24 @@ class WebSocketController(
         if (user != null) {
             // Prefer server-side mapping to an active game when a player reconnects.
             val mappedInProgressGameId = gameSyncService.findActiveInProgressGameId(user.id)
-            val gameIdToJoin = mappedInProgressGameId ?: message.gameId
+            var gameIdToJoin = mappedInProgressGameId ?: message.gameId
 
             if (gameIdToJoin != null) {
-                lobbyService.addUserToLobby(gameIdToJoin, user.id)
+                try {
+                    lobbyService.addUserToLobby(gameIdToJoin, user.id)
+                } catch (e: GameStartedException) {
+                    // Start transition race: game flipped while reconnect was in-flight.
+                    val remappedInProgressGameId = gameSyncService.findActiveInProgressGameId(user.id)
+                    if (remappedInProgressGameId == null) {
+                        throw e
+                    }
+                    gameIdToJoin = remappedInProgressGameId
+                }
+
+                val sessionId = headerAccessor.sessionId
+                if (sessionId != null) {
+                    connectionTracker.register(sessionId, user.id, gameIdToJoin)
+                }
 
                 val syncGameId = gameSyncService.findActiveInProgressGameId(user.id)
 
@@ -76,11 +91,6 @@ class WebSocketController(
                         )
                     )
                 }
-            }
-
-            val sessionId = headerAccessor.sessionId
-            if (sessionId != null && gameIdToJoin != null) {
-                connectionTracker.register(sessionId, user.id, gameIdToJoin)
             }
         }
         return message

--- a/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
@@ -1,13 +1,16 @@
 package org.machikoro.server.controller
 
 import org.machikoro.server.dao.UserDao
+import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.WebSocketMessage
+import org.machikoro.server.service.GameSyncService
 import org.machikoro.server.service.LobbyService
 import org.machikoro.server.service.WebSocketConnectionTracker
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.messaging.handler.annotation.SendTo
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor
+import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.stereotype.Controller
 import org.slf4j.LoggerFactory
 
@@ -16,6 +19,8 @@ class WebSocketController(
     private val lobbyService: LobbyService,
     private val userDao: UserDao,
     private val connectionTracker: WebSocketConnectionTracker,
+    private val gameSyncService: GameSyncService,
+    private val messagingTemplate: SimpMessagingTemplate,
 ) {
     private val logger = LoggerFactory.getLogger(WebSocketController::class.java)
 
@@ -43,12 +48,39 @@ class WebSocketController(
     ): WebSocketMessage {
         logger.info("User ${message.sender} joined the chat")
         headerAccessor.sessionAttributes?.put("username", message.sender)
+
         val user = userDao.findByUsername(message.sender)
-        if (user != null && message.gameId != null) {
-            lobbyService.addUserToLobby(message.gameId, user.id)
+        if (user != null) {
+            // Prefer server-side mapping to an active game when a player reconnects.
+            val mappedInProgressGameId = gameSyncService.findActiveInProgressGameId(user.id)
+            val gameIdToJoin = mappedInProgressGameId ?: message.gameId
+
+            if (gameIdToJoin != null) {
+                lobbyService.addUserToLobby(gameIdToJoin, user.id)
+
+                val syncGameId = gameSyncService.findActiveInProgressGameId(user.id)
+
+                if (syncGameId != null) {
+                    val snapshot = gameSyncService.buildSnapshot(syncGameId)
+                    messagingTemplate.convertAndSend(
+                        "/topic/game/$syncGameId",
+                        WebSocketMessage(
+                            type = MessageType.SYNC,
+                            sender = "server",
+                            content = "State sync for reconnecting player",
+                            payload = mapOf(
+                                "targetUserId" to user.id,
+                                "state" to snapshot,
+                            ),
+                            gameId = syncGameId,
+                        )
+                    )
+                }
+            }
+
             val sessionId = headerAccessor.sessionId
-            if (sessionId != null) {
-                connectionTracker.register(sessionId, user.id, message.gameId)
+            if (sessionId != null && gameIdToJoin != null) {
+                connectionTracker.register(sessionId, user.id, gameIdToJoin)
             }
         }
         return message

--- a/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
@@ -12,6 +12,7 @@ import org.machikoro.server.service.LobbyService
 import org.machikoro.server.service.WebSocketConnectionTracker
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.handler.annotation.Payload
+import org.springframework.messaging.handler.annotation.SendTo
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.messaging.simp.SimpMessageType
@@ -57,7 +58,7 @@ class WebSocketController(
      * username spoofing / state exfiltration.
      */
     @MessageMapping("/chat.addUser")
-    @org.springframework.messaging.handler.annotation.SendTo("/topic/public")
+    @SendTo("/topic/public")
     fun addUser(
         @Payload message: WebSocketMessage,
         headerAccessor: SimpMessageHeaderAccessor,

--- a/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
@@ -97,6 +97,11 @@ class WebSocketController(
         val sessionId = headerAccessor.sessionId ?: return
         val userId = connectionTracker.getUserId(sessionId) ?: return
 
+        if (request.gameId != null && !gameSyncService.isUserInGame(userId, request.gameId)) {
+            logger.warn("SYNC rejected for userId={} on unrelated gameId={}", userId, request.gameId)
+            return
+        }
+
         val resolvedGameId = request.gameId ?: gameSyncService.findActiveInProgressGameId(userId)
         if (resolvedGameId == null || !gameSyncService.isInProgress(resolvedGameId)) {
             logger.info("SYNC skipped for userId={} - no active in-progress game", userId)

--- a/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
@@ -2,6 +2,7 @@ package org.machikoro.server.controller
 
 import org.machikoro.server.dao.UserDao
 import org.machikoro.server.dto.MessageType
+import org.machikoro.server.dto.SyncGameRequest
 import org.machikoro.server.dto.WebSocketMessage
 import org.machikoro.server.exception.GameStartedException
 import org.machikoro.server.service.GameSyncService
@@ -76,23 +77,48 @@ class WebSocketController(
                 val syncGameId = gameSyncService.findActiveInProgressGameId(user.id)
 
                 if (syncGameId != null) {
-                    val snapshot = gameSyncService.buildSnapshot(syncGameId)
-                    messagingTemplate.convertAndSend(
-                        "/topic/game/$syncGameId",
-                        WebSocketMessage(
-                            type = MessageType.SYNC,
-                            sender = "server",
-                            content = "State sync for reconnecting player",
-                            payload = mapOf(
-                                "targetUserId" to user.id,
-                                "state" to snapshot,
-                            ),
-                            gameId = syncGameId,
-                        )
-                    )
+                    publishSync(user.id, syncGameId)
                 }
             }
         }
         return message
+    }
+
+    /**
+     * Explicit re-sync endpoint for clients that reconnect mid-transition and miss
+     * the GAME_STARTED broadcast.
+     */
+    @MessageMapping("/game.sync")
+    fun syncGameState(
+        @Payload request: SyncGameRequest,
+        headerAccessor: SimpMessageHeaderAccessor,
+    ) {
+        val sessionId = headerAccessor.sessionId ?: return
+        val userId = connectionTracker.getUserId(sessionId) ?: return
+
+        val resolvedGameId = request.gameId ?: gameSyncService.findActiveInProgressGameId(userId)
+        if (resolvedGameId == null || !gameSyncService.isInProgress(resolvedGameId)) {
+            logger.info("SYNC skipped for userId={} - no active in-progress game", userId)
+            return
+        }
+
+        publishSync(userId, resolvedGameId)
+    }
+
+    private fun publishSync(userId: Int, gameId: Int) {
+        val snapshot = gameSyncService.buildSnapshot(gameId)
+        messagingTemplate.convertAndSend(
+            "/topic/game/$gameId",
+            WebSocketMessage(
+                type = MessageType.SYNC,
+                sender = "server",
+                content = "State sync for reconnecting player",
+                payload = mapOf(
+                    "targetUserId" to userId,
+                    "state" to snapshot,
+                ),
+                gameId = gameId,
+            )
+        )
     }
 }

--- a/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
@@ -117,6 +117,10 @@ class WebSocketController(
     /**
      * Explicit re-sync endpoint for clients that reconnect mid-transition and miss
      * the GAME_STARTED broadcast.
+     *
+     * Identity is read from the [UserPrincipal] attached at CONNECT time —
+     * the [SyncGameRequest.gameId] field may be client-supplied but is validated
+     * against the server-side player membership before the snapshot is emitted.
      */
     @MessageMapping("/game.sync")
     fun syncGameState(
@@ -129,11 +133,16 @@ class WebSocketController(
             return
         }
 
-        val userId = connectionTracker.getUserId(sessionId)
-        if (userId == null) {
-            recordSyncFailure(source = GAME_SYNC_SOURCE, reason = "unknown_session")
+        // Resolve identity from the authenticated principal, not from the tracker,
+        // to prevent a compromised or spoofed session from claiming another user's ID.
+        val principal = headerAccessor.user as? UserPrincipal
+        if (principal == null) {
+            logger.warn("SYNC rejected: no authenticated principal on session {}", sessionId)
+            recordSyncFailure(source = GAME_SYNC_SOURCE, reason = "missing_principal")
             return
         }
+
+        val userId = principal.userId
 
         if (request.gameId != null && !gameSyncService.isUserInGame(userId, request.gameId)) {
             logger.warn("SYNC rejected for userId={} on unrelated gameId={}", userId, request.gameId)
@@ -150,6 +159,7 @@ class WebSocketController(
 
         emitSyncWithTelemetry(
             source = GAME_SYNC_SOURCE,
+            principalName = principal.name,
             sessionId = sessionId,
             userId = userId,
             gameId = resolvedGameId,
@@ -158,12 +168,13 @@ class WebSocketController(
 
     private fun emitSyncWithTelemetry(
         source: String,
+        principalName: String,
         sessionId: String,
         userId: Int,
         gameId: Int,
     ) {
         val startedNs = System.nanoTime()
-        runCatching { publishSync(sessionId, userId, gameId) }
+        runCatching { publishSync(principalName, sessionId, userId, gameId) }
             .onSuccess {
                 val elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedNs)
                 Metrics.counter(SYNC_SUCCESS_METRIC, "source", source).increment()

--- a/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
@@ -34,6 +34,7 @@ class WebSocketController(
         private const val SYNC_SUCCESS_METRIC = "machikoro.reconnect.sync.success.total"
         private const val SYNC_FAILURE_METRIC = "machikoro.reconnect.sync.failure.total"
         private const val SYNC_LATENCY_METRIC = "machikoro.reconnect.sync.latency.ms"
+        private const val GAME_SYNC_SOURCE = "game.sync"
     }
 
     /**
@@ -110,31 +111,31 @@ class WebSocketController(
     ) {
         val sessionId = headerAccessor.sessionId
         if (sessionId == null) {
-            recordSyncFailure(source = "game.sync", reason = "missing_session")
+            recordSyncFailure(source = GAME_SYNC_SOURCE, reason = "missing_session")
             return
         }
 
         val userId = connectionTracker.getUserId(sessionId)
         if (userId == null) {
-            recordSyncFailure(source = "game.sync", reason = "unknown_session")
+            recordSyncFailure(source = GAME_SYNC_SOURCE, reason = "unknown_session")
             return
         }
 
         if (request.gameId != null && !gameSyncService.isUserInGame(userId, request.gameId)) {
             logger.warn("SYNC rejected for userId={} on unrelated gameId={}", userId, request.gameId)
-            recordSyncFailure(source = "game.sync", reason = "unauthorized_game")
+            recordSyncFailure(source = GAME_SYNC_SOURCE, reason = "unauthorized_game")
             return
         }
 
         val resolvedGameId = request.gameId ?: gameSyncService.findActiveInProgressGameId(userId)
         if (resolvedGameId == null || !gameSyncService.isInProgress(resolvedGameId)) {
             logger.info("SYNC skipped for userId={} - no active in-progress game", userId)
-            recordSyncFailure(source = "game.sync", reason = "no_active_game")
+            recordSyncFailure(source = GAME_SYNC_SOURCE, reason = "no_active_game")
             return
         }
 
         emitSyncWithTelemetry(
-            source = "game.sync",
+            source = GAME_SYNC_SOURCE,
             sessionId = sessionId,
             userId = userId,
             gameId = resolvedGameId,

--- a/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
@@ -204,7 +204,16 @@ class WebSocketController(
         ).increment()
     }
 
-    private fun publishSync(sessionId: String, userId: Int, gameId: Int) {
+    /**
+     * Builds and delivers the game-state snapshot to a single reconnecting user.
+     *
+     * [principalName] is the value from [UserPrincipal.name] (i.e. the username),
+     * which is what Spring's [org.springframework.messaging.simp.user.UserDestinationResolver]
+     * uses to look up the subscriber's session.  Passing a raw STOMP sessionId here
+     * would cause the message to be silently dropped in production because the resolver
+     * resolves destinations by principal, not by session ID directly.
+     */
+    private fun publishSync(principalName: String, sessionId: String, userId: Int, gameId: Int) {
         val snapshot = gameSyncService.buildSnapshot(gameId)
         val headers = SimpMessageHeaderAccessor.create(SimpMessageType.MESSAGE).apply {
             setSessionId(sessionId)
@@ -212,7 +221,7 @@ class WebSocketController(
         }.messageHeaders
 
         messagingTemplate.convertAndSendToUser(
-            sessionId,
+            principalName,
             "/queue/game-sync",
             WebSocketMessage(
                 type = MessageType.SYNC,

--- a/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
@@ -2,7 +2,7 @@ package org.machikoro.server.controller
 
 import io.micrometer.core.instrument.Metrics
 import io.micrometer.core.instrument.Timer
-import org.machikoro.server.dao.UserDao
+import org.machikoro.server.auth.UserPrincipal
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.SyncGameRequest
 import org.machikoro.server.dto.WebSocketMessage
@@ -12,7 +12,6 @@ import org.machikoro.server.service.LobbyService
 import org.machikoro.server.service.WebSocketConnectionTracker
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.handler.annotation.Payload
-import org.springframework.messaging.handler.annotation.SendTo
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.messaging.simp.SimpMessageType
@@ -23,7 +22,6 @@ import java.util.concurrent.TimeUnit
 @Controller
 class WebSocketController(
     private val lobbyService: LobbyService,
-    private val userDao: UserDao,
     private val connectionTracker: WebSocketConnectionTracker,
     private val gameSyncService: GameSyncService,
     private val messagingTemplate: SimpMessagingTemplate,
@@ -52,51 +50,67 @@ class WebSocketController(
      * Handle user join events and broadcast to all subscribers.
      * Stores username in session for later reference during disconnect.
      * Registers the session in [WebSocketConnectionTracker] when user and gameId are known.
+     *
+     * Identity is read exclusively from the [UserPrincipal] attached by
+     * [org.machikoro.server.auth.StompAuthChannelInterceptor] at CONNECT time —
+     * the client-supplied [WebSocketMessage.sender] field is ignored to prevent
+     * username spoofing / state exfiltration.
      */
     @MessageMapping("/chat.addUser")
-    @SendTo("/topic/public")
+    @org.springframework.messaging.handler.annotation.SendTo("/topic/public")
     fun addUser(
         @Payload message: WebSocketMessage,
-        headerAccessor: SimpMessageHeaderAccessor
+        headerAccessor: SimpMessageHeaderAccessor,
     ): WebSocketMessage {
-        logger.info("User ${message.sender} joined the chat")
-        headerAccessor.sessionAttributes?.put("username", message.sender)
+        val principal = headerAccessor.user as? UserPrincipal
+        if (principal == null) {
+            logger.warn("addUser rejected: no authenticated principal on session ${headerAccessor.sessionId}")
+            return message
+        }
 
-        val user = userDao.findByUsername(message.sender)
-        if (user != null) {
-            // Prefer server-side mapping to an active game when a player reconnects.
-            val mappedInProgressGameId = gameSyncService.findActiveInProgressGameId(user.id)
-            var gameIdToJoin = mappedInProgressGameId ?: message.gameId
+        logger.info("User '{}' joined the chat", principal.username)
+        // Store server-verified username so the disconnect listener can reference it
+        // without trusting whatever the client put in the message payload.
+        headerAccessor.sessionAttributes?.put("username", principal.username)
 
-            if (gameIdToJoin != null) {
-                try {
-                    lobbyService.addUserToLobby(gameIdToJoin, user.id)
-                } catch (e: GameStartedException) {
-                    // Start transition race: game flipped while reconnect was in-flight.
-                    val remappedInProgressGameId = gameSyncService.findActiveInProgressGameId(user.id)
-                    if (remappedInProgressGameId == null) {
-                        throw e
-                    }
-                    gameIdToJoin = remappedInProgressGameId
+        // Prefer server-side mapping to an active game when a player reconnects.
+        val mappedInProgressGameId = gameSyncService.findActiveInProgressGameId(principal.userId)
+        var gameIdToJoin = mappedInProgressGameId ?: message.gameId
+
+        if (gameIdToJoin != null) {
+            try {
+                lobbyService.addUserToLobby(gameIdToJoin, principal.userId)
+            } catch (e: GameStartedException) {
+                // Start-transition race: the game status flipped to IN_PROGRESS between
+                // the client sending JOIN and the server processing it.  The client is not
+                // in an inconsistent state — it simply joined a lobby that just started.
+                // Attempt to re-map to the now-active game so the player receives the
+                // correct state snapshot.  If no active game can be found after the race,
+                // the exception is re-thrown and the client must retry.
+                val remappedInProgressGameId = gameSyncService.findActiveInProgressGameId(principal.userId)
+                if (remappedInProgressGameId == null) {
+                    throw e
                 }
+                gameIdToJoin = remappedInProgressGameId
+            }
 
-                val sessionId = headerAccessor.sessionId
-                if (sessionId != null) {
-                    connectionTracker.register(sessionId, user.id, gameIdToJoin)
-                }
+            val sessionId = headerAccessor.sessionId
+            if (sessionId != null) {
+                connectionTracker.register(sessionId, principal.userId, gameIdToJoin)
+            }
 
-                val syncGameId = gameSyncService.findActiveInProgressGameId(user.id)
-
-                if (syncGameId != null && sessionId != null) {
-                    emitSyncWithTelemetry(
-                        source = "chat.addUser",
-                        sessionId = sessionId,
-                        userId = user.id,
-                        gameId = syncGameId,
-                    )
-                }
+            val syncGameId = gameSyncService.findActiveInProgressGameId(principal.userId)
+            if (syncGameId != null && sessionId != null) {
+                emitSyncWithTelemetry(
+                    source = "chat.addUser",
+                    principalName = principal.name,
+                    sessionId = sessionId,
+                    userId = principal.userId,
+                    gameId = syncGameId,
+                )
             }
         }
+
         return message
     }
 

--- a/src/main/kotlin/org/machikoro/server/dao/PlayerCardDao.kt
+++ b/src/main/kotlin/org/machikoro/server/dao/PlayerCardDao.kt
@@ -3,6 +3,7 @@ package org.machikoro.server.dao
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
@@ -35,6 +36,27 @@ class PlayerCardDao {
             .selectAll()
             .where { PlayerCards.playerId eq playerId }
             .map { it.toPlayerCardModel() }
+    }
+
+    /**
+     * Bulk-fetches cards for multiple players in a single query and groups them
+     * by player ID.  Use this in preference to calling [findByPlayerId] in a loop
+     * (N+1 anti-pattern) when you already have a list of player IDs — e.g. inside
+     * [org.machikoro.server.service.GameSyncService.buildSnapshot].
+     *
+     * @param playerIds the set of player IDs to fetch cards for
+     * @return a map from player ID to that player's card list; players with no
+     *         cards are absent from the map (not mapped to an empty list).
+     */
+    fun findByPlayerIds(playerIds: List<Int>): Map<Int, List<PlayerCardModel>> {
+        if (playerIds.isEmpty()) return emptyMap()
+        return transaction {
+            (PlayerCards innerJoin Cards)
+                .selectAll()
+                .where { PlayerCards.playerId inList playerIds }
+                .map { it.toPlayerCardModel() }
+                .groupBy { it.playerId }
+        }
     }
 
     /**

--- a/src/main/kotlin/org/machikoro/server/dao/PlayerDao.kt
+++ b/src/main/kotlin/org/machikoro/server/dao/PlayerDao.kt
@@ -2,9 +2,9 @@ package org.machikoro.server.dao
 
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.JoinType
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
-import org.jetbrains.exposed.v1.jdbc.innerJoin
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
 import org.jetbrains.exposed.v1.jdbc.selectAll
@@ -67,7 +67,11 @@ class PlayerDao {
      * Returns the most recent IN_PROGRESS game ID the given user belongs to.
      */
     fun findActiveGameIdByUserId(userId: Int): Int? = transaction {
-        (Players innerJoin Games)
+        Players.join(
+            Games,
+            JoinType.INNER,
+            additionalConstraint = { Players.gameId eq Games.id }
+        )
             .selectAll()
             .where { (Players.userId eq userId) and (Games.status eq GameStatus.IN_PROGRESS) }
             .orderBy(Games.id to SortOrder.DESC)

--- a/src/main/kotlin/org/machikoro/server/dao/PlayerDao.kt
+++ b/src/main/kotlin/org/machikoro/server/dao/PlayerDao.kt
@@ -2,13 +2,17 @@ package org.machikoro.server.dao
 
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.innerJoin
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
+import org.machikoro.server.database.Games
 import org.machikoro.server.database.Players
+import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.models.PlayerModel
 import org.machikoro.server.exception.PlayerNotFoundException
 import org.springframework.stereotype.Repository
@@ -47,6 +51,29 @@ class PlayerDao {
             .where { Players.gameId eq gameId }
             .orderBy(Players.turnOrder to SortOrder.ASC)
             .map { it.toModel() }
+    }
+
+    /**
+     * Finds a player's row by (gameId, userId), if already present.
+     */
+    fun findByGameIdAndUserId(gameId: Int, userId: Int): PlayerModel? = transaction {
+        Players.selectAll()
+            .where { (Players.gameId eq gameId) and (Players.userId eq userId) }
+            .singleOrNull()
+            ?.toModel()
+    }
+
+    /**
+     * Returns the most recent IN_PROGRESS game ID the given user belongs to.
+     */
+    fun findActiveGameIdByUserId(userId: Int): Int? = transaction {
+        (Players innerJoin Games)
+            .selectAll()
+            .where { (Players.userId eq userId) and (Games.status eq GameStatus.IN_PROGRESS) }
+            .orderBy(Games.id to SortOrder.DESC)
+            .firstOrNull()
+            ?.get(Players.gameId)
+            ?.value
     }
 
     /**

--- a/src/main/kotlin/org/machikoro/server/dto/ChatMessage.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/ChatMessage.kt
@@ -9,6 +9,7 @@ enum class MessageType {
     LEAVE,
     GAME_START,
     GAME_STARTED,
+    SYNC,
     GAME_ACTION,
     GAME_END,
     PLAYER_LEFT_FINISHED_GAME,

--- a/src/main/kotlin/org/machikoro/server/dto/SyncGameRequest.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/SyncGameRequest.kt
@@ -1,0 +1,13 @@
+package org.machikoro.server.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Optional game context for an explicit reconnect sync request")
+data class SyncGameRequest(
+    @Schema(
+        description = "Game ID to sync. If omitted, server resolves the caller's active IN_PROGRESS game.",
+        example = "1"
+    )
+    val gameId: Int? = null,
+)
+

--- a/src/main/kotlin/org/machikoro/server/service/GameSyncService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/GameSyncService.kt
@@ -1,0 +1,41 @@
+package org.machikoro.server.service
+
+import org.machikoro.server.dao.GameDao
+import org.machikoro.server.dao.PlayerCardDao
+import org.machikoro.server.dao.PlayerDao
+import org.machikoro.server.domain.enums.GameStatus
+import org.machikoro.server.dto.GameStateDto
+import org.machikoro.server.exception.GameNotFoundException
+import org.springframework.stereotype.Service
+
+@Service
+class GameSyncService(
+    private val gameDao: GameDao,
+    private val playerDao: PlayerDao,
+    private val playerCardDao: PlayerCardDao,
+) {
+
+    fun findActiveInProgressGameId(userId: Int): Int? =
+        playerDao.findActiveGameIdByUserId(userId)
+
+    fun buildSnapshot(gameId: Int): GameStateDto {
+        val game = gameDao.findById(gameId)
+            ?: throw GameNotFoundException("Game $gameId not found")
+
+        val players = playerDao.getPlayers(gameId)
+        val playerCards = players.associate { player ->
+            player.id to playerCardDao.findByPlayerId(player.id)
+        }
+
+        return GameStateDto(
+            game = game,
+            players = players,
+            playerCards = playerCards,
+            turnOrder = players.sortedBy { it.turnOrder }.map { it.id },
+        )
+    }
+
+    fun isInProgress(gameId: Int): Boolean =
+        gameDao.findById(gameId)?.status == GameStatus.IN_PROGRESS
+}
+

--- a/src/main/kotlin/org/machikoro/server/service/GameSyncService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/GameSyncService.kt
@@ -37,5 +37,8 @@ class GameSyncService(
 
     fun isInProgress(gameId: Int): Boolean =
         gameDao.findById(gameId)?.status == GameStatus.IN_PROGRESS
+
+    fun isUserInGame(userId: Int, gameId: Int): Boolean =
+        playerDao.findByGameIdAndUserId(gameId, userId) != null
 }
 

--- a/src/main/kotlin/org/machikoro/server/service/GameSyncService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/GameSyncService.kt
@@ -23,8 +23,10 @@ class GameSyncService(
             ?: throw GameNotFoundException("Game $gameId not found")
 
         val players = playerDao.getPlayers(gameId)
+        // Fetch all player cards in one query instead of N individual lookups.
+        val playerCardsByPlayerId = playerCardDao.findByPlayerIds(players.map { it.id })
         val playerCards = players.associate { player ->
-            player.id to playerCardDao.findByPlayerId(player.id)
+            player.id to (playerCardsByPlayerId[player.id] ?: emptyList())
         }
 
         return GameStateDto(

--- a/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
@@ -55,11 +55,17 @@ open class LobbyService(
         val game = gameDao.findById(gameId)
             ?: throw GameNotFoundException("Game $gameId not found")
 
+        // Reconnect path: player already belongs to this game, so do not re-insert.
+        playerDao.findByGameIdAndUserId(gameId, userId)?.let { return it }
+
         if (game.status == GameStatus.IN_PROGRESS) {
             throw GameStartedException("Game $gameId has already started")
         }
 
         synchronized(lobbyLocks.getOrPut(gameId) { Any() }) {
+            // Protect against duplicate inserts on concurrent reconnect/join attempts.
+            playerDao.findByGameIdAndUserId(gameId, userId)?.let { return it }
+
             val players = playerDao.getPlayers(gameId)
             if (players.size >= game.maxPlayers) {
                 throw LobbyFullException("Game $gameId is full (max ${game.maxPlayers} players)")

--- a/src/test/kotlin/org/machikoro/server/controller/LobbyWebSocketControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/LobbyWebSocketControllerTest.kt
@@ -2,11 +2,10 @@ package org.machikoro.server.controller
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.machikoro.server.dao.UserDao
+import org.machikoro.server.auth.UserPrincipal
 import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.enums.TurnPhase
 import org.machikoro.server.domain.models.GameModel
-import org.machikoro.server.domain.models.UserModel
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.WebSocketMessage
 import org.machikoro.server.service.LobbyService
@@ -16,12 +15,18 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 
 class LobbyWebSocketControllerTest {
 
     private val lobbyService = mock<LobbyService>()
-    private val userDao = mock<UserDao>()
-    private val controller = LobbyWebSocketController(lobbyService, userDao)
+    private val controller = LobbyWebSocketController(lobbyService)
+
+    /** Helper: accessor with an authenticated principal attached. */
+    private fun authenticatedAccessor(userId: Int, username: String): SimpMessageHeaderAccessor =
+        SimpMessageHeaderAccessor.create().apply {
+            user = UserPrincipal(userId = userId, username = username)
+        }
 
     private fun game() = GameModel(
         id = 1,
@@ -37,26 +42,18 @@ class LobbyWebSocketControllerTest {
     )
 
     @Test
-    fun `createLobby creates lobby for sender and returns LOBBY_CREATED message`() {
-        val username = "Player1"
-        val user = UserModel(
-            id = 10,
-            username = username,
-            passwordHash = null,
-            sessionToken = null,
-            totalWins = 0,
-            totalGamesPlayed = 0
-        )
+    fun `createLobby creates lobby for authenticated user and returns LOBBY_CREATED message`() {
+        whenever(lobbyService.createLobby(10)).thenReturn(game())
 
-        whenever(userDao.findByUsername(username)).thenReturn(user)
-        whenever(lobbyService.createLobby(user.id)).thenReturn(game())
+        val accessor = authenticatedAccessor(userId = 10, username = "Player1")
 
         val result = controller.createLobby(
             WebSocketMessage(
                 type = MessageType.JOIN,
-                sender = username,
+                sender = "ignored-by-server",
                 content = "create lobby"
-            )
+            ),
+            accessor,
         )
 
         val payload = result.payload as? Map<String, Any>
@@ -70,26 +67,26 @@ class LobbyWebSocketControllerTest {
         assertEquals(10, payload["hostUserId"])
         assertEquals("WAITING", payload["status"])
 
-        verify(userDao).findByUsername(username)
-        verify(lobbyService).createLobby(user.id)
+        // Must call lobbyService with the principal's userId, not message.sender
+        verify(lobbyService).createLobby(10)
     }
 
     @Test
-    fun `createLobby throws and does not call lobbyService when sender is unknown`() {
-        val unknownUsername = "ghost"
-        whenever(userDao.findByUsername(unknownUsername)).thenReturn(null)
+    fun `createLobby throws when no authenticated principal is present`() {
+        // Accessor with no UserPrincipal — simulates a bypassed STOMP auth
+        val accessor = SimpMessageHeaderAccessor.create()
 
         assertThrows<RuntimeException> {
             controller.createLobby(
                 WebSocketMessage(
                     type = MessageType.JOIN,
-                    sender = unknownUsername,
+                    sender = "ghost",
                     content = "create lobby",
                 ),
+                accessor,
             )
         }
 
-        verify(userDao).findByUsername(unknownUsername)
         verify(lobbyService, never()).createLobby(any())
     }
 }

--- a/src/test/kotlin/org/machikoro/server/controller/WebSocketControllerTests.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/WebSocketControllerTests.kt
@@ -8,6 +8,7 @@ import org.machikoro.server.dao.UserDao
 import org.machikoro.server.domain.models.UserModel
 import org.machikoro.server.dto.GameStateDto
 import org.machikoro.server.dto.MessageType
+import org.machikoro.server.dto.SyncGameRequest
 import org.machikoro.server.dto.WebSocketMessage
 import org.machikoro.server.exception.GameStartedException
 import org.machikoro.server.service.GameSyncService
@@ -184,5 +185,35 @@ class WebSocketControllerTests {
         val captor = argumentCaptor<WebSocketMessage>()
         verify(messagingTemplate).convertAndSend(eq("/topic/game/3"), captor.capture())
         assertEquals(MessageType.SYNC, captor.firstValue.type)
+    }
+
+    @Test
+    fun `syncGameState publishes SYNC for connected player with active game`() {
+        whenever(connectionTracker.getUserId("session-sync")).thenReturn(50)
+        whenever(gameSyncService.findActiveInProgressGameId(50)).thenReturn(8)
+        whenever(gameSyncService.isInProgress(8)).thenReturn(true)
+        whenever(gameSyncService.buildSnapshot(8)).thenReturn(mock<GameStateDto>())
+
+        val accessor = SimpMessageHeaderAccessor.create()
+        accessor.sessionId = "session-sync"
+
+        controller.syncGameState(SyncGameRequest(gameId = null), accessor)
+
+        val captor = argumentCaptor<WebSocketMessage>()
+        verify(messagingTemplate).convertAndSend(eq("/topic/game/8"), captor.capture())
+        assertEquals(MessageType.SYNC, captor.firstValue.type)
+        assertEquals(8, captor.firstValue.gameId)
+    }
+
+    @Test
+    fun `syncGameState does nothing when session is unknown`() {
+        whenever(connectionTracker.getUserId("session-missing")).thenReturn(null)
+
+        val accessor = SimpMessageHeaderAccessor.create()
+        accessor.sessionId = "session-missing"
+
+        controller.syncGameState(SyncGameRequest(gameId = 1), accessor)
+
+        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
     }
 }

--- a/src/test/kotlin/org/machikoro/server/controller/WebSocketControllerTests.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/WebSocketControllerTests.kt
@@ -169,6 +169,10 @@ class WebSocketControllerTests {
         )
         assertEquals(MessageType.SYNC, captor.firstValue.type)
         assertEquals(7, captor.firstValue.gameId)
+        @Suppress("UNCHECKED_CAST")
+        val payload = captor.firstValue.payload as Map<String, Any>
+        assertEquals(foundUser.id, payload["targetUserId"])
+        assertEquals("session-rejoin", payload["targetSessionId"])
     }
 
     @Test
@@ -195,6 +199,10 @@ class WebSocketControllerTests {
             any<Map<String, Any>>(),
         )
         assertEquals(MessageType.SYNC, captor.firstValue.type)
+        @Suppress("UNCHECKED_CAST")
+        val payload = captor.firstValue.payload as Map<String, Any>
+        assertEquals(foundUser.id, payload["targetUserId"])
+        assertEquals("session-race", payload["targetSessionId"])
     }
 
     @Test
@@ -218,6 +226,10 @@ class WebSocketControllerTests {
         )
         assertEquals(MessageType.SYNC, captor.firstValue.type)
         assertEquals(8, captor.firstValue.gameId)
+        @Suppress("UNCHECKED_CAST")
+        val payload = captor.firstValue.payload as Map<String, Any>
+        assertEquals(50, payload["targetUserId"])
+        assertEquals("session-sync", payload["targetSessionId"])
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/controller/WebSocketControllerTests.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/WebSocketControllerTests.kt
@@ -236,4 +236,23 @@ class WebSocketControllerTests {
             any<Map<String, Any>>(),
         )
     }
+
+    @Test
+    fun `syncGameState rejects explicit gameId when user is not a member`() {
+        whenever(connectionTracker.getUserId("session-unauthorized")).thenReturn(70)
+        whenever(gameSyncService.isUserInGame(70, 99)).thenReturn(false)
+
+        val accessor = SimpMessageHeaderAccessor.create()
+        accessor.sessionId = "session-unauthorized"
+
+        controller.syncGameState(SyncGameRequest(gameId = 99), accessor)
+
+        verify(messagingTemplate, never()).convertAndSendToUser(
+            any<String>(),
+            any<String>(),
+            any<WebSocketMessage>(),
+            any<Map<String, Any>>(),
+        )
+        verify(gameSyncService, never()).buildSnapshot(any())
+    }
 }

--- a/src/test/kotlin/org/machikoro/server/controller/WebSocketControllerTests.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/WebSocketControllerTests.kt
@@ -4,8 +4,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.machikoro.server.dao.UserDao
-import org.machikoro.server.domain.models.UserModel
+import org.machikoro.server.auth.UserPrincipal
 import org.machikoro.server.dto.GameStateDto
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.SyncGameRequest
@@ -27,22 +26,26 @@ import org.springframework.messaging.simp.SimpMessagingTemplate
 class WebSocketControllerTests {
 
     private val lobbyService = mock<LobbyService>()
-    private val userDao = mock<UserDao>()
     private val connectionTracker = mock<WebSocketConnectionTracker>()
     private val gameSyncService = mock<GameSyncService>()
     private val messagingTemplate = mock<SimpMessagingTemplate>()
     private val controller = WebSocketController(
         lobbyService,
-        userDao,
         connectionTracker,
         gameSyncService,
         messagingTemplate,
     )
 
-    private fun user(id: Int, username: String) = UserModel(
-        id = id, username = username, passwordHash = null,
-        sessionToken = null, totalWins = 0, totalGamesPlayed = 0
-    )
+    /** Helper: create an accessor pre-populated with an authenticated UserPrincipal. */
+    private fun authenticatedAccessor(
+        userId: Int,
+        username: String,
+        sessionId: String = "session-default",
+    ): SimpMessageHeaderAccessor = SimpMessageHeaderAccessor.create().apply {
+        this.sessionId = sessionId
+        this.sessionAttributes = mutableMapOf()
+        user = UserPrincipal(userId = userId, username = username)
+    }
 
     @BeforeEach
     fun setup() {
@@ -60,20 +63,23 @@ class WebSocketControllerTests {
 
     @Test
     fun addUserShouldStoreUsernameInSessionAttributes() {
-        val message = WebSocketMessage(type = MessageType.JOIN, sender = "bob")
-        val accessor = SimpMessageHeaderAccessor.create()
-        accessor.sessionAttributes = mutableMapOf()
+        val message = WebSocketMessage(type = MessageType.JOIN, sender = "ignored-payload-sender")
+        val accessor = authenticatedAccessor(userId = 1, username = "bob")
 
         val result = controller.addUser(message, accessor)
 
         assertEquals(message, result)
+        // Username stored must come from the authenticated principal, not from message.sender
         assertEquals("bob", accessor.sessionAttributes?.get("username"))
     }
 
     @Test
     fun addUserShouldNotFailWhenSessionAttributesAreMissing() {
         val message = WebSocketMessage(type = MessageType.JOIN, sender = "carol")
-        val accessor = SimpMessageHeaderAccessor.create()
+        // A valid principal but no sessionAttributes map
+        val accessor = SimpMessageHeaderAccessor.create().apply {
+            user = UserPrincipal(userId = 2, username = "carol")
+        }
 
         val result = controller.addUser(message, accessor)
 
@@ -82,29 +88,12 @@ class WebSocketControllerTests {
     }
 
     @Test
-    fun `addUser calls addUserToLobby and registers session when user and gameId are present`() {
-        val gameId = 1
-        val foundUser = user(id = 10, username = "dave")
-        whenever(userDao.findByUsername("dave")).thenReturn(foundUser)
-
-        val message = WebSocketMessage(type = MessageType.JOIN, sender = "dave", gameId = gameId)
-        val accessor = SimpMessageHeaderAccessor.create()
-        accessor.sessionId = "session-abc"
-        accessor.sessionAttributes = mutableMapOf()
-
-        controller.addUser(message, accessor)
-
-        verify(lobbyService).addUserToLobby(gameId, foundUser.id)
-        verify(connectionTracker).register("session-abc", foundUser.id, gameId)
-    }
-
-    @Test
-    fun `addUser does not call addUserToLobby when user is not found`() {
-        whenever(userDao.findByUsername("unknown")).thenReturn(null)
-
-        val message = WebSocketMessage(type = MessageType.JOIN, sender = "unknown", gameId = 1)
-        val accessor = SimpMessageHeaderAccessor.create()
-        accessor.sessionAttributes = mutableMapOf()
+    fun `addUser returns early without touching lobby when principal is missing`() {
+        val message = WebSocketMessage(type = MessageType.JOIN, sender = "ghost", gameId = 1)
+        // No principal set — simulates a connection that bypassed STOMP auth (shouldn't happen in prod)
+        val accessor = SimpMessageHeaderAccessor.create().apply {
+            sessionAttributes = mutableMapOf()
+        }
 
         controller.addUser(message, accessor)
 
@@ -113,13 +102,23 @@ class WebSocketControllerTests {
     }
 
     @Test
-    fun `addUser does not call addUserToLobby when gameId is null`() {
-        val foundUser = user(id = 5, username = "eve")
-        whenever(userDao.findByUsername("eve")).thenReturn(foundUser)
+    fun `addUser calls addUserToLobby and registers session when user and gameId are present`() {
+        val gameId = 1
+        val accessor = authenticatedAccessor(userId = 10, username = "dave", sessionId = "session-abc")
+
+        val message = WebSocketMessage(type = MessageType.JOIN, sender = "dave", gameId = gameId)
+
+        controller.addUser(message, accessor)
+
+        verify(lobbyService).addUserToLobby(gameId, 10)
+        verify(connectionTracker).register("session-abc", 10, gameId)
+    }
+
+    @Test
+    fun `addUser does not call addUserToLobby when gameId is null and no active game`() {
+        val accessor = authenticatedAccessor(userId = 5, username = "eve")
 
         val message = WebSocketMessage(type = MessageType.JOIN, sender = "eve", gameId = null)
-        val accessor = SimpMessageHeaderAccessor.create()
-        accessor.sessionAttributes = mutableMapOf()
 
         controller.addUser(message, accessor)
 
@@ -129,40 +128,36 @@ class WebSocketControllerTests {
 
     @Test
     fun `addUser does not register session when sessionId is null`() {
-        val foundUser = user(id = 7, username = "frank")
-        whenever(userDao.findByUsername("frank")).thenReturn(foundUser)
-
         val message = WebSocketMessage(type = MessageType.JOIN, sender = "frank", gameId = 2)
-        // SimpMessageHeaderAccessor.create() without setting sessionId → sessionId is null
-        val accessor = SimpMessageHeaderAccessor.create()
-        accessor.sessionAttributes = mutableMapOf()
+        // accessor without sessionId set → sessionId is null
+        val accessor = SimpMessageHeaderAccessor.create().apply {
+            sessionAttributes = mutableMapOf()
+            user = UserPrincipal(userId = 7, username = "frank")
+        }
 
         controller.addUser(message, accessor)
 
-        verify(lobbyService).addUserToLobby(2, foundUser.id)
+        verify(lobbyService).addUserToLobby(2, 7)
         verify(connectionTracker, never()).register(any(), any(), any())
     }
 
     @Test
     fun `addUser maps reconnecting user to active in-progress game and sends SYNC`() {
-        val foundUser = user(id = 11, username = "gina")
-        whenever(userDao.findByUsername("gina")).thenReturn(foundUser)
-        whenever(gameSyncService.findActiveInProgressGameId(foundUser.id)).thenReturn(7)
+        whenever(gameSyncService.findActiveInProgressGameId(11)).thenReturn(7)
         whenever(gameSyncService.buildSnapshot(7)).thenReturn(mock<GameStateDto>())
 
+        val accessor = authenticatedAccessor(userId = 11, username = "gina", sessionId = "session-rejoin")
         val message = WebSocketMessage(type = MessageType.JOIN, sender = "gina", gameId = null)
-        val accessor = SimpMessageHeaderAccessor.create()
-        accessor.sessionId = "session-rejoin"
-        accessor.sessionAttributes = mutableMapOf()
 
         controller.addUser(message, accessor)
 
-        verify(lobbyService).addUserToLobby(7, foundUser.id)
-        verify(connectionTracker).register("session-rejoin", foundUser.id, 7)
+        verify(lobbyService).addUserToLobby(7, 11)
+        verify(connectionTracker).register("session-rejoin", 11, 7)
 
         val captor = argumentCaptor<WebSocketMessage>()
+        // convertAndSendToUser first arg must be the principal name, not the sessionId
         verify(messagingTemplate).convertAndSendToUser(
-            eq("session-rejoin"),
+            eq("gina"),
             eq("/queue/game-sync"),
             captor.capture(),
             any<Map<String, Any>>(),
@@ -171,29 +166,25 @@ class WebSocketControllerTests {
         assertEquals(7, captor.firstValue.gameId)
         @Suppress("UNCHECKED_CAST")
         val payload = captor.firstValue.payload as Map<String, Any>
-        assertEquals(foundUser.id, payload["targetUserId"])
+        assertEquals(11, payload["targetUserId"])
         assertEquals("session-rejoin", payload["targetSessionId"])
     }
 
     @Test
     fun `addUser handles transition race by re-mapping user and syncing state`() {
-        val foundUser = user(id = 12, username = "harry")
-        whenever(userDao.findByUsername("harry")).thenReturn(foundUser)
-        whenever(gameSyncService.findActiveInProgressGameId(foundUser.id)).thenReturn(null, 3, 3)
-        whenever(lobbyService.addUserToLobby(3, foundUser.id)).thenThrow(GameStartedException("already started"))
+        whenever(gameSyncService.findActiveInProgressGameId(12)).thenReturn(null, 3, 3)
+        whenever(lobbyService.addUserToLobby(3, 12)).thenThrow(GameStartedException("already started"))
         whenever(gameSyncService.buildSnapshot(3)).thenReturn(mock<GameStateDto>())
 
+        val accessor = authenticatedAccessor(userId = 12, username = "harry", sessionId = "session-race")
         val message = WebSocketMessage(type = MessageType.JOIN, sender = "harry", gameId = 3)
-        val accessor = SimpMessageHeaderAccessor.create()
-        accessor.sessionId = "session-race"
-        accessor.sessionAttributes = mutableMapOf()
 
         controller.addUser(message, accessor)
 
-        verify(connectionTracker).register("session-race", foundUser.id, 3)
+        verify(connectionTracker).register("session-race", 12, 3)
         val captor = argumentCaptor<WebSocketMessage>()
         verify(messagingTemplate).convertAndSendToUser(
-            eq("session-race"),
+            eq("harry"),
             eq("/queue/game-sync"),
             captor.capture(),
             any<Map<String, Any>>(),
@@ -201,25 +192,24 @@ class WebSocketControllerTests {
         assertEquals(MessageType.SYNC, captor.firstValue.type)
         @Suppress("UNCHECKED_CAST")
         val payload = captor.firstValue.payload as Map<String, Any>
-        assertEquals(foundUser.id, payload["targetUserId"])
+        assertEquals(12, payload["targetUserId"])
         assertEquals("session-race", payload["targetSessionId"])
     }
 
     @Test
     fun `syncGameState publishes SYNC for connected player with active game`() {
-        whenever(connectionTracker.getUserId("session-sync")).thenReturn(50)
         whenever(gameSyncService.findActiveInProgressGameId(50)).thenReturn(8)
         whenever(gameSyncService.isInProgress(8)).thenReturn(true)
         whenever(gameSyncService.buildSnapshot(8)).thenReturn(mock<GameStateDto>())
 
-        val accessor = SimpMessageHeaderAccessor.create()
-        accessor.sessionId = "session-sync"
+        val accessor = authenticatedAccessor(userId = 50, username = "sync-user", sessionId = "session-sync")
 
         controller.syncGameState(SyncGameRequest(gameId = null), accessor)
 
         val captor = argumentCaptor<WebSocketMessage>()
+        // First arg must be the principal name, not the sessionId
         verify(messagingTemplate).convertAndSendToUser(
-            eq("session-sync"),
+            eq("sync-user"),
             eq("/queue/game-sync"),
             captor.capture(),
             any<Map<String, Any>>(),
@@ -233,11 +223,11 @@ class WebSocketControllerTests {
     }
 
     @Test
-    fun `syncGameState does nothing when session is unknown`() {
-        whenever(connectionTracker.getUserId("session-missing")).thenReturn(null)
-
-        val accessor = SimpMessageHeaderAccessor.create()
-        accessor.sessionId = "session-missing"
+    fun `syncGameState does nothing when principal is missing`() {
+        // No UserPrincipal on the accessor — should reject silently
+        val accessor = SimpMessageHeaderAccessor.create().apply {
+            sessionId = "session-no-principal"
+        }
 
         controller.syncGameState(SyncGameRequest(gameId = 1), accessor)
 
@@ -251,11 +241,9 @@ class WebSocketControllerTests {
 
     @Test
     fun `syncGameState rejects explicit gameId when user is not a member`() {
-        whenever(connectionTracker.getUserId("session-unauthorized")).thenReturn(70)
         whenever(gameSyncService.isUserInGame(70, 99)).thenReturn(false)
 
-        val accessor = SimpMessageHeaderAccessor.create()
-        accessor.sessionId = "session-unauthorized"
+        val accessor = authenticatedAccessor(userId = 70, username = "unauthorized-user", sessionId = "session-unauthorized")
 
         controller.syncGameState(SyncGameRequest(gameId = 99), accessor)
 
@@ -268,3 +256,4 @@ class WebSocketControllerTests {
         verify(gameSyncService, never()).buildSnapshot(any())
     }
 }
+

--- a/src/test/kotlin/org/machikoro/server/controller/WebSocketControllerTests.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/WebSocketControllerTests.kt
@@ -2,6 +2,7 @@ package org.machikoro.server.controller
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.machikoro.server.dao.UserDao
 import org.machikoro.server.domain.models.UserModel
@@ -41,6 +42,11 @@ class WebSocketControllerTests {
         id = id, username = username, passwordHash = null,
         sessionToken = null, totalWins = 0, totalGamesPlayed = 0
     )
+
+    @BeforeEach
+    fun setup() {
+        whenever(gameSyncService.findActiveInProgressGameId(any())).thenReturn(null)
+    }
 
     @Test
     fun sendMessageShouldReturnUnchangedMessage() {

--- a/src/test/kotlin/org/machikoro/server/controller/WebSocketControllerTests.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/WebSocketControllerTests.kt
@@ -165,7 +165,7 @@ class WebSocketControllerTests {
             eq("session-rejoin"),
             eq("/queue/game-sync"),
             captor.capture(),
-            any(),
+            any<Map<String, Any>>(),
         )
         assertEquals(MessageType.SYNC, captor.firstValue.type)
         assertEquals(7, captor.firstValue.gameId)
@@ -192,7 +192,7 @@ class WebSocketControllerTests {
             eq("session-race"),
             eq("/queue/game-sync"),
             captor.capture(),
-            any(),
+            any<Map<String, Any>>(),
         )
         assertEquals(MessageType.SYNC, captor.firstValue.type)
     }
@@ -214,7 +214,7 @@ class WebSocketControllerTests {
             eq("session-sync"),
             eq("/queue/game-sync"),
             captor.capture(),
-            any(),
+            any<Map<String, Any>>(),
         )
         assertEquals(MessageType.SYNC, captor.firstValue.type)
         assertEquals(8, captor.firstValue.gameId)
@@ -229,6 +229,11 @@ class WebSocketControllerTests {
 
         controller.syncGameState(SyncGameRequest(gameId = 1), accessor)
 
-        verify(messagingTemplate, never()).convertAndSendToUser(any<String>(), any<String>(), any<WebSocketMessage>(), any())
+        verify(messagingTemplate, never()).convertAndSendToUser(
+            any<String>(),
+            any<String>(),
+            any<WebSocketMessage>(),
+            any<Map<String, Any>>(),
+        )
     }
 }

--- a/src/test/kotlin/org/machikoro/server/controller/WebSocketControllerTests.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/WebSocketControllerTests.kt
@@ -5,23 +5,37 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.machikoro.server.dao.UserDao
 import org.machikoro.server.domain.models.UserModel
+import org.machikoro.server.dto.GameStateDto
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.WebSocketMessage
+import org.machikoro.server.exception.GameStartedException
+import org.machikoro.server.service.GameSyncService
 import org.machikoro.server.service.LobbyService
 import org.machikoro.server.service.WebSocketConnectionTracker
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor
+import org.springframework.messaging.simp.SimpMessagingTemplate
 
 class WebSocketControllerTests {
 
     private val lobbyService = mock<LobbyService>()
     private val userDao = mock<UserDao>()
     private val connectionTracker = mock<WebSocketConnectionTracker>()
-    private val controller = WebSocketController(lobbyService, userDao, connectionTracker)
+    private val gameSyncService = mock<GameSyncService>()
+    private val messagingTemplate = mock<SimpMessagingTemplate>()
+    private val controller = WebSocketController(
+        lobbyService,
+        userDao,
+        connectionTracker,
+        gameSyncService,
+        messagingTemplate,
+    )
 
     private fun user(id: Int, username: String) = UserModel(
         id = id, username = username, passwordHash = null,
@@ -120,5 +134,52 @@ class WebSocketControllerTests {
 
         verify(lobbyService).addUserToLobby(2, foundUser.id)
         verify(connectionTracker, never()).register(any(), any(), any())
+    }
+
+    @Test
+    fun `addUser maps reconnecting user to active in-progress game and sends SYNC`() {
+        val foundUser = user(id = 11, username = "gina")
+        whenever(userDao.findByUsername("gina")).thenReturn(foundUser)
+        whenever(gameSyncService.findActiveInProgressGameId(foundUser.id)).thenReturn(7)
+        whenever(gameSyncService.buildSnapshot(7)).thenReturn(mock<GameStateDto>())
+
+        val message = WebSocketMessage(type = MessageType.JOIN, sender = "gina", gameId = null)
+        val accessor = SimpMessageHeaderAccessor.create()
+        accessor.sessionId = "session-rejoin"
+        accessor.sessionAttributes = mutableMapOf()
+
+        controller.addUser(message, accessor)
+
+        verify(lobbyService).addUserToLobby(7, foundUser.id)
+        verify(connectionTracker).register("session-rejoin", foundUser.id, 7)
+
+        val captor = argumentCaptor<WebSocketMessage>()
+        verify(messagingTemplate).convertAndSend(eq("/topic/game/7"), captor.capture())
+        assertEquals(MessageType.SYNC, captor.firstValue.type)
+        assertEquals(7, captor.firstValue.gameId)
+    }
+
+    @Test
+    fun `addUser handles transition race by re-mapping user and syncing state`() {
+        val foundUser = user(id = 12, username = "harry")
+        whenever(userDao.findByUsername("harry")).thenReturn(foundUser)
+        whenever(gameSyncService.findActiveInProgressGameId(foundUser.id)).thenReturn(null, 3)
+        whenever(lobbyService.addUserToLobby(3, foundUser.id)).thenThrow(GameStartedException("already started"))
+        whenever(gameSyncService.buildSnapshot(3)).thenReturn(mock<GameStateDto>())
+
+        val message = WebSocketMessage(type = MessageType.JOIN, sender = "harry", gameId = 3)
+        val accessor = SimpMessageHeaderAccessor.create()
+        accessor.sessionId = "session-race"
+        accessor.sessionAttributes = mutableMapOf()
+
+        // addUserToLobby is now idempotent in LobbyService, but we keep this test to
+        // prove reconnect path tolerates start transition races in controller mapping.
+        try {
+            controller.addUser(message, accessor)
+        } catch (_: GameStartedException) {
+            // If service throws in this mocked setup, the mapping lookup still happened.
+        }
+
+        verify(gameSyncService).findActiveInProgressGameId(foundUser.id)
     }
 }

--- a/src/test/kotlin/org/machikoro/server/controller/WebSocketControllerTests.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/WebSocketControllerTests.kt
@@ -163,7 +163,7 @@ class WebSocketControllerTests {
     fun `addUser handles transition race by re-mapping user and syncing state`() {
         val foundUser = user(id = 12, username = "harry")
         whenever(userDao.findByUsername("harry")).thenReturn(foundUser)
-        whenever(gameSyncService.findActiveInProgressGameId(foundUser.id)).thenReturn(null, 3)
+        whenever(gameSyncService.findActiveInProgressGameId(foundUser.id)).thenReturn(null, 3, 3)
         whenever(lobbyService.addUserToLobby(3, foundUser.id)).thenThrow(GameStartedException("already started"))
         whenever(gameSyncService.buildSnapshot(3)).thenReturn(mock<GameStateDto>())
 
@@ -172,14 +172,11 @@ class WebSocketControllerTests {
         accessor.sessionId = "session-race"
         accessor.sessionAttributes = mutableMapOf()
 
-        // addUserToLobby is now idempotent in LobbyService, but we keep this test to
-        // prove reconnect path tolerates start transition races in controller mapping.
-        try {
-            controller.addUser(message, accessor)
-        } catch (_: GameStartedException) {
-            // If service throws in this mocked setup, the mapping lookup still happened.
-        }
+        controller.addUser(message, accessor)
 
-        verify(gameSyncService).findActiveInProgressGameId(foundUser.id)
+        verify(connectionTracker).register("session-race", foundUser.id, 3)
+        val captor = argumentCaptor<WebSocketMessage>()
+        verify(messagingTemplate).convertAndSend(eq("/topic/game/3"), captor.capture())
+        assertEquals(MessageType.SYNC, captor.firstValue.type)
     }
 }

--- a/src/test/kotlin/org/machikoro/server/controller/WebSocketControllerTests.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/WebSocketControllerTests.kt
@@ -161,7 +161,12 @@ class WebSocketControllerTests {
         verify(connectionTracker).register("session-rejoin", foundUser.id, 7)
 
         val captor = argumentCaptor<WebSocketMessage>()
-        verify(messagingTemplate).convertAndSend(eq("/topic/game/7"), captor.capture())
+        verify(messagingTemplate).convertAndSendToUser(
+            eq("session-rejoin"),
+            eq("/queue/game-sync"),
+            captor.capture(),
+            any(),
+        )
         assertEquals(MessageType.SYNC, captor.firstValue.type)
         assertEquals(7, captor.firstValue.gameId)
     }
@@ -183,7 +188,12 @@ class WebSocketControllerTests {
 
         verify(connectionTracker).register("session-race", foundUser.id, 3)
         val captor = argumentCaptor<WebSocketMessage>()
-        verify(messagingTemplate).convertAndSend(eq("/topic/game/3"), captor.capture())
+        verify(messagingTemplate).convertAndSendToUser(
+            eq("session-race"),
+            eq("/queue/game-sync"),
+            captor.capture(),
+            any(),
+        )
         assertEquals(MessageType.SYNC, captor.firstValue.type)
     }
 
@@ -200,7 +210,12 @@ class WebSocketControllerTests {
         controller.syncGameState(SyncGameRequest(gameId = null), accessor)
 
         val captor = argumentCaptor<WebSocketMessage>()
-        verify(messagingTemplate).convertAndSend(eq("/topic/game/8"), captor.capture())
+        verify(messagingTemplate).convertAndSendToUser(
+            eq("session-sync"),
+            eq("/queue/game-sync"),
+            captor.capture(),
+            any(),
+        )
         assertEquals(MessageType.SYNC, captor.firstValue.type)
         assertEquals(8, captor.firstValue.gameId)
     }
@@ -214,6 +229,6 @@ class WebSocketControllerTests {
 
         controller.syncGameState(SyncGameRequest(gameId = 1), accessor)
 
-        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
+        verify(messagingTemplate, never()).convertAndSendToUser(any<String>(), any<String>(), any<WebSocketMessage>(), any())
     }
 }

--- a/src/test/kotlin/org/machikoro/server/dao/PlayerDaoTest.kt
+++ b/src/test/kotlin/org/machikoro/server/dao/PlayerDaoTest.kt
@@ -11,6 +11,7 @@ import org.machikoro.server.database.AbstractDBSetup
 import org.machikoro.server.database.Games
 import org.machikoro.server.database.Players
 import org.machikoro.server.database.Users
+import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.exception.PlayerNotFoundException
 
 class PlayerDaoTest : AbstractDBSetup() {
@@ -141,5 +142,61 @@ class PlayerDaoTest : AbstractDBSetup() {
         val player2 = playerDao.addPlayer(gameId, userId2)
         assertEquals(0, player1.turnOrder)
         assertEquals(1, player2.turnOrder)
+    }
+
+    @Test
+    fun `findByGameIdAndUserId returns player when mapping exists`() {
+        val player = playerDao.addPlayer(gameId, userId)
+
+        val found = playerDao.findByGameIdAndUserId(gameId, userId)
+
+        assertNotNull(found)
+        assertEquals(player.id, found!!.id)
+    }
+
+    @Test
+    fun `findByGameIdAndUserId returns null when mapping is missing`() {
+        assertNull(playerDao.findByGameIdAndUserId(gameId, 999999))
+    }
+
+    @Test
+    fun `findActiveGameIdByUserId returns newest in-progress game`() {
+        val olderGameId = gameDao.create(userId)
+        val newerGameId = gameDao.create(userId)
+
+        playerDao.addPlayer(olderGameId, userId)
+        playerDao.addPlayer(newerGameId, userId)
+
+        gameDao.updateStatus(olderGameId, GameStatus.IN_PROGRESS)
+        gameDao.updateStatus(newerGameId, GameStatus.IN_PROGRESS)
+
+        assertEquals(newerGameId, playerDao.findActiveGameIdByUserId(userId))
+    }
+
+    @Test
+    fun `findActiveGameIdByUserId ignores waiting games`() {
+        val waitingGameId = gameDao.create(userId)
+        playerDao.addPlayer(waitingGameId, userId)
+
+        assertNull(playerDao.findActiveGameIdByUserId(userId))
+    }
+
+    @Test
+    fun `updateLastSeen stores a timestamp for player`() {
+        val player = playerDao.addPlayer(gameId, userId)
+        val before = System.currentTimeMillis()
+
+        playerDao.updateLastSeen(player.id)
+
+        val updated = playerDao.findById(player.id)
+        assertNotNull(updated?.lastSeenAt)
+        assertTrue(updated!!.lastSeenAt!! >= before)
+    }
+
+    @Test
+    fun `updateLastSeen throws when player does not exist`() {
+        assertThrows<PlayerNotFoundException> {
+            playerDao.updateLastSeen(999999)
+        }
     }
 }

--- a/src/test/kotlin/org/machikoro/server/dto/ChatMessageTests.kt
+++ b/src/test/kotlin/org/machikoro/server/dto/ChatMessageTests.kt
@@ -10,7 +10,7 @@ class ChatMessageTests {
     @Test
     fun messageTypeShouldExposeAllSupportedValues() {
         val expected = setOf(
-            "CHAT", "JOIN", "LEAVE", "GAME_START", "GAME_STARTED", "GAME_ACTION", "GAME_END",
+            "CHAT", "JOIN", "LEAVE", "GAME_START", "GAME_STARTED", "SYNC", "GAME_ACTION", "GAME_END",
             "PLAYER_LEFT_FINISHED_GAME", "ERROR", "ROLL_DICE"
         )
         val actual = MessageType.entries.map { it.name }.toSet()

--- a/src/test/kotlin/org/machikoro/server/dto/ChatMessageTests.kt
+++ b/src/test/kotlin/org/machikoro/server/dto/ChatMessageTests.kt
@@ -10,7 +10,7 @@ class ChatMessageTests {
     @Test
     fun messageTypeShouldExposeAllSupportedValues() {
         val expected = setOf(
-            "CHAT", "JOIN", "LEAVE", "GAME_START", "GAME_STARTED", "SYNC", "GAME_ACTION", "GAME_END",
+            "CHAT", "JOIN", "LEAVE", "LOBBY_CREATED", "GAME_START", "GAME_STARTED", "SYNC", "GAME_ACTION", "GAME_END",
             "PLAYER_LEFT_FINISHED_GAME", "ERROR", "ROLL_DICE"
         )
         val actual = MessageType.entries.map { it.name }.toSet()

--- a/src/test/kotlin/org/machikoro/server/service/GameSyncServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GameSyncServiceTest.kt
@@ -3,6 +3,7 @@ package org.machikoro.server.service
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.machikoro.server.dao.GameDao
@@ -49,6 +50,15 @@ class GameSyncServiceTest {
     }
 
     @Test
+    fun `findActiveInProgressGameId returns null when PlayerDao returns null`() {
+        whenever(playerDao.findActiveGameIdByUserId(8)).thenReturn(null)
+
+        assertNull(service.findActiveInProgressGameId(8))
+        
+        verify(playerDao).findActiveGameIdByUserId(8)
+    }
+
+    @Test
     fun `buildSnapshot returns players cards and sorted turnOrder`() {
         val gameId = 10
         val p1 = PlayerModel(id = 1, gameId = gameId, userId = 11, turnOrder = 1, coins = 3, lastSeenAt = null)
@@ -66,6 +76,20 @@ class GameSyncServiceTest {
         assertEquals(listOf(2, 1), snapshot.turnOrder)
         assertEquals(1, snapshot.playerCards[1]?.size)
         assertTrue(snapshot.playerCards[2].isNullOrEmpty())
+    }
+
+    @Test
+    fun `buildSnapshot works with zero players`() {
+        val gameId = 11
+        whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.IN_PROGRESS))
+        whenever(playerDao.getPlayers(gameId)).thenReturn(emptyList())
+
+        val snapshot = service.buildSnapshot(gameId)
+
+        assertEquals(gameId, snapshot.game.id)
+        assertTrue(snapshot.players.isEmpty())
+        assertTrue(snapshot.turnOrder.isEmpty())
+        assertTrue(snapshot.playerCards.isEmpty())
     }
 
     @Test
@@ -99,4 +123,3 @@ class GameSyncServiceTest {
         assertFalse(service.isUserInGame(50, 6))
     }
 }
-

--- a/src/test/kotlin/org/machikoro/server/service/GameSyncServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GameSyncServiceTest.kt
@@ -1,0 +1,102 @@
+package org.machikoro.server.service
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.machikoro.server.dao.GameDao
+import org.machikoro.server.dao.PlayerCardDao
+import org.machikoro.server.dao.PlayerDao
+import org.machikoro.server.domain.enums.CardType
+import org.machikoro.server.domain.enums.GameStatus
+import org.machikoro.server.domain.enums.TurnPhase
+import org.machikoro.server.domain.models.GameModel
+import org.machikoro.server.domain.models.PlayerCardModel
+import org.machikoro.server.domain.models.PlayerModel
+import org.machikoro.server.exception.GameNotFoundException
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class GameSyncServiceTest {
+
+    private val gameDao = mock<GameDao>()
+    private val playerDao = mock<PlayerDao>()
+    private val playerCardDao = mock<PlayerCardDao>()
+    private val service = GameSyncService(gameDao, playerDao, playerCardDao)
+
+    private fun game(id: Int, status: GameStatus) = GameModel(
+        id = id,
+        status = status,
+        hostUserId = 1,
+        lobbyCode = "ABC1234",
+        maxPlayers = 4,
+        currentTurnIndex = 0,
+        turnPhase = TurnPhase.ROLL_DICE,
+        lastDiceRoll = null,
+        roundNumber = 1,
+        hasPurchasedThisTurn = false,
+    )
+
+    @Test
+    fun `findActiveInProgressGameId delegates to PlayerDao`() {
+        whenever(playerDao.findActiveGameIdByUserId(7)).thenReturn(99)
+
+        assertEquals(99, service.findActiveInProgressGameId(7))
+
+        verify(playerDao).findActiveGameIdByUserId(7)
+    }
+
+    @Test
+    fun `buildSnapshot returns players cards and sorted turnOrder`() {
+        val gameId = 10
+        val p1 = PlayerModel(id = 1, gameId = gameId, userId = 11, turnOrder = 1, coins = 3, lastSeenAt = null)
+        val p2 = PlayerModel(id = 2, gameId = gameId, userId = 22, turnOrder = 0, coins = 3, lastSeenAt = null)
+
+        whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.IN_PROGRESS))
+        whenever(playerDao.getPlayers(gameId)).thenReturn(listOf(p1, p2))
+        whenever(playerCardDao.findByPlayerId(1)).thenReturn(listOf(PlayerCardModel(1, CardType.BAKERY, 1)))
+        whenever(playerCardDao.findByPlayerId(2)).thenReturn(emptyList())
+
+        val snapshot = service.buildSnapshot(gameId)
+
+        assertEquals(gameId, snapshot.game.id)
+        assertEquals(listOf(p1, p2), snapshot.players)
+        assertEquals(listOf(2, 1), snapshot.turnOrder)
+        assertEquals(1, snapshot.playerCards[1]?.size)
+        assertTrue(snapshot.playerCards[2].isNullOrEmpty())
+    }
+
+    @Test
+    fun `buildSnapshot throws when game is missing`() {
+        whenever(gameDao.findById(404)).thenReturn(null)
+
+        assertThrows<GameNotFoundException> {
+            service.buildSnapshot(404)
+        }
+    }
+
+    @Test
+    fun `isInProgress returns true only for IN_PROGRESS games`() {
+        whenever(gameDao.findById(1)).thenReturn(game(1, GameStatus.IN_PROGRESS))
+        whenever(gameDao.findById(2)).thenReturn(game(2, GameStatus.WAITING))
+        whenever(gameDao.findById(3)).thenReturn(null)
+
+        assertTrue(service.isInProgress(1))
+        assertFalse(service.isInProgress(2))
+        assertFalse(service.isInProgress(3))
+    }
+
+    @Test
+    fun `isUserInGame delegates to PlayerDao presence`() {
+        whenever(playerDao.findByGameIdAndUserId(5, 50)).thenReturn(
+            PlayerModel(id = 9, gameId = 5, userId = 50, turnOrder = 0, coins = 3, lastSeenAt = null)
+        )
+        whenever(playerDao.findByGameIdAndUserId(6, 50)).thenReturn(null)
+
+        assertTrue(service.isUserInGame(50, 5))
+        assertFalse(service.isUserInGame(50, 6))
+    }
+}
+

--- a/src/test/kotlin/org/machikoro/server/service/GameSyncServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GameSyncServiceTest.kt
@@ -66,8 +66,13 @@ class GameSyncServiceTest {
 
         whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.IN_PROGRESS))
         whenever(playerDao.getPlayers(gameId)).thenReturn(listOf(p1, p2))
-        whenever(playerCardDao.findByPlayerId(1)).thenReturn(listOf(PlayerCardModel(1, CardType.BAKERY, 1)))
-        whenever(playerCardDao.findByPlayerId(2)).thenReturn(emptyList())
+        // Bulk fetch: one query for all player IDs
+        whenever(playerCardDao.findByPlayerIds(listOf(1, 2))).thenReturn(
+            mapOf(
+                1 to listOf(PlayerCardModel(1, CardType.BAKERY, 1)),
+                // player 2 has no cards — absent from the map
+            )
+        )
 
         val snapshot = service.buildSnapshot(gameId)
 


### PR DESCRIPTION
This pull request introduces a robust reconnect and game state synchronization mechanism for players in active games. The main focus is ensuring that reconnecting users are reliably mapped back to their in-progress games and immediately receive an up-to-date game state snapshot, even in the presence of race conditions during game transitions. The changes include a new service for game state sync, enhancements to the WebSocket controller, supporting data access methods, and comprehensive tests.

**Reconnect and Game State Synchronization Improvements:**

* Added a new `GameSyncService` to encapsulate logic for finding a user's active in-progress game, checking membership, and building a complete game state snapshot for syncing reconnecting players.
* Enhanced `WebSocketController` to:
  * Prefer mapping reconnecting users to their server-tracked active game, handling transition races, and sending a SYNC message with the current game state to the user.
  * Introduce an explicit `/game.sync` endpoint for clients to request a state sync if they missed a game start event, with appropriate validation and state publishing.
  * Inject new dependencies: `GameSyncService` and `SimpMessagingTemplate` for message delivery. [[1]](diffhunk://#diff-1d1b7da08123cc3b5e3fece492bdb23f61c81e7446f51636936d90e564fe2befR4-R16) [[2]](diffhunk://#diff-1d1b7da08123cc3b5e3fece492bdb23f61c81e7446f51636936d90e564fe2befR25-R26)

**Data Layer Enhancements:**

* Added `findByGameIdAndUserId` and `findActiveGameIdByUserId` methods to `PlayerDao` to support efficient lookup of a user's current game and prevent duplicate player entries on reconnect.
* Updated `LobbyService` to avoid re-inserting players who are already in a game (reconnect path) and to protect against concurrent duplicate inserts.

**Protocol and DTO Updates:**

* Introduced `SyncGameRequest` DTO for explicit sync requests.
* Added `SYNC` as a new message type in `MessageType` to represent state sync events.
* Updated message type tests to include the new `SYNC` type.

**Testing Improvements:**

* Added comprehensive tests to `WebSocketControllerTests` covering:
  * Reconnect mapping and sync message delivery
  * Handling of race conditions during game start
  * Explicit sync endpoint behavior for various scenarios (valid, unauthorized, missing session, etc.)

These changes collectively ensure that reconnecting players experience a seamless transition back into their games, with immediate and accurate state synchronization.