### PR TITLE
Chore/doco cd deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,14 @@
 # Server Configuration
 SERVER_PORT=8080
 
+# Public host port published by the production compose stack on the AAU
+# shared server. Each group gets its own assigned port (group 6 = 53210).
+PUBLIC_PORT=53210
+
+# Comma-separated list of allowed Origins for WebSocket / CORS.
+# In production set this to the public URL(s) the clients use.
+WEBSOCKET_ALLOWED_ORIGINS=http://localhost:8080,http://localhost:3000
+
 # Database Configuration
 DB_HOST=localhost
 DB_PORT=5432
@@ -8,6 +16,6 @@ DB_NAME=mydatabase
 DB_USERNAME=myuser
 DB_PASSWORD=secret
 
-# PGAdmin4
+# PGAdmin4 (local dev only - see compose-dev.yaml)
 PGADMIN_EMAIL=admin@admin.com
 PGADMIN_PASSWORD=admin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,37 +60,10 @@ jobs:
           name: server-test-reports
           path: build/reports/tests/
 
-  deploy:
-    name: Deploy to Server
-    runs-on: ubuntu-latest
-    needs: build-and-test
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-
-      - name: Build JAR
-        run: ./gradlew bootJar
-
-      - name: Deploy via SSH
-        uses: appleboy/ssh-action@v1.0.3
-        with:
-          host: ${{ secrets.DEPLOY_HOST }}
-          username: ${{ secrets.DEPLOY_USER }}
-          key: ${{ secrets.DEPLOY_SSH_KEY }}
-          script: |
-            cd /opt/machi-koro-server
-            docker compose pull
-            docker compose up -d --build
+  # Deployment is handled by doco-cd on every push to `main`.
+  # doco-cd clones the repo to
+  #   /var/lib/docker/volumes/doco-cd-setup_data/_data/github.com/<org>/<repo>/
+  # on the AAU shared server and runs `docker compose up -d` against
+  # `compose.yaml`. Production secrets live in a server-side `.env` placed
+  # next to `compose.yaml` (chmod 600). For debugging / rollback use SSH:
+  #   ssh grp-6@se2-demo.aau.at -p 53200

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,59 @@
+name: Publish Docker image to GHCR
+
+on:
+  push:
+    branches: [ "main" ]
+    tags: [ "v*" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ghcr-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-push:
+    name: Build & push image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # GHCR image names must be lowercase. The repository here is
+          # `SE2-Machi-Koro/Server`; the lowercase form is hard-coded so the
+          # tag is stable regardless of how the workflow is invoked.
+          images: ghcr.io/se2-machi-koro/server
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,prefix=sha-,format=short
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,13 +21,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -35,7 +35,7 @@ jobs:
 
       - name: Compute image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           # GHCR image names must be lowercase. The repository here is
           # `SE2-Machi-Koro/Server`; the lowercase form is hard-coded so the
@@ -48,7 +48,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ out/
 ### GitHub Copilot ###
 .copilot/
 copilotDiffState.xml
+.env.test
+compose.local-test.yaml

--- a/README.md
+++ b/README.md
@@ -247,3 +247,53 @@ To verify the server is running:
 ```
 GET http://localhost:8080/actuator/health
 ```
+
+## Deployment
+
+The server is deployed to the AAU shared infrastructure (`se2-demo.aau.at`, group 6) via
+[doco-cd](https://github.com/kimdre/doco-cd), which reconciles the running stack from this
+repository's `compose.yaml` on every push to `main`.
+
+### Pipeline overview
+
+1. A push to `main` triggers the [`Publish Docker image to GHCR`](.github/workflows/docker-publish.yml)
+   workflow, which builds the backend image and pushes it to
+   `ghcr.io/se2-machi-koro/server` with the tags:
+   - `latest` (only on `main`)
+   - `sha-<short-commit>` (every build, used for rollback)
+   - `v*` (when a Git tag matching `v*` is pushed)
+2. doco-cd on the AAU server detects the change, pulls the new image (`pull_policy: always`),
+   and restarts the `backend` service defined in [compose.yaml](compose.yaml).
+3. The Postgres service runs alongside the backend on the internal compose network and is
+   **not exposed to the host** — only the backend is published on `PUBLIC_PORT` (`53210`).
+
+### Live endpoints
+
+| Resource     | URL                                                  |
+|--------------|------------------------------------------------------|
+| Backend      | `http://se2-demo.aau.at:53210`                       |
+| Health check | `http://se2-demo.aau.at:53210/actuator/health`       |
+| WebSocket    | `ws://se2-demo.aau.at:53210/ws`                      |
+
+### Server access
+
+```bash
+ssh grp-6@se2-demo.aau.at -p 53200
+```
+
+The doco-cd working copy of this repo lives at:
+
+```
+/var/lib/docker/volumes/doco-cd-setup_data/_data/github.com/SE2-Machi-Koro/Server/
+```
+
+The production `.env` must be placed next to `compose.yaml` in that directory and locked
+down with `chmod 600`. Use [.env.example](.env.example) as the template; the production
+values for `DB_USERNAME` / `DB_PASSWORD` are set by the team and never committed.
+
+### Rollback
+
+To roll back to a previous image, edit the production `.env` on the server and set
+`IMAGE_TAG=sha-<short-commit>` (or any other tag published to GHCR), then trigger a
+doco-cd reconcile. The `compose.yaml` resolves the image as
+`ghcr.io/se2-machi-koro/server:${IMAGE_TAG:-latest}`.

--- a/README.md
+++ b/README.md
@@ -158,15 +158,17 @@ internal `GameModel` may hold additional state used purely for server-side logic
 
 2. Edit the following required variables in `.env`:
 
-   | Variable         | Description                     | 
-   |------------------|---------------------------------|
-   | DB_USERNAME      | PostgreSQL database username    |
-   | DB_PASSWORD      | PostgreSQL database password    |
-   | DB_NAME          | Database name                   |
-   | DB_PORT          | Database port (default: 5432)   |
-   | PGADMIN_EMAIL    | Email for pgAdmin (optional)    |
-   | PGADMIN_PASSWORD | Password for pgAdmin (optional) |
-   | SERVER_PORT      | Port for backend server         |
+   | Variable                    | Description                                                                  |
+   |-----------------------------|------------------------------------------------------------------------------|
+   | DB_USERNAME                 | PostgreSQL database username                                                 |
+   | DB_PASSWORD                 | PostgreSQL database password                                                 |
+   | DB_NAME                     | Database name                                                                |
+   | DB_PORT                     | Database port (default: 5432, local dev only)                                |
+   | SERVER_PORT                 | Port for backend server inside the container (default: 8080)                 |
+   | PUBLIC_PORT                 | Host port the backend is published on in production (AAU group 6: `53210`)   |
+   | WEBSOCKET_ALLOWED_ORIGINS   | Comma-separated list of allowed CORS origins for the WebSocket endpoint      |
+   | PGADMIN_EMAIL               | Email for pgAdmin (local dev only — see `compose-dev.yaml`)                  |
+   | PGADMIN_PASSWORD            | Password for pgAdmin (local dev only — see `compose-dev.yaml`)               |
 
 Example `.env`:
 
@@ -175,9 +177,11 @@ DB_USERNAME=admin
 DB_PASSWORD=password123
 DB_NAME=machikoro
 DB_PORT=5432
+SERVER_PORT=8080
+PUBLIC_PORT=53210
+WEBSOCKET_ALLOWED_ORIGINS=http://localhost:8080,http://localhost:3000
 PGADMIN_EMAIL=admin@admin.com
 PGADMIN_PASSWORD=admin
-SERVER_PORT=8080
 ```
 
 ## Local Build & Run

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -10,7 +10,7 @@ services:
     ports:
       - '${DB_PORT:-5432}:5432'
     volumes:
-      - postgres_data:/var/lib/postgresql
+      - postgres_data:/var/lib/postgresql/data
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U ${DB_USERNAME} -d ${DB_NAME:-machikoro}" ]
       interval: 5s

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -10,7 +10,10 @@ services:
     ports:
       - '${DB_PORT:-5432}:5432'
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      # Postgres 18+ requires the mount at /var/lib/postgresql (the parent dir);
+      # data is stored under /var/lib/postgresql/<major>/docker/ to support
+      # pg_upgrade --link across major versions.
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U ${DB_USERNAME} -d ${DB_NAME:-machikoro}" ]
       interval: 5s

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,8 +7,8 @@ services:
       - 'POSTGRES_DB=${DB_NAME:-machikoro}'
       - 'POSTGRES_PASSWORD=${DB_PASSWORD}'
       - 'POSTGRES_USER=${DB_USERNAME}'
-    ports:
-      - '${DB_PORT:-5432}:5432'
+    # Database is reached by the backend over the internal compose network
+    # (DB_HOST=postgres). Not exposed to the host on the shared AAU server.
     volumes:
       - postgres_data:/var/lib/postgresql
     healthcheck:
@@ -18,33 +18,24 @@ services:
       retries: 5
       start_period: 30s
 
-  pgAdmin:
-    container_name: 'machikoro-pgadmin'
-    image: 'dpage/pgadmin4:8.4'
-    restart: unless-stopped
-    environment:
-      - 'PGADMIN_DEFAULT_EMAIL=${PGADMIN_EMAIL}'
-      - 'PGADMIN_DEFAULT_PASSWORD=${PGADMIN_PASSWORD}'
-    ports:
-      - '5050:80'
-    depends_on:
-      - postgres
-    volumes:
-      - pgadmin_data:/var/lib/pgadmin
-
   backend:
     container_name: 'machikoro-server'
     build: .
     restart: unless-stopped
     ports:
-      - '${SERVER_PORT:-8080}:8080'
+      # Host port (assigned by AAU course infra) -> container port (always 8080).
+      - '${PUBLIC_PORT:-53210}:8080'
     environment:
       - 'DB_HOST=postgres'
       - 'DB_PORT=5432'
       - 'DB_NAME=${DB_NAME:-machikoro}'
       - 'DB_USERNAME=${DB_USERNAME}'
       - 'DB_PASSWORD=${DB_PASSWORD}'
-      - 'SERVER_PORT=${SERVER_PORT:-8080}'
+      - 'SERVER_PORT=8080'
+      # Spring Boot's docker-compose support is meant for local dev only;
+      # disable it inside the container so it doesn't try to spawn `docker compose`.
+      - 'SPRING_DOCKER_COMPOSE_ENABLED=false'
+      - 'WEBSOCKET_ALLOWED_ORIGINS=${WEBSOCKET_ALLOWED_ORIGINS:-http://se2-demo.aau.at:53210,https://se2-demo.aau.at:53210}'
     depends_on:
       postgres:
         condition: service_healthy
@@ -57,4 +48,3 @@ services:
 
 volumes:
   postgres_data:
-  pgadmin_data:

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,7 +10,10 @@ services:
     # Database is reached by the backend over the internal compose network
     # (DB_HOST=postgres). Not exposed to the host on the shared AAU server.
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      # Postgres 18+ requires the mount at /var/lib/postgresql (the parent dir);
+      # data is stored under /var/lib/postgresql/<major>/docker/ to support
+      # pg_upgrade --link across major versions.
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U ${DB_USERNAME} -d ${DB_NAME:-machikoro}" ]
       interval: 5s

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,7 +10,7 @@ services:
     # Database is reached by the backend over the internal compose network
     # (DB_HOST=postgres). Not exposed to the host on the shared AAU server.
     volumes:
-      - postgres_data:/var/lib/postgresql
+      - postgres_data:/var/lib/postgresql/data
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U ${DB_USERNAME} -d ${DB_NAME:-machikoro}" ]
       interval: 5s
@@ -20,7 +20,13 @@ services:
 
   backend:
     container_name: 'machikoro-server'
-    build: .
+    # Image is built and pushed to GHCR by .github/workflows/docker-publish.yml
+    # on every push to `main` (tagged `latest` and `sha-<short>`) and on git
+    # tags `v*` (tagged with the version). Override IMAGE_TAG in the server-side
+    # `.env` (e.g. `IMAGE_TAG=sha-abc1234`) to roll back to a specific build
+    # without changing the repo, then `docker compose up -d` over SSH.
+    image: 'ghcr.io/se2-machi-koro/server:${IMAGE_TAG:-latest}'
+    pull_policy: always
     restart: unless-stopped
     ports:
       # Host port (assigned by AAU course infra) -> container port (always 8080).


### PR DESCRIPTION
This pull request makes several important updates to the project's deployment and configuration setup, focusing on improving production readiness, Docker image publishing, and environment configuration. The changes clarify how the server is deployed, update Docker Compose files for better production practices, and introduce a new workflow for publishing Docker images to GitHub Container Registry (GHCR).

**Deployment & CI/CD workflow improvements:**

- Removed the manual deploy job from the GitHub Actions CI workflow (`ci.yml`) and replaced it with documentation explaining that deployment is now handled by an external system (`doco-cd`) on the AAU shared server. This clarifies the deployment process and reduces complexity in the CI pipeline.
- Added a new GitHub Actions workflow (`docker-publish.yml`) to automatically build and publish Docker images to GHCR on every push to `main` or when a new version tag is created. This ensures that production images are always up-to-date and available for deployment.

**Docker Compose & environment configuration:**

- Updated `compose.yaml`:
  - Changed the backend service to use the pre-built Docker image from GHCR instead of building locally, and ensured the image is always pulled fresh. The published port is now set via the `PUBLIC_PORT` environment variable, aligning with AAU infrastructure requirements.
  - Removed the `pgAdmin` service and its associated volume from the production compose file, as it's intended for local development only.
  - Updated the `postgres` service volume mapping to use the correct data directory.

- Updated `compose-dev.yaml`:
  - Fixed the `postgres` service volume mapping to correctly persist database data.

**Environment variable improvements:**

- Enhanced `.env.example` with new variables for production configuration:
  - Added `PUBLIC_PORT` for specifying the externally accessible port.
  - Added `WEBSOCKET_ALLOWED_ORIGINS` for CORS/WebSocket origin control.
  - Clarified that `PGAdmin4` settings are for local development only.