### PR TITLE
Fix/kotlin oom compilation error

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,71 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ "main", "develop" ]
+  pull_request:
+    branches: [ "main", "develop" ]
+  schedule:
+    # Weekly scan on Monday 06:00 UTC.
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (java-kotlin)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: java-kotlin
+            build-mode: manual
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts', '**/*.gradle') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      # Manual build: compile only what CodeQL needs to analyze (main + test sources).
+      # `--no-daemon` avoids leaking a Gradle daemon between Action steps; memory
+      # for the Kotlin compile worker is configured in gradle.properties.
+      - name: Build (compile sources for CodeQL)
+        run: ./gradlew --no-daemon compileKotlin compileTestKotlin -x test --stacktrace
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,11 @@
+# Increase heap for the Gradle daemon (used by CI runners and CodeQL autobuild).
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+
+# Increase heap for the Kotlin compile daemon. The default (~512m) is not
+# enough to compile this module under CodeQL's instrumented autobuild and
+# was causing `OOMErrorException: Not enough memory to run compilation`.
+kotlin.daemon.jvmargs=-Xmx3g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+
+# Standard performance flags.
+org.gradle.parallel=true
+org.gradle.caching=true


### PR DESCRIPTION
This pull request introduces CodeQL static analysis into the CI workflow and optimizes Gradle build settings for better performance and reliability, particularly in CI environments. The main changes include adding a new GitHub Actions workflow for CodeQL analysis and updating `gradle.properties` to increase memory allocation for Gradle and Kotlin compilation processes.

**CI/CD: CodeQL Integration**
* Added a new GitHub Actions workflow (`.github/workflows/codeql.yml`) to run CodeQL static analysis on pushes, pull requests, and a weekly schedule for the `main` and `develop` branches. The workflow sets up JDK 21, caches Gradle dependencies, builds the project, and performs CodeQL analysis for Java/Kotlin code.

**Build Performance and Reliability**
* Updated `gradle.properties` to increase heap size for the Gradle daemon and the Kotlin compile daemon, addressing out-of-memory errors during CI and CodeQL builds. Also enabled Gradle parallelism and build caching for improved performance.