### PR TITLE
180 round counter logic

### DIFF
--- a/src/main/kotlin/org/machikoro/server/controller/GameController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/GameController.kt
@@ -234,9 +234,11 @@ class GameController(
             WebSocketMessage(
                 type = MessageType.GAME_END,
                 sender = "server",
-                payload = mapOf("winnerId" to winnerId,
-                                "roundsPlayed" to roundsPlayed)
-            )
+                payload = mapOf(
+                    "winnerId" to winnerId,
+                    "roundsPlayed" to roundsPlayed,
+                ),
+            ),
         )
     }
 }

--- a/src/main/kotlin/org/machikoro/server/controller/GameController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/GameController.kt
@@ -2,7 +2,6 @@ package org.machikoro.server.controller
 
 import org.machikoro.server.domain.enums.TurnPhase
 import org.machikoro.server.dto.EndTurnOutcome
-import org.machikoro.server.domain.models.PlayerModel
 import org.machikoro.server.dto.AdvancePhaseRequest
 import org.machikoro.server.dto.EndTurnRequest
 import org.machikoro.server.dto.GameStateDto
@@ -146,7 +145,7 @@ class GameController(
             }
             is EndTurnOutcome.Won -> {
                 logger.info("Game ${request.gameId} finished, winner=${result.winnerId}")
-                broadcastWinner(request.gameId, result.winnerId)
+                broadcastWin(request.gameId, result.winnerId)
             }
         }
     }
@@ -229,7 +228,7 @@ class GameController(
         )
     }
 
-    private fun broadcastWinner(gameId: Int, winnerId: Int) {
+    private fun broadcastWin(gameId: Int, winnerId: Int) {
         messagingTemplate.convertAndSend(
             "/topic/game/$gameId",
             WebSocketMessage(

--- a/src/main/kotlin/org/machikoro/server/controller/GameController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/GameController.kt
@@ -145,7 +145,7 @@ class GameController(
             }
             is EndTurnOutcome.Won -> {
                 logger.info("Game ${request.gameId} finished, winner=${result.winnerId}")
-                broadcastWin(request.gameId, result.winnerId)
+                broadcastWin(request.gameId, result.winnerId, result.roundsPlayed)
             }
         }
     }
@@ -228,13 +228,14 @@ class GameController(
         )
     }
 
-    private fun broadcastWin(gameId: Int, winnerId: Int) {
+    private fun broadcastWin(gameId: Int, winnerId: Int, roundsPlayed: Int) {
         messagingTemplate.convertAndSend(
             "/topic/game/$gameId",
             WebSocketMessage(
                 type = MessageType.GAME_END,
                 sender = "server",
-                payload = mapOf("winnerId" to winnerId)
+                payload = mapOf("winnerId" to winnerId,
+                                "roundsPlayed" to roundsPlayed)
             )
         )
     }

--- a/src/main/kotlin/org/machikoro/server/dto/EndTurnOutcome.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/EndTurnOutcome.kt
@@ -19,5 +19,7 @@ sealed interface EndTurnOutcome {
     data class Won(
         @field:Schema(description = "ID of the winning player", example = "1")
         val winnerId: Int,
+        @field:Schema(description = "Number of played rounds", example = "10")
+        val roundsPlayed: Int
     ) : EndTurnOutcome
 }

--- a/src/main/kotlin/org/machikoro/server/dto/EndTurnOutcome.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/EndTurnOutcome.kt
@@ -20,6 +20,6 @@ sealed interface EndTurnOutcome {
         @field:Schema(description = "ID of the winning player", example = "1")
         val winnerId: Int,
         @field:Schema(description = "Number of played rounds", example = "10")
-        val roundsPlayed: Int
+        val roundsPlayed: Int,
     ) : EndTurnOutcome
 }

--- a/src/main/kotlin/org/machikoro/server/service/GamePhaseService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/GamePhaseService.kt
@@ -57,7 +57,7 @@ class GamePhaseService(
         winConditionService.detectWinner(gameId)?.let { winner ->
             userDao.incrementWins(winner.userId)
             finishGame(gameId)
-            return EndTurnOutcome.Won(winner.id)
+            return EndTurnOutcome.Won(winner.id, game.roundNumber)
         }
 
         val nextPhase = advanceTurn(gameId)

--- a/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
@@ -192,9 +192,10 @@ class GameControllerTest {
     fun `endTurn broadcasts GAME_END on game topic when winner exists`() {
         val gameId = 42
         val winnerId = 1
+        val roundsPlayed = 10
 
         whenever(gamePhaseService.endTurn(gameId))
-            .thenReturn(EndTurnOutcome.Won(winnerId))
+            .thenReturn(EndTurnOutcome.Won(winnerId, roundsPlayed))
 
         controller.endTurn(EndTurnRequest(gameId))
 
@@ -204,7 +205,7 @@ class GameControllerTest {
         val message = captor.firstValue
         assertEquals(MessageType.GAME_END, message.type)
         assertEquals("server", message.sender)
-        assertEquals(mapOf("winnerId" to winnerId), message.payload)
+        assertEquals(mapOf("winnerId" to winnerId, "roundsPlayed" to roundsPlayed), message.payload)
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/service/GamePhaseServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GamePhaseServiceTest.kt
@@ -206,10 +206,11 @@ class GamePhaseServiceTest {
         val gameId = 30
         val userId = 10
         val id = 1
+        val roundsPlayed = 10
         val winner = PlayerModel(id, gameId, userId, 0, 3, 30)
 
         whenever(gameStateGuard.ensureGameIsRunning(gameId))
-            .thenReturn(gameInPhase(gameId, TurnPhase.BUY_OR_BUILD))
+            .thenReturn(gameInPhase(gameId, TurnPhase.BUY_OR_BUILD, roundNumber = roundsPlayed ))
         whenever(winConditionService.detectWinner(gameId))
             .thenReturn(winner)
         whenever(playerDao.getPlayers(gameId))
@@ -221,6 +222,10 @@ class GamePhaseServiceTest {
         assertEquals(
             id,
             (result).winnerId
+        )
+        assertEquals(
+            roundsPlayed,
+            (result).roundsPlayed
         )
 
         verify(gameDao).updateTurnPhase(gameId, TurnPhase.END_TURN)


### PR DESCRIPTION
## Summary
Adds roundsPlayed to EndTurnOutcome.Won from game state
Sent to clients in broadcastWin (renamed from broadcastWinner since will be expanded in future with e.g ranking, time etc.
Enables displaying total rounds on the winner screen
Existing tests were adjusted respectivelly 

#180 was already partly finished, just small feature to complete

Closes #180