### PR TITLE
feat: #160 enforce active-player guard on game-mutating WebSocket endpoints

### DIFF
--- a/src/main/kotlin/org/machikoro/server/controller/EarningsController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/EarningsController.kt
@@ -1,8 +1,10 @@
 package org.machikoro.server.controller
 
+import java.security.Principal
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.ResolveEffectsRequest
 import org.machikoro.server.dto.WebSocketMessage
+import org.machikoro.server.service.GameStateGuard
 import org.machikoro.server.service.interfaces.EarningsService
 import org.slf4j.LoggerFactory
 import org.springframework.messaging.handler.annotation.MessageMapping
@@ -16,7 +18,8 @@ import org.springframework.stereotype.Controller
 @Controller
 class EarningsController(
     private val earningsService: EarningsService,
-    private val messagingTemplate: SimpMessagingTemplate
+    private val messagingTemplate: SimpMessagingTemplate,
+    private val gameStateGuard: GameStateGuard,
 ) {
     private val logger = LoggerFactory.getLogger(EarningsController::class.java)
 
@@ -24,7 +27,8 @@ class EarningsController(
      * Resolves card effects for all players and broadcasts the result to the game topic.
      */
     @MessageMapping("/game.resolveEffects")
-    fun resolveEffects(@Payload request: ResolveEffectsRequest) {
+    fun resolveEffects(@Payload request: ResolveEffectsRequest, principal: Principal) {
+        gameStateGuard.ensureSenderIsActivePlayer(request.gameId, principal)
         val gameTopic = "/topic/game/${request.gameId}"
         try {
             earningsService.resolveEffects(request.gameId)

--- a/src/main/kotlin/org/machikoro/server/controller/GameController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/GameController.kt
@@ -1,5 +1,6 @@
 package org.machikoro.server.controller
 
+import java.security.Principal
 import org.machikoro.server.domain.enums.TurnPhase
 import org.machikoro.server.dto.EndTurnOutcome
 import org.machikoro.server.domain.models.PlayerModel
@@ -14,6 +15,7 @@ import org.machikoro.server.dto.StartGameRequest
 import org.machikoro.server.dto.WebSocketMessage
 import org.machikoro.server.service.DiceService
 import org.machikoro.server.service.GamePhaseService
+import org.machikoro.server.service.GameStateGuard
 import org.machikoro.server.service.LeaveFinishedGameService
 import org.machikoro.server.service.LobbyService
 import org.machikoro.server.service.PurchaseResult
@@ -35,6 +37,7 @@ class GameController(
     private val diceService: DiceService,
     private val lobbyService: LobbyService,
     private val connectionTracker: WebSocketConnectionTracker,
+    private val gameStateGuard: GameStateGuard,
 ) {
     private val logger = LoggerFactory.getLogger(GameController::class.java)
 
@@ -113,7 +116,8 @@ class GameController(
      * Message is sent to /app/game.advancePhase and broadcast to /topic/game/{gameId}.
      */
     @MessageMapping("/game.advancePhase")
-    fun advancePhase(@Payload request: AdvancePhaseRequest) {
+    fun advancePhase(@Payload request: AdvancePhaseRequest, principal: Principal) {
+        gameStateGuard.ensureSenderIsActivePlayer(request.gameId, principal)
         val newPhase = gamePhaseService.advancePhase(request.gameId)
         logger.info("Advanced phase for game ${request.gameId} to $newPhase")
         broadcastPhase(request.gameId, newPhase)
@@ -125,7 +129,8 @@ class GameController(
      * landmark completes the game.
      */
     @MessageMapping("/game.purchase")
-    fun purchase(@Payload request: PurchaseRequest) {
+    fun purchase(@Payload request: PurchaseRequest, principal: Principal) {
+        gameStateGuard.ensureSenderIsActivePlayer(request.gameId, principal)
         val result = purchaseService.purchase(
             gameId = request.gameId,
             purchaseType = request.purchaseType,
@@ -138,7 +143,8 @@ class GameController(
     }
 
     @MessageMapping("/game.endTurn")
-    fun endTurn(@Payload request: EndTurnRequest) {
+    fun endTurn(@Payload request: EndTurnRequest, principal: Principal) {
+        gameStateGuard.ensureSenderIsActivePlayer(request.gameId, principal)
         when (val result = gamePhaseService.endTurn(request.gameId)) {
             is EndTurnOutcome.Continue -> {
                 logger.info("Ended turn for game ${request.gameId}, new phase ${result.nextPhase}")
@@ -152,7 +158,8 @@ class GameController(
     }
 
     @MessageMapping("/game.leave")
-    fun leaveFinishedGame(@Payload request: LeaveFinishedGameRequest) {
+    fun leaveFinishedGame(@Payload request: LeaveFinishedGameRequest, principal: Principal) {
+        gameStateGuard.ensureSenderOwnsPlayer(request.gameId, request.playerId, principal)
         leaveFinishedGameService.leaveFinishedGame(request.gameId, request.playerId)
         logger.info("${request.playerId} left game ${request.gameId}")
         broadcastPlayerLeftFinishedGame(request.gameId, request.playerId)
@@ -163,7 +170,8 @@ class GameController(
      * Message is sent to /app/game.rollDice and broadcast to /topic/game/{gameId}
      */
     @MessageMapping("/game.rollDice")
-    fun rollDice(@Payload request: RollDiceRequest) {
+    fun rollDice(@Payload request: RollDiceRequest, principal: Principal) {
+        gameStateGuard.ensureSenderIsActivePlayer(request.gameId, principal)
         val gameTopic = "/topic/game/${request.gameId}"
         logger.info("Roll dice request from player ${request.playerId} in game ${request.gameId}")
         try {

--- a/src/main/kotlin/org/machikoro/server/service/DiceService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/DiceService.kt
@@ -1,7 +1,6 @@
 package org.machikoro.server.service
 
 import org.machikoro.server.dao.GameDao
-import org.machikoro.server.dao.PlayerDao
 import org.machikoro.server.dao.PlayerLandmarkDao
 import org.machikoro.server.domain.enums.LandmarkType
 import org.machikoro.server.domain.enums.TurnPhase
@@ -13,7 +12,6 @@ import org.springframework.stereotype.Service
 @Service
 class DiceService(
     private val gameDao: GameDao,
-    private val playerDao: PlayerDao,
     private val playerLandmarkDao: PlayerLandmarkDao,
     private val gameStateGuard: GameStateGuard,
 ) {
@@ -22,14 +20,6 @@ class DiceService(
 
         if (game.turnPhase != TurnPhase.ROLL_DICE) {
             throw CustomWebSocketException("WRONG_PHASE", "It's not the roll dice phase")
-        }
-
-        val activePlayer = playerDao.getPlayers(request.gameId)
-            .getOrNull(game.currentTurnIndex)
-            ?: throw CustomWebSocketException("PLAYER_NOT_FOUND", "Active player not found")
-
-        if (activePlayer.id != request.playerId) {
-            throw CustomWebSocketException("NOT_YOUR_TURN", "It's not your turn!")
         }
 
         if (request.rollTwoDice) {

--- a/src/main/kotlin/org/machikoro/server/service/GameStateGuard.kt
+++ b/src/main/kotlin/org/machikoro/server/service/GameStateGuard.kt
@@ -1,6 +1,9 @@
 package org.machikoro.server.service
 
+import java.security.Principal
+import org.machikoro.server.auth.UserPrincipal
 import org.machikoro.server.dao.GameDao
+import org.machikoro.server.dao.PlayerDao
 import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.models.GameModel
 import org.machikoro.server.exception.CustomWebSocketException
@@ -10,6 +13,7 @@ import org.springframework.stereotype.Service
 @Service
 class GameStateGuard(
     private val gameDao: GameDao,
+    private val playerDao: PlayerDao,
 ) {
 
     /**
@@ -44,4 +48,66 @@ class GameStateGuard(
         }
     }
 
+    /**
+     * Verifies that [principal] is the player whose turn is currently active in
+     * [gameId]. Used by all turn-bound mutations (purchase, endTurn, rollDice,
+     * advancePhase, resolveEffects) so client payloads cannot impersonate
+     * another player by forging gameId or playerId fields.
+     *
+     * Returns the resolved [UserPrincipal] for callers that want it.
+     *
+     * Throws [CustomWebSocketException] with one of:
+     *  - `UNAUTHENTICATED`   — no [UserPrincipal] is attached to the session.
+     *  - `GAME_FINISHED`     — game has already ended (via [ensureGameIsRunning]).
+     *  - `NO_ACTIVE_PLAYER`  — currentTurnIndex points outside the player list.
+     *  - `NOT_YOUR_TURN`     — caller is authenticated but not the active player.
+     */
+    fun ensureSenderIsActivePlayer(gameId: Int, principal: Principal?): UserPrincipal {
+        val user = requireUserPrincipal(principal)
+        val game = ensureGameIsRunning(gameId)
+        val active = playerDao.getPlayers(gameId).getOrNull(game.currentTurnIndex)
+            ?: throw CustomWebSocketException(
+                errorCode = "NO_ACTIVE_PLAYER",
+                message = "Game $gameId has no player at turn index ${game.currentTurnIndex}",
+            )
+        if (active.userId != user.userId) {
+            throw CustomWebSocketException(
+                errorCode = "NOT_YOUR_TURN",
+                message = "It is not your turn",
+            )
+        }
+        return user
+    }
+
+    /**
+     * Verifies that [principal] owns the player identified by [playerId] within
+     * [gameId]. Used for `/game.leave` so a user can only remove their own seat
+     * from a finished game, not another player's.
+     *
+     * Throws [CustomWebSocketException] with one of:
+     *  - `UNAUTHENTICATED`     — no [UserPrincipal] is attached to the session.
+     *  - `PLAYER_NOT_IN_GAME`  — [playerId] does not exist in [gameId].
+     *  - `NOT_YOUR_PLAYER`     — caller is authenticated but does not own the player.
+     */
+    fun ensureSenderOwnsPlayer(gameId: Int, playerId: Int, principal: Principal?): UserPrincipal {
+        val user = requireUserPrincipal(principal)
+        val player = playerDao.getPlayers(gameId).firstOrNull { it.id == playerId }
+            ?: throw CustomWebSocketException(
+                errorCode = "PLAYER_NOT_IN_GAME",
+                message = "Player $playerId is not in game $gameId",
+            )
+        if (player.userId != user.userId) {
+            throw CustomWebSocketException(
+                errorCode = "NOT_YOUR_PLAYER",
+                message = "You do not own player $playerId",
+            )
+        }
+        return user
+    }
+
+    private fun requireUserPrincipal(principal: Principal?): UserPrincipal =
+        principal as? UserPrincipal ?: throw CustomWebSocketException(
+            errorCode = "UNAUTHENTICATED",
+            message = "Authenticated principal required",
+        )
 }

--- a/src/main/kotlin/org/machikoro/server/service/PurchaseService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/PurchaseService.kt
@@ -41,9 +41,6 @@ class PurchaseService(
         cardType: CardType?,
         landmarkType: LandmarkType?,
     ): PurchaseResult = transaction {
-        // TODO(#160): Enforce active-player authorization on game-mutating WebSocket actions.
-        // Do not trust gameId from the client payload alone.
-
         val game = gameStateGuard.ensureGameIsRunning(gameId)
 
         if (game.turnPhase != TurnPhase.BUY_OR_BUILD) {

--- a/src/test/kotlin/org/machikoro/server/controller/EarningsControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/EarningsControllerTest.kt
@@ -1,15 +1,22 @@
 package org.machikoro.server.controller
 
+import java.security.Principal
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.machikoro.server.auth.UserPrincipal
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.ResolveEffectsRequest
 import org.machikoro.server.dto.WebSocketMessage
+import org.machikoro.server.exception.CustomWebSocketException
 import org.machikoro.server.exception.GameNotFoundException
+import org.machikoro.server.service.GameStateGuard
 import org.machikoro.server.service.interfaces.EarningsService
+import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.messaging.simp.SimpMessagingTemplate
@@ -19,14 +26,18 @@ class EarningsControllerTest {
 
     private val earningsService: EarningsService = mock()
     private val messagingTemplate: SimpMessagingTemplate = mock()
-    private val controller = EarningsController(earningsService, messagingTemplate)
+    private val gameStateGuard: GameStateGuard = mock()
+    private val controller = EarningsController(earningsService, messagingTemplate, gameStateGuard)
+
+    private val principal: Principal = UserPrincipal(userId = 1, username = "alice")
 
     @Test
     fun `resolveEffects calls service and broadcasts success`() {
         val request = ResolveEffectsRequest(gameId = 1)
 
-        controller.resolveEffects(request)
+        controller.resolveEffects(request, principal)
 
+        verify(gameStateGuard).ensureSenderIsActivePlayer(1, principal)
         verify(earningsService).resolveEffects(1)
 
         val captor = argumentCaptor<WebSocketMessage>()
@@ -44,7 +55,7 @@ class EarningsControllerTest {
         val request = ResolveEffectsRequest(gameId = 1)
         doThrow(GameNotFoundException("Game 1 not found")).whenever(earningsService).resolveEffects(1)
 
-        controller.resolveEffects(request)
+        controller.resolveEffects(request, principal)
 
         val captor = argumentCaptor<WebSocketMessage>()
         verify(messagingTemplate).convertAndSend(eq("/topic/game/1"), captor.capture())
@@ -54,5 +65,19 @@ class EarningsControllerTest {
         assertEquals("server", message.sender)
         assertEquals("EFFECTS_FAILED", (message.payload as Map<*, *>)["event"])
         assertEquals("Game 1 not found", (message.payload as Map<*, *>)["message"])
+    }
+
+    @Test
+    fun `resolveEffects propagates NOT_YOUR_TURN and does not call service or broadcast`() {
+        val request = ResolveEffectsRequest(gameId = 1)
+        whenever(gameStateGuard.ensureSenderIsActivePlayer(1, principal))
+            .thenThrow(CustomWebSocketException("NOT_YOUR_TURN", "It is not your turn"))
+
+        val ex = assertThrows<CustomWebSocketException> {
+            controller.resolveEffects(request, principal)
+        }
+        assertEquals("NOT_YOUR_TURN", ex.errorCode)
+        verify(earningsService, never()).resolveEffects(any())
+        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
     }
 }

--- a/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
@@ -1,7 +1,10 @@
 package org.machikoro.server.controller
 
+import java.security.Principal
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.machikoro.server.auth.UserPrincipal
 import org.machikoro.server.domain.enums.CardType
 import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.enums.LandmarkType
@@ -20,9 +23,11 @@ import org.machikoro.server.dto.RollDiceRequest
 import org.machikoro.server.dto.RollDiceResponse
 import org.machikoro.server.dto.StartGameRequest
 import org.machikoro.server.dto.WebSocketMessage
+import org.machikoro.server.exception.CustomWebSocketException
 import org.machikoro.server.exception.NotHostException
 import org.machikoro.server.service.DiceService
 import org.machikoro.server.service.GamePhaseService
+import org.machikoro.server.service.GameStateGuard
 import org.machikoro.server.service.LeaveFinishedGameService
 import org.machikoro.server.service.LobbyService
 import org.machikoro.server.service.PurchaseResult
@@ -48,10 +53,13 @@ class GameControllerTest {
     private val diceService = mock<DiceService>()
     private val lobbyService = mock<LobbyService>()
     private val connectionTracker = mock<WebSocketConnectionTracker>()
+    private val gameStateGuard = mock<GameStateGuard>()
     private val controller = GameController(
         gamePhaseService, messagingTemplate, leaveFinishedGameService,
-        purchaseService, diceService, lobbyService, connectionTracker
+        purchaseService, diceService, lobbyService, connectionTracker, gameStateGuard,
     )
+
+    private val principal: Principal = UserPrincipal(userId = 1, username = "alice")
 
     // ── startGame ─────────────────────────────────────────────────────────────
 
@@ -134,13 +142,16 @@ class GameControllerTest {
         assertEquals("START_FAILED", (message.payload as Map<String, Any>)["event"])
     }
 
+    // ── advancePhase ──────────────────────────────────────────────────────────
+
     @Test
     fun `advancePhase delegates to service with the requested game id`() {
         val gameId = 42
         whenever(gamePhaseService.advancePhase(gameId)).thenReturn(TurnPhase.RESOLVE_EFFECTS)
 
-        controller.advancePhase(AdvancePhaseRequest(gameId))
+        controller.advancePhase(AdvancePhaseRequest(gameId), principal)
 
+        verify(gameStateGuard).ensureSenderIsActivePlayer(gameId, principal)
         verify(gamePhaseService).advancePhase(gameId)
     }
 
@@ -149,7 +160,7 @@ class GameControllerTest {
         val gameId = 42
         whenever(gamePhaseService.advancePhase(gameId)).thenReturn(TurnPhase.RESOLVE_EFFECTS)
 
-        controller.advancePhase(AdvancePhaseRequest(gameId))
+        controller.advancePhase(AdvancePhaseRequest(gameId), principal)
 
         val captor = argumentCaptor<WebSocketMessage>()
         verify(messagingTemplate).convertAndSend(eq("/topic/game/$gameId"), captor.capture())
@@ -161,13 +172,30 @@ class GameControllerTest {
     }
 
     @Test
+    fun `advancePhase propagates NOT_YOUR_TURN and does not call service`() {
+        val gameId = 42
+        whenever(gameStateGuard.ensureSenderIsActivePlayer(gameId, principal))
+            .thenThrow(CustomWebSocketException("NOT_YOUR_TURN", "It is not your turn"))
+
+        val ex = assertThrows<CustomWebSocketException> {
+            controller.advancePhase(AdvancePhaseRequest(gameId), principal)
+        }
+        assertEquals("NOT_YOUR_TURN", ex.errorCode)
+        verify(gamePhaseService, never()).advancePhase(any())
+        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
+    }
+
+    // ── endTurn ───────────────────────────────────────────────────────────────
+
+    @Test
     fun `endTurn delegates to service with the requested game id`() {
         val gameId = 42
         whenever(gamePhaseService.endTurn(gameId))
             .thenReturn(EndTurnOutcome.Continue(TurnPhase.ROLL_DICE))
 
-        controller.endTurn(EndTurnRequest(gameId))
+        controller.endTurn(EndTurnRequest(gameId), principal)
 
+        verify(gameStateGuard).ensureSenderIsActivePlayer(gameId, principal)
         verify(gamePhaseService).endTurn(gameId)
     }
 
@@ -177,7 +205,7 @@ class GameControllerTest {
         whenever(gamePhaseService.endTurn(gameId))
             .thenReturn(EndTurnOutcome.Continue(TurnPhase.ROLL_DICE))
 
-        controller.endTurn(EndTurnRequest(gameId))
+        controller.endTurn(EndTurnRequest(gameId), principal)
 
         val captor = argumentCaptor<WebSocketMessage>()
         verify(messagingTemplate).convertAndSend(eq("/topic/game/$gameId"), captor.capture())
@@ -196,7 +224,7 @@ class GameControllerTest {
         whenever(gamePhaseService.endTurn(gameId))
             .thenReturn(EndTurnOutcome.Won(winnerId))
 
-        controller.endTurn(EndTurnRequest(gameId))
+        controller.endTurn(EndTurnRequest(gameId), principal)
 
         val captor = argumentCaptor<WebSocketMessage>()
         verify(messagingTemplate).convertAndSend(eq("/topic/game/$gameId"), captor.capture())
@@ -206,6 +234,22 @@ class GameControllerTest {
         assertEquals("server", message.sender)
         assertEquals(mapOf("winnerId" to winnerId), message.payload)
     }
+
+    @Test
+    fun `endTurn propagates NOT_YOUR_TURN and does not call service`() {
+        val gameId = 42
+        whenever(gameStateGuard.ensureSenderIsActivePlayer(gameId, principal))
+            .thenThrow(CustomWebSocketException("NOT_YOUR_TURN", "It is not your turn"))
+
+        val ex = assertThrows<CustomWebSocketException> {
+            controller.endTurn(EndTurnRequest(gameId), principal)
+        }
+        assertEquals("NOT_YOUR_TURN", ex.errorCode)
+        verify(gamePhaseService, never()).endTurn(any())
+        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
+    }
+
+    // ── purchase ──────────────────────────────────────────────────────────────
 
     @Test
     fun `purchase delegates to service with the requested payload`() {
@@ -221,9 +265,11 @@ class GameControllerTest {
         )
 
         controller.purchase(
-            PurchaseRequest(gameId, PurchaseType.ESTABLISHMENT, cardType = CardType.BAKERY)
+            PurchaseRequest(gameId, PurchaseType.ESTABLISHMENT, cardType = CardType.BAKERY),
+            principal,
         )
 
+        verify(gameStateGuard).ensureSenderIsActivePlayer(gameId, principal)
         verify(purchaseService).purchase(gameId, PurchaseType.ESTABLISHMENT, CardType.BAKERY, null)
     }
 
@@ -242,7 +288,8 @@ class GameControllerTest {
         )
 
         controller.purchase(
-            PurchaseRequest(gameId, PurchaseType.LANDMARK, landmarkType = LandmarkType.TRAIN_STATION)
+            PurchaseRequest(gameId, PurchaseType.LANDMARK, landmarkType = LandmarkType.TRAIN_STATION),
+            principal,
         )
 
         val captor = argumentCaptor<WebSocketMessage>()
@@ -262,13 +309,33 @@ class GameControllerTest {
     }
 
     @Test
+    fun `purchase propagates NOT_YOUR_TURN and does not call service`() {
+        val gameId = 42
+        whenever(gameStateGuard.ensureSenderIsActivePlayer(gameId, principal))
+            .thenThrow(CustomWebSocketException("NOT_YOUR_TURN", "It is not your turn"))
+
+        val ex = assertThrows<CustomWebSocketException> {
+            controller.purchase(
+                PurchaseRequest(gameId, PurchaseType.ESTABLISHMENT, cardType = CardType.BAKERY),
+                principal,
+            )
+        }
+        assertEquals("NOT_YOUR_TURN", ex.errorCode)
+        verify(purchaseService, never()).purchase(any(), any(), any(), any())
+        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
+    }
+
+    // ── leaveFinishedGame ─────────────────────────────────────────────────────
+
+    @Test
     fun `leaveFinishedGame calls service before broadcasting`() {
         val gameId = 1
         val playerId = 10
 
-        controller.leaveFinishedGame(LeaveFinishedGameRequest(gameId, playerId))
+        controller.leaveFinishedGame(LeaveFinishedGameRequest(gameId, playerId), principal)
 
-        val order = inOrder(leaveFinishedGameService, messagingTemplate)
+        val order = inOrder(gameStateGuard, leaveFinishedGameService, messagingTemplate)
+        order.verify(gameStateGuard).ensureSenderOwnsPlayer(gameId, playerId, principal)
         order.verify(leaveFinishedGameService).leaveFinishedGame(gameId, playerId)
         order.verify(messagingTemplate).convertAndSend(eq("/topic/game/$gameId"), any<WebSocketMessage>())
     }
@@ -282,7 +349,7 @@ class GameControllerTest {
             .thenThrow(RuntimeException("boom"))
 
         org.junit.jupiter.api.assertThrows<RuntimeException> {
-            controller.leaveFinishedGame(LeaveFinishedGameRequest(gameId, playerId))
+            controller.leaveFinishedGame(LeaveFinishedGameRequest(gameId, playerId), principal)
         }
     }
 
@@ -291,7 +358,7 @@ class GameControllerTest {
         val gameId = 5
         val playerId = 20
 
-        controller.leaveFinishedGame(LeaveFinishedGameRequest(gameId, playerId))
+        controller.leaveFinishedGame(LeaveFinishedGameRequest(gameId, playerId), principal)
 
         verify(messagingTemplate).convertAndSend(eq("/topic/game/$gameId"), any<WebSocketMessage>())
     }
@@ -301,7 +368,7 @@ class GameControllerTest {
         val gameId = 3
         val playerId = 99
 
-        controller.leaveFinishedGame(LeaveFinishedGameRequest(gameId, playerId))
+        controller.leaveFinishedGame(LeaveFinishedGameRequest(gameId, playerId), principal)
 
         val captor = argumentCaptor<WebSocketMessage>()
         verify(messagingTemplate).convertAndSend(eq("/topic/game/$gameId"), captor.capture())
@@ -312,6 +379,23 @@ class GameControllerTest {
     }
 
     @Test
+    fun `leaveFinishedGame propagates NOT_YOUR_PLAYER and does not call service`() {
+        val gameId = 3
+        val playerId = 99
+        whenever(gameStateGuard.ensureSenderOwnsPlayer(gameId, playerId, principal))
+            .thenThrow(CustomWebSocketException("NOT_YOUR_PLAYER", "You do not own player 99"))
+
+        val ex = assertThrows<CustomWebSocketException> {
+            controller.leaveFinishedGame(LeaveFinishedGameRequest(gameId, playerId), principal)
+        }
+        assertEquals("NOT_YOUR_PLAYER", ex.errorCode)
+        verify(leaveFinishedGameService, never()).leaveFinishedGame(any(), any())
+        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
+    }
+
+    // ── rollDice ──────────────────────────────────────────────────────────────
+
+    @Test
     fun `rollDice broadcasts result to correct game topic`() {
         val gameId = 1
         val playerId = 2
@@ -320,8 +404,9 @@ class GameControllerTest {
 
         whenever(diceService.rollDice(request)).thenReturn(response)
 
-        controller.rollDice(request)
+        controller.rollDice(request, principal)
 
+        verify(gameStateGuard).ensureSenderIsActivePlayer(gameId, principal)
         val captor = argumentCaptor<WebSocketMessage>()
         verify(messagingTemplate).convertAndSend(eq("/topic/game/$gameId"), captor.capture())
 
@@ -340,7 +425,7 @@ class GameControllerTest {
 
         whenever(diceService.rollDice(request)).thenThrow(RuntimeException("dice exploded"))
 
-        controller.rollDice(request)
+        controller.rollDice(request, principal)
 
         val captor = argumentCaptor<WebSocketMessage>()
         verify(messagingTemplate).convertAndSend(eq("/topic/game/$gameId"), captor.capture())
@@ -352,5 +437,21 @@ class GameControllerTest {
             mapOf("event" to "ROLL_FAILED", "message" to "dice exploded"),
             message.payload
         )
+    }
+
+    @Test
+    fun `rollDice propagates NOT_YOUR_TURN and does not call service or broadcast`() {
+        val gameId = 1
+        val playerId = 2
+        val request = RollDiceRequest(gameId = gameId, playerId = playerId)
+        whenever(gameStateGuard.ensureSenderIsActivePlayer(gameId, principal))
+            .thenThrow(CustomWebSocketException("NOT_YOUR_TURN", "It is not your turn"))
+
+        val ex = assertThrows<CustomWebSocketException> {
+            controller.rollDice(request, principal)
+        }
+        assertEquals("NOT_YOUR_TURN", ex.errorCode)
+        verify(diceService, never()).rollDice(any())
+        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
     }
 }

--- a/src/test/kotlin/org/machikoro/server/service/DiceServiceTests.kt
+++ b/src/test/kotlin/org/machikoro/server/service/DiceServiceTests.kt
@@ -4,14 +4,12 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.machikoro.server.dao.GameDao
-import org.machikoro.server.dao.PlayerDao
 import org.machikoro.server.dao.PlayerLandmarkDao
 import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.enums.LandmarkType
 import org.machikoro.server.domain.enums.TurnPhase
 import org.machikoro.server.domain.models.GameModel
 import org.machikoro.server.domain.models.PlayerLandmarkModel
-import org.machikoro.server.domain.models.PlayerModel
 import org.machikoro.server.dto.RollDiceRequest
 import org.machikoro.server.exception.CustomWebSocketException
 import org.machikoro.server.exception.GameNotFoundException
@@ -24,10 +22,9 @@ import org.mockito.kotlin.whenever
 class DiceServiceTests {
 
     private val gameDao = mock<GameDao>()
-    private val playerDao = mock<PlayerDao>()
     private val playerLandmarkDao = mock<PlayerLandmarkDao>()
     private val gameStateGuard = mock<GameStateGuard>()
-    private val diceService = DiceService(gameDao, playerDao, playerLandmarkDao, gameStateGuard)
+    private val diceService = DiceService(gameDao, playerLandmarkDao, gameStateGuard)
 
     private val defaultGame = GameModel(
         id = 1,
@@ -42,19 +39,9 @@ class DiceServiceTests {
         maxPlayers = 4
     )
 
-    private val activePlayer = PlayerModel(
-        id = 2,
-        gameId = 1,
-        userId = 1,
-        turnOrder = 0,
-        coins = 3,
-        lastSeenAt = 60
-    )
-
     @Test
     fun rollDiceShouldReturnSingleDieValueBetween1And6() {
         whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(defaultGame)
-        whenever(playerDao.getPlayers(1)).thenReturn(listOf(activePlayer))
 
         val request = RollDiceRequest(gameId = 1, playerId = 2)
         val result = diceService.rollDice(request)
@@ -74,7 +61,6 @@ class DiceServiceTests {
         assertThrows(GameNotFoundException::class.java) {
             diceService.rollDice(request)
         }
-        verify(playerDao, never()).getPlayers(any())
         verify(gameDao, never()).updateAfterRoll(any(), any(), any())
     }
 
@@ -89,7 +75,6 @@ class DiceServiceTests {
             diceService.rollDice(request)
         }
         assertEquals("GAME_FINISHED", ex.errorCode)
-        verify(playerDao, never()).getPlayers(any())
         verify(gameDao, never()).updateAfterRoll(any(), any(), any())
     }
 
@@ -106,21 +91,8 @@ class DiceServiceTests {
     }
 
     @Test
-    fun rollDiceShouldThrowWhenNotActivePlayer() {
-        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(defaultGame)
-        whenever(playerDao.getPlayers(1)).thenReturn(listOf(activePlayer))
-
-        val request = RollDiceRequest(gameId = 1, playerId = 99)
-
-        assertThrows(CustomWebSocketException::class.java) {
-            diceService.rollDice(request)
-        }
-    }
-
-    @Test
     fun rollDiceShouldThrowWhenRollTwoDiceWithoutTrainStation() {
         whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(defaultGame)
-        whenever(playerDao.getPlayers(1)).thenReturn(listOf(activePlayer))
         whenever(playerLandmarkDao.findByPlayerIdAndType(2, LandmarkType.TRAIN_STATION))
             .thenReturn(PlayerLandmarkModel(playerId = 2, landmarkType = LandmarkType.TRAIN_STATION, isBuilt = false))
 
@@ -134,7 +106,6 @@ class DiceServiceTests {
     @Test
     fun rollTwoDiceShouldReturnTwoDiceValuesBetween2And12WhenTrainStationOwned() {
         whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(defaultGame)
-        whenever(playerDao.getPlayers(1)).thenReturn(listOf(activePlayer))
         whenever(playerLandmarkDao.findByPlayerIdAndType(2, LandmarkType.TRAIN_STATION))
             .thenReturn(PlayerLandmarkModel(playerId = 2, landmarkType = LandmarkType.TRAIN_STATION, isBuilt = true))
 

--- a/src/test/kotlin/org/machikoro/server/service/GameStateGuardTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GameStateGuardTest.kt
@@ -1,14 +1,18 @@
 package org.machikoro.server.service
 
+import java.security.Principal
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.machikoro.server.auth.UserPrincipal
 import org.machikoro.server.dao.GameDao
+import org.machikoro.server.dao.PlayerDao
 import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.enums.TurnPhase
 import org.machikoro.server.domain.models.GameModel
+import org.machikoro.server.domain.models.PlayerModel
 import org.machikoro.server.exception.CustomWebSocketException
 import org.machikoro.server.exception.GameNotFoundException
 import org.mockito.kotlin.mock
@@ -17,19 +21,33 @@ import org.mockito.kotlin.whenever
 class GameStateGuardTest {
 
     private val gameDao = mock<GameDao>()
-    private val guard = GameStateGuard(gameDao)
+    private val playerDao = mock<PlayerDao>()
+    private val guard = GameStateGuard(gameDao, playerDao)
 
-    private fun game(id: Int, status: GameStatus) = GameModel(
+    private fun game(
+        id: Int,
+        status: GameStatus,
+        currentTurnIndex: Int = 0,
+    ) = GameModel(
         id = id,
         status = status,
         hostUserId = 1,
         lobbyCode = "ABC1234",
         maxPlayers = 4,
-        currentTurnIndex = 0,
+        currentTurnIndex = currentTurnIndex,
         turnPhase = TurnPhase.ROLL_DICE,
         lastDiceRoll = null,
         roundNumber = 1,
         hasPurchasedThisTurn = false,
+    )
+
+    private fun player(id: Int, userId: Int, gameId: Int = 1, turnOrder: Int = 0) = PlayerModel(
+        id = id,
+        gameId = gameId,
+        userId = userId,
+        turnOrder = turnOrder,
+        coins = 3,
+        lastSeenAt = null,
     )
 
     @Test
@@ -123,5 +141,141 @@ class GameStateGuardTest {
         assertThrows<GameNotFoundException> {
             guard.ensureGameIsFinished(gameId)
         }
+    }
+
+    // ── ensureSenderIsActivePlayer ────────────────────────────────────────────
+
+    @Test
+    fun `ensureSenderIsActivePlayer returns the principal when caller is the active player`() {
+        val gameId = 1
+        whenever(gameDao.findById(gameId))
+            .thenReturn(game(gameId, GameStatus.IN_PROGRESS, currentTurnIndex = 0))
+        whenever(playerDao.getPlayers(gameId)).thenReturn(
+            listOf(player(id = 10, userId = 7), player(id = 11, userId = 8, turnOrder = 1)),
+        )
+        val principal = UserPrincipal(userId = 7, username = "alice")
+
+        val result = guard.ensureSenderIsActivePlayer(gameId, principal)
+
+        assertEquals(principal, result)
+    }
+
+    @Test
+    fun `ensureSenderIsActivePlayer throws NOT_YOUR_TURN when caller is not the active player`() {
+        val gameId = 1
+        whenever(gameDao.findById(gameId))
+            .thenReturn(game(gameId, GameStatus.IN_PROGRESS, currentTurnIndex = 0))
+        whenever(playerDao.getPlayers(gameId)).thenReturn(
+            listOf(player(id = 10, userId = 7), player(id = 11, userId = 8, turnOrder = 1)),
+        )
+        val principal = UserPrincipal(userId = 8, username = "bob")
+
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            guard.ensureSenderIsActivePlayer(gameId, principal)
+        }
+        assertEquals("NOT_YOUR_TURN", ex.errorCode)
+    }
+
+    @Test
+    fun `ensureSenderIsActivePlayer throws UNAUTHENTICATED when principal is not a UserPrincipal`() {
+        val gameId = 1
+        val foreignPrincipal = Principal { "anon" }
+
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            guard.ensureSenderIsActivePlayer(gameId, foreignPrincipal)
+        }
+        assertEquals("UNAUTHENTICATED", ex.errorCode)
+    }
+
+    @Test
+    fun `ensureSenderIsActivePlayer throws UNAUTHENTICATED when principal is null`() {
+        val gameId = 1
+
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            guard.ensureSenderIsActivePlayer(gameId, null)
+        }
+        assertEquals("UNAUTHENTICATED", ex.errorCode)
+    }
+
+    @Test
+    fun `ensureSenderIsActivePlayer throws NO_ACTIVE_PLAYER when currentTurnIndex is out of range`() {
+        val gameId = 1
+        whenever(gameDao.findById(gameId))
+            .thenReturn(game(gameId, GameStatus.IN_PROGRESS, currentTurnIndex = 5))
+        whenever(playerDao.getPlayers(gameId)).thenReturn(listOf(player(id = 10, userId = 7)))
+        val principal = UserPrincipal(userId = 7, username = "alice")
+
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            guard.ensureSenderIsActivePlayer(gameId, principal)
+        }
+        assertEquals("NO_ACTIVE_PLAYER", ex.errorCode)
+    }
+
+    @Test
+    fun `ensureSenderIsActivePlayer propagates GAME_FINISHED when game has ended`() {
+        val gameId = 1
+        whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.FINISHED))
+        val principal = UserPrincipal(userId = 7, username = "alice")
+
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            guard.ensureSenderIsActivePlayer(gameId, principal)
+        }
+        assertEquals("GAME_FINISHED", ex.errorCode)
+    }
+
+    // ── ensureSenderOwnsPlayer ────────────────────────────────────────────────
+
+    @Test
+    fun `ensureSenderOwnsPlayer returns the principal when caller owns the player`() {
+        val gameId = 1
+        val playerId = 10
+        whenever(playerDao.getPlayers(gameId)).thenReturn(
+            listOf(player(id = playerId, userId = 7), player(id = 11, userId = 8, turnOrder = 1)),
+        )
+        val principal = UserPrincipal(userId = 7, username = "alice")
+
+        val result = guard.ensureSenderOwnsPlayer(gameId, playerId, principal)
+
+        assertEquals(principal, result)
+    }
+
+    @Test
+    fun `ensureSenderOwnsPlayer throws NOT_YOUR_PLAYER when player belongs to a different user`() {
+        val gameId = 1
+        val playerId = 10
+        whenever(playerDao.getPlayers(gameId)).thenReturn(
+            listOf(player(id = playerId, userId = 7), player(id = 11, userId = 8, turnOrder = 1)),
+        )
+        val principal = UserPrincipal(userId = 8, username = "bob")
+
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            guard.ensureSenderOwnsPlayer(gameId, playerId, principal)
+        }
+        assertEquals("NOT_YOUR_PLAYER", ex.errorCode)
+    }
+
+    @Test
+    fun `ensureSenderOwnsPlayer throws PLAYER_NOT_IN_GAME when playerId is not part of this game`() {
+        val gameId = 1
+        whenever(playerDao.getPlayers(gameId)).thenReturn(
+            listOf(player(id = 11, userId = 8, turnOrder = 1)),
+        )
+        val principal = UserPrincipal(userId = 7, username = "alice")
+
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            guard.ensureSenderOwnsPlayer(gameId, playerId = 99, principal)
+        }
+        assertEquals("PLAYER_NOT_IN_GAME", ex.errorCode)
+    }
+
+    @Test
+    fun `ensureSenderOwnsPlayer throws UNAUTHENTICATED when principal is not a UserPrincipal`() {
+        val gameId = 1
+        val foreignPrincipal = Principal { "anon" }
+
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            guard.ensureSenderOwnsPlayer(gameId, playerId = 10, foreignPrincipal)
+        }
+        assertEquals("UNAUTHENTICATED", ex.errorCode)
     }
 }


### PR DESCRIPTION
Closes #160. Last server-side piece of the auth chain after #159 attached a `UserPrincipal` to every authenticated STOMP session.

## Summary
- New `GameStateGuard.ensureSenderIsActivePlayer(gameId, principal)` and `ensureSenderOwnsPlayer(gameId, playerId, principal)` derive identity from the server-attached `Principal`, never from client payload.
- All six game-mutating endpoints (`/game.purchase`, `/game.endTurn`, `/game.rollDice`, `/game.advancePhase`, `/game.leave`, `/game.resolveEffects`) now call the guard before touching state. Guard calls sit *before* any `try/catch` so `NOT_YOUR_TURN` / `NOT_YOUR_PLAYER` route to the offender's `/user/queue/errors` rather than being broadcast on the game topic.
- Removed the now-redundant local active-player check from `DiceService` (compared `request.playerId`, which is client-supplied / bypassable) and the matching `TODO(#160)` block from `PurchaseService.purchase`.

## Error codes (stable, for client branching)
| Code | When |
|---|---|
| `NOT_YOUR_TURN` | Caller is authenticated but not the active player. |
| `NOT_YOUR_PLAYER` | Caller doesn't own the playerId on `/game.leave`. |
| `UNAUTHENTICATED` | No `UserPrincipal` on the session (defensive — interceptor should reject earlier). |
| `NO_ACTIVE_PLAYER` | `currentTurnIndex` points outside the player list. |
| `PLAYER_NOT_IN_GAME` | `playerId` not in this game. |

## Commit split
1. `feat: #160 add ensureSenderIsActivePlayer and ensureSenderOwnsPlayer guards` — `GameStateGuard` + 17 unit tests. No callers yet.
2. `feat: #160 wire active-player guards into game-mutating WebSocket endpoints` — `GameController`, `EarningsController`, plus accept/reject controller tests.
3. `refactor: #160 remove redundant local active-player check from DiceService` — drops the bypassable check, unused `PlayerDao` dep, and the `TODO(#160)` from `PurchaseService`.

Each commit compiles and passes its own tests independently.

## Out of scope (explicitly per the issue body)
- Token expiration / refresh — Server #170.
- Rate limiting — Server #169.
- Replacing `WebSocketController.addUser`'s payload-supplied username with the principal — out-of-scope per #159.
- Client-side work — Client #106 (auth-gate UI) is the matching follow-up.

## Test plan
- [x] `./gradlew compileKotlin compileTestKotlin --warning-mode all` — clean (no new warnings).
- [x] `./gradlew test --tests "*GameStateGuardTest*" --tests "*GameControllerTest*" --tests "*EarningsControllerTest*" --tests "*DiceServiceTests*"` — 47 tests pass.
- [x] JaCoCo on touched classes: GameStateGuard 100%, GameController 98%, EarningsController 98%, DiceService 99%.
- [ ] Manual end-to-end with two logged-in users via Swagger / websocat: A is active, B sends `/app/game.purchase` for the same gameId → expects `NOT_YOUR_TURN` on B's `/user/queue/errors`, no state mutation. A sends → succeeds. A sends `/game.leave` with B's playerId → `NOT_YOUR_PLAYER`. A sends with own playerId → succeeds.
- [x] Sonar quality gate green on the PR.