### PR TITLE
fix: route GameController + EarningsController principal lookups through helper

### DIFF
--- a/src/main/kotlin/org/machikoro/server/auth/UserPrincipalAccessor.kt
+++ b/src/main/kotlin/org/machikoro/server/auth/UserPrincipalAccessor.kt
@@ -1,5 +1,6 @@
 package org.machikoro.server.auth
 
+import org.machikoro.server.exception.CustomWebSocketException
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 
 /**
@@ -26,3 +27,15 @@ const val USER_PRINCIPAL_KEY = "userPrincipal"
 fun SimpMessageHeaderAccessor.userPrincipal(): UserPrincipal? =
     user as? UserPrincipal
         ?: sessionAttributes?.get(USER_PRINCIPAL_KEY) as? UserPrincipal
+
+/**
+ * Resolve the authenticated [UserPrincipal] or throw
+ * [CustomWebSocketException] with `UNAUTHENTICATED` so it's routed via
+ * `GlobalWebSocketExceptionHandler` like other handled failures. Use this in
+ * any `@MessageMapping` handler that requires an authenticated user.
+ */
+fun SimpMessageHeaderAccessor.requireUserPrincipal(): UserPrincipal =
+    userPrincipal() ?: throw CustomWebSocketException(
+        errorCode = "UNAUTHENTICATED",
+        message = "Authenticated principal not found — connection may not have completed STOMP handshake",
+    )

--- a/src/main/kotlin/org/machikoro/server/controller/EarningsController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/EarningsController.kt
@@ -1,6 +1,6 @@
 package org.machikoro.server.controller
 
-import java.security.Principal
+import org.machikoro.server.auth.requireUserPrincipal
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.ResolveEffectsRequest
 import org.machikoro.server.dto.WebSocketMessage
@@ -9,6 +9,7 @@ import org.machikoro.server.service.interfaces.EarningsService
 import org.slf4j.LoggerFactory
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.handler.annotation.Payload
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.stereotype.Controller
 
@@ -27,8 +28,9 @@ class EarningsController(
      * Resolves card effects for all players and broadcasts the result to the game topic.
      */
     @MessageMapping("/game.resolveEffects")
-    fun resolveEffects(@Payload request: ResolveEffectsRequest, principal: Principal) {
-        gameStateGuard.ensureSenderIsActivePlayer(request.gameId, principal)
+    fun resolveEffects(@Payload request: ResolveEffectsRequest, headerAccessor: SimpMessageHeaderAccessor) {
+        val user = headerAccessor.requireUserPrincipal()
+        gameStateGuard.ensureSenderIsActivePlayer(request.gameId, user)
         val gameTopic = "/topic/game/${request.gameId}"
         try {
             earningsService.resolveEffects(request.gameId)

--- a/src/main/kotlin/org/machikoro/server/controller/GameController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/GameController.kt
@@ -1,6 +1,6 @@
 package org.machikoro.server.controller
 
-import java.security.Principal
+import org.machikoro.server.auth.requireUserPrincipal
 import org.machikoro.server.domain.enums.TurnPhase
 import org.machikoro.server.dto.EndTurnOutcome
 import org.machikoro.server.dto.AdvancePhaseRequest
@@ -115,8 +115,8 @@ class GameController(
      * Message is sent to /app/game.advancePhase and broadcast to /topic/game/{gameId}.
      */
     @MessageMapping("/game.advancePhase")
-    fun advancePhase(@Payload request: AdvancePhaseRequest, principal: Principal) {
-        gameStateGuard.ensureSenderIsActivePlayer(request.gameId, principal)
+    fun advancePhase(@Payload request: AdvancePhaseRequest, headerAccessor: SimpMessageHeaderAccessor) {
+        requireActivePlayer(request.gameId, headerAccessor)
         val newPhase = gamePhaseService.advancePhase(request.gameId)
         logger.info("Advanced phase for game ${request.gameId} to $newPhase")
         broadcastPhase(request.gameId, newPhase)
@@ -128,8 +128,8 @@ class GameController(
      * landmark completes the game.
      */
     @MessageMapping("/game.purchase")
-    fun purchase(@Payload request: PurchaseRequest, principal: Principal) {
-        gameStateGuard.ensureSenderIsActivePlayer(request.gameId, principal)
+    fun purchase(@Payload request: PurchaseRequest, headerAccessor: SimpMessageHeaderAccessor) {
+        requireActivePlayer(request.gameId, headerAccessor)
         val result = purchaseService.purchase(
             gameId = request.gameId,
             purchaseType = request.purchaseType,
@@ -142,8 +142,8 @@ class GameController(
     }
 
     @MessageMapping("/game.endTurn")
-    fun endTurn(@Payload request: EndTurnRequest, principal: Principal) {
-        gameStateGuard.ensureSenderIsActivePlayer(request.gameId, principal)
+    fun endTurn(@Payload request: EndTurnRequest, headerAccessor: SimpMessageHeaderAccessor) {
+        requireActivePlayer(request.gameId, headerAccessor)
         when (val result = gamePhaseService.endTurn(request.gameId)) {
             is EndTurnOutcome.Continue -> {
                 logger.info("Ended turn for game ${request.gameId}, new phase ${result.nextPhase}")
@@ -157,8 +157,8 @@ class GameController(
     }
 
     @MessageMapping("/game.leave")
-    fun leaveFinishedGame(@Payload request: LeaveFinishedGameRequest, principal: Principal) {
-        gameStateGuard.ensureSenderOwnsPlayer(request.gameId, request.playerId, principal)
+    fun leaveFinishedGame(@Payload request: LeaveFinishedGameRequest, headerAccessor: SimpMessageHeaderAccessor) {
+        requireOwnerOfPlayer(request.gameId, request.playerId, headerAccessor)
         leaveFinishedGameService.leaveFinishedGame(request.gameId, request.playerId)
         logger.info("${request.playerId} left game ${request.gameId}")
         broadcastPlayerLeftFinishedGame(request.gameId, request.playerId)
@@ -169,8 +169,8 @@ class GameController(
      * Message is sent to /app/game.rollDice and broadcast to /topic/game/{gameId}
      */
     @MessageMapping("/game.rollDice")
-    fun rollDice(@Payload request: RollDiceRequest, principal: Principal) {
-        gameStateGuard.ensureSenderIsActivePlayer(request.gameId, principal)
+    fun rollDice(@Payload request: RollDiceRequest, headerAccessor: SimpMessageHeaderAccessor) {
+        requireActivePlayer(request.gameId, headerAccessor)
         val gameTopic = "/topic/game/${request.gameId}"
         logger.info("Roll dice request from player ${request.playerId} in game ${request.gameId}")
         try {
@@ -248,5 +248,19 @@ class GameController(
                 ),
             ),
         )
+    }
+
+    /**
+     * Resolve the authenticated user from the STOMP session and assert they
+     * are the active player for [gameId]. Throws `UNAUTHENTICATED` /
+     * `NOT_YOUR_TURN` / `NO_ACTIVE_PLAYER` / `GAME_FINISHED` per the helper
+     * and guard contracts.
+     */
+    private fun requireActivePlayer(gameId: Int, headerAccessor: SimpMessageHeaderAccessor) {
+        gameStateGuard.ensureSenderIsActivePlayer(gameId, headerAccessor.requireUserPrincipal())
+    }
+
+    private fun requireOwnerOfPlayer(gameId: Int, playerId: Int, headerAccessor: SimpMessageHeaderAccessor) {
+        gameStateGuard.ensureSenderOwnsPlayer(gameId, playerId, headerAccessor.requireUserPrincipal())
     }
 }

--- a/src/main/kotlin/org/machikoro/server/service/GameStateGuard.kt
+++ b/src/main/kotlin/org/machikoro/server/service/GameStateGuard.kt
@@ -1,6 +1,5 @@
 package org.machikoro.server.service
 
-import java.security.Principal
 import org.machikoro.server.auth.UserPrincipal
 import org.machikoro.server.dao.GameDao
 import org.machikoro.server.dao.PlayerDao
@@ -49,21 +48,21 @@ class GameStateGuard(
     }
 
     /**
-     * Verifies that [principal] is the player whose turn is currently active in
+     * Verifies that [user] is the player whose turn is currently active in
      * [gameId]. Used by all turn-bound mutations (purchase, endTurn, rollDice,
      * advancePhase, resolveEffects) so client payloads cannot impersonate
      * another player by forging gameId or playerId fields.
      *
-     * Returns the resolved [UserPrincipal] for callers that want it.
+     * Callers resolve the principal via
+     * `SimpMessageHeaderAccessor.requireUserPrincipal()` before calling — the
+     * UNAUTHENTICATED case is handled at that boundary, not here.
      *
      * Throws [CustomWebSocketException] with one of:
-     *  - `UNAUTHENTICATED`   — no [UserPrincipal] is attached to the session.
      *  - `GAME_FINISHED`     — game has already ended (via [ensureGameIsRunning]).
      *  - `NO_ACTIVE_PLAYER`  — currentTurnIndex points outside the player list.
      *  - `NOT_YOUR_TURN`     — caller is authenticated but not the active player.
      */
-    fun ensureSenderIsActivePlayer(gameId: Int, principal: Principal?): UserPrincipal {
-        val user = requireUserPrincipal(principal)
+    fun ensureSenderIsActivePlayer(gameId: Int, user: UserPrincipal) {
         val game = ensureGameIsRunning(gameId)
         val active = playerDao.getPlayers(gameId).getOrNull(game.currentTurnIndex)
             ?: throw CustomWebSocketException(
@@ -76,21 +75,18 @@ class GameStateGuard(
                 message = "It is not your turn",
             )
         }
-        return user
     }
 
     /**
-     * Verifies that [principal] owns the player identified by [playerId] within
+     * Verifies that [user] owns the player identified by [playerId] within
      * [gameId]. Used for `/game.leave` so a user can only remove their own seat
      * from a finished game, not another player's.
      *
      * Throws [CustomWebSocketException] with one of:
-     *  - `UNAUTHENTICATED`     — no [UserPrincipal] is attached to the session.
      *  - `PLAYER_NOT_IN_GAME`  — [playerId] does not exist in [gameId].
      *  - `NOT_YOUR_PLAYER`     — caller is authenticated but does not own the player.
      */
-    fun ensureSenderOwnsPlayer(gameId: Int, playerId: Int, principal: Principal?): UserPrincipal {
-        val user = requireUserPrincipal(principal)
+    fun ensureSenderOwnsPlayer(gameId: Int, playerId: Int, user: UserPrincipal) {
         val player = playerDao.getPlayers(gameId).firstOrNull { it.id == playerId }
             ?: throw CustomWebSocketException(
                 errorCode = "PLAYER_NOT_IN_GAME",
@@ -102,12 +98,5 @@ class GameStateGuard(
                 message = "You do not own player $playerId",
             )
         }
-        return user
     }
-
-    private fun requireUserPrincipal(principal: Principal?): UserPrincipal =
-        principal as? UserPrincipal ?: throw CustomWebSocketException(
-            errorCode = "UNAUTHENTICATED",
-            message = "Authenticated principal required",
-        )
 }

--- a/src/test/kotlin/org/machikoro/server/auth/UserPrincipalAccessorTest.kt
+++ b/src/test/kotlin/org/machikoro/server/auth/UserPrincipalAccessorTest.kt
@@ -1,0 +1,73 @@
+package org.machikoro.server.auth
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.machikoro.server.exception.CustomWebSocketException
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor
+import java.security.Principal
+
+class UserPrincipalAccessorTest {
+
+    private val alice = UserPrincipal(userId = 7, username = "alice")
+
+    @Test
+    fun `userPrincipal reads from accessor user when set`() {
+        val accessor = SimpMessageHeaderAccessor.create().apply { user = alice }
+
+        assertEquals(alice, accessor.userPrincipal())
+    }
+
+    @Test
+    fun `userPrincipal falls back to sessionAttributes when accessor user is missing`() {
+        // Realistic case: SEND frame after CONNECT, where Spring lost the
+        // accessor.user but the interceptor's sessionAttributes write survives.
+        val accessor = SimpMessageHeaderAccessor.create().apply {
+            sessionAttributes = mutableMapOf(USER_PRINCIPAL_KEY to alice)
+        }
+
+        assertEquals(alice, accessor.userPrincipal())
+    }
+
+    @Test
+    fun `userPrincipal returns null when neither source is populated`() {
+        val accessor = SimpMessageHeaderAccessor.create()
+
+        assertNull(accessor.userPrincipal())
+    }
+
+    @Test
+    fun `userPrincipal returns null when accessor user is a non-UserPrincipal Principal`() {
+        // Defensive: another component might set a foreign Principal type. The
+        // helper must not coerce — the cast fails closed.
+        val accessor = SimpMessageHeaderAccessor.create().apply {
+            user = Principal { "foreign" }
+        }
+
+        assertNull(accessor.userPrincipal())
+    }
+
+    @Test
+    fun `requireUserPrincipal returns the principal when present`() {
+        val accessor = SimpMessageHeaderAccessor.create().apply {
+            sessionAttributes = mutableMapOf(USER_PRINCIPAL_KEY to alice)
+        }
+
+        assertEquals(alice, accessor.requireUserPrincipal())
+    }
+
+    @Test
+    fun `requireUserPrincipal throws UNAUTHENTICATED when no principal is present`() {
+        val accessor = SimpMessageHeaderAccessor.create()
+
+        val ex = assertThrows<CustomWebSocketException> {
+            accessor.requireUserPrincipal()
+        }
+        assertEquals("UNAUTHENTICATED", ex.errorCode)
+        assertEquals(
+            "Authenticated principal not found — connection may not have completed STOMP handshake",
+            ex.message,
+        )
+    }
+}

--- a/src/test/kotlin/org/machikoro/server/controller/EarningsControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/EarningsControllerTest.kt
@@ -1,6 +1,5 @@
 package org.machikoro.server.controller
 
-import java.security.Principal
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.machikoro.server.auth.UserPrincipal
@@ -19,6 +18,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import kotlin.test.assertEquals
 
@@ -29,15 +29,18 @@ class EarningsControllerTest {
     private val gameStateGuard: GameStateGuard = mock()
     private val controller = EarningsController(earningsService, messagingTemplate, gameStateGuard)
 
-    private val principal: Principal = UserPrincipal(userId = 1, username = "alice")
+    private val alice = UserPrincipal(userId = 1, username = "alice")
+
+    private fun authedAccessor(): SimpMessageHeaderAccessor =
+        SimpMessageHeaderAccessor.create().apply { user = alice }
 
     @Test
     fun `resolveEffects calls service and broadcasts success`() {
         val request = ResolveEffectsRequest(gameId = 1)
 
-        controller.resolveEffects(request, principal)
+        controller.resolveEffects(request, authedAccessor())
 
-        verify(gameStateGuard).ensureSenderIsActivePlayer(1, principal)
+        verify(gameStateGuard).ensureSenderIsActivePlayer(1, alice)
         verify(earningsService).resolveEffects(1)
 
         val captor = argumentCaptor<WebSocketMessage>()
@@ -55,7 +58,7 @@ class EarningsControllerTest {
         val request = ResolveEffectsRequest(gameId = 1)
         doThrow(GameNotFoundException("Game 1 not found")).whenever(earningsService).resolveEffects(1)
 
-        controller.resolveEffects(request, principal)
+        controller.resolveEffects(request, authedAccessor())
 
         val captor = argumentCaptor<WebSocketMessage>()
         verify(messagingTemplate).convertAndSend(eq("/topic/game/1"), captor.capture())
@@ -70,14 +73,27 @@ class EarningsControllerTest {
     @Test
     fun `resolveEffects propagates NOT_YOUR_TURN and does not call service or broadcast`() {
         val request = ResolveEffectsRequest(gameId = 1)
-        whenever(gameStateGuard.ensureSenderIsActivePlayer(1, principal))
+        whenever(gameStateGuard.ensureSenderIsActivePlayer(1, alice))
             .thenThrow(CustomWebSocketException("NOT_YOUR_TURN", "It is not your turn"))
 
         val ex = assertThrows<CustomWebSocketException> {
-            controller.resolveEffects(request, principal)
+            controller.resolveEffects(request, authedAccessor())
         }
         assertEquals("NOT_YOUR_TURN", ex.errorCode)
         verify(earningsService, never()).resolveEffects(any())
         verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
+    }
+
+    @Test
+    fun `resolveEffects throws UNAUTHENTICATED when accessor has no principal`() {
+        val request = ResolveEffectsRequest(gameId = 1)
+        val unauthed = SimpMessageHeaderAccessor.create()
+
+        val ex = assertThrows<CustomWebSocketException> {
+            controller.resolveEffects(request, unauthed)
+        }
+        assertEquals("UNAUTHENTICATED", ex.errorCode)
+        verify(gameStateGuard, never()).ensureSenderIsActivePlayer(any(), any())
+        verify(earningsService, never()).resolveEffects(any())
     }
 }

--- a/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
@@ -1,6 +1,5 @@
 package org.machikoro.server.controller
 
-import java.security.Principal
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -59,7 +58,11 @@ class GameControllerTest {
         purchaseService, diceService, lobbyService, connectionTracker, gameStateGuard,
     )
 
-    private val principal: Principal = UserPrincipal(userId = 1, username = "alice")
+    private val alice = UserPrincipal(userId = 1, username = "alice")
+
+    /** Authenticated accessor with [alice] resolvable via the helper. */
+    private fun authedAccessor(): SimpMessageHeaderAccessor =
+        SimpMessageHeaderAccessor.create().apply { user = alice }
 
     // ── startGame ─────────────────────────────────────────────────────────────
 
@@ -149,9 +152,9 @@ class GameControllerTest {
         val gameId = 42
         whenever(gamePhaseService.advancePhase(gameId)).thenReturn(TurnPhase.RESOLVE_EFFECTS)
 
-        controller.advancePhase(AdvancePhaseRequest(gameId), principal)
+        controller.advancePhase(AdvancePhaseRequest(gameId), authedAccessor())
 
-        verify(gameStateGuard).ensureSenderIsActivePlayer(gameId, principal)
+        verify(gameStateGuard).ensureSenderIsActivePlayer(gameId, alice)
         verify(gamePhaseService).advancePhase(gameId)
     }
 
@@ -160,7 +163,7 @@ class GameControllerTest {
         val gameId = 42
         whenever(gamePhaseService.advancePhase(gameId)).thenReturn(TurnPhase.RESOLVE_EFFECTS)
 
-        controller.advancePhase(AdvancePhaseRequest(gameId), principal)
+        controller.advancePhase(AdvancePhaseRequest(gameId), authedAccessor())
 
         val captor = argumentCaptor<WebSocketMessage>()
         verify(messagingTemplate).convertAndSend(eq("/topic/game/$gameId"), captor.capture())
@@ -174,11 +177,11 @@ class GameControllerTest {
     @Test
     fun `advancePhase propagates NOT_YOUR_TURN and does not call service`() {
         val gameId = 42
-        whenever(gameStateGuard.ensureSenderIsActivePlayer(gameId, principal))
+        whenever(gameStateGuard.ensureSenderIsActivePlayer(gameId, alice))
             .thenThrow(CustomWebSocketException("NOT_YOUR_TURN", "It is not your turn"))
 
         val ex = assertThrows<CustomWebSocketException> {
-            controller.advancePhase(AdvancePhaseRequest(gameId), principal)
+            controller.advancePhase(AdvancePhaseRequest(gameId), authedAccessor())
         }
         assertEquals("NOT_YOUR_TURN", ex.errorCode)
         verify(gamePhaseService, never()).advancePhase(any())
@@ -193,9 +196,9 @@ class GameControllerTest {
         whenever(gamePhaseService.endTurn(gameId))
             .thenReturn(EndTurnOutcome.Continue(TurnPhase.ROLL_DICE))
 
-        controller.endTurn(EndTurnRequest(gameId), principal)
+        controller.endTurn(EndTurnRequest(gameId), authedAccessor())
 
-        verify(gameStateGuard).ensureSenderIsActivePlayer(gameId, principal)
+        verify(gameStateGuard).ensureSenderIsActivePlayer(gameId, alice)
         verify(gamePhaseService).endTurn(gameId)
     }
 
@@ -205,7 +208,7 @@ class GameControllerTest {
         whenever(gamePhaseService.endTurn(gameId))
             .thenReturn(EndTurnOutcome.Continue(TurnPhase.ROLL_DICE))
 
-        controller.endTurn(EndTurnRequest(gameId), principal)
+        controller.endTurn(EndTurnRequest(gameId), authedAccessor())
 
         val captor = argumentCaptor<WebSocketMessage>()
         verify(messagingTemplate).convertAndSend(eq("/topic/game/$gameId"), captor.capture())
@@ -225,7 +228,7 @@ class GameControllerTest {
         whenever(gamePhaseService.endTurn(gameId))
             .thenReturn(EndTurnOutcome.Won(winnerId, roundsPlayed))
 
-        controller.endTurn(EndTurnRequest(gameId), principal)
+        controller.endTurn(EndTurnRequest(gameId), authedAccessor())
 
         val captor = argumentCaptor<WebSocketMessage>()
         verify(messagingTemplate).convertAndSend(eq("/topic/game/$gameId"), captor.capture())
@@ -239,11 +242,11 @@ class GameControllerTest {
     @Test
     fun `endTurn propagates NOT_YOUR_TURN and does not call service`() {
         val gameId = 42
-        whenever(gameStateGuard.ensureSenderIsActivePlayer(gameId, principal))
+        whenever(gameStateGuard.ensureSenderIsActivePlayer(gameId, alice))
             .thenThrow(CustomWebSocketException("NOT_YOUR_TURN", "It is not your turn"))
 
         val ex = assertThrows<CustomWebSocketException> {
-            controller.endTurn(EndTurnRequest(gameId), principal)
+            controller.endTurn(EndTurnRequest(gameId), authedAccessor())
         }
         assertEquals("NOT_YOUR_TURN", ex.errorCode)
         verify(gamePhaseService, never()).endTurn(any())
@@ -267,10 +270,10 @@ class GameControllerTest {
 
         controller.purchase(
             PurchaseRequest(gameId, PurchaseType.ESTABLISHMENT, cardType = CardType.BAKERY),
-            principal,
+            authedAccessor(),
         )
 
-        verify(gameStateGuard).ensureSenderIsActivePlayer(gameId, principal)
+        verify(gameStateGuard).ensureSenderIsActivePlayer(gameId, alice)
         verify(purchaseService).purchase(gameId, PurchaseType.ESTABLISHMENT, CardType.BAKERY, null)
     }
 
@@ -290,7 +293,7 @@ class GameControllerTest {
 
         controller.purchase(
             PurchaseRequest(gameId, PurchaseType.LANDMARK, landmarkType = LandmarkType.TRAIN_STATION),
-            principal,
+            authedAccessor(),
         )
 
         val captor = argumentCaptor<WebSocketMessage>()
@@ -312,13 +315,13 @@ class GameControllerTest {
     @Test
     fun `purchase propagates NOT_YOUR_TURN and does not call service`() {
         val gameId = 42
-        whenever(gameStateGuard.ensureSenderIsActivePlayer(gameId, principal))
+        whenever(gameStateGuard.ensureSenderIsActivePlayer(gameId, alice))
             .thenThrow(CustomWebSocketException("NOT_YOUR_TURN", "It is not your turn"))
 
         val ex = assertThrows<CustomWebSocketException> {
             controller.purchase(
                 PurchaseRequest(gameId, PurchaseType.ESTABLISHMENT, cardType = CardType.BAKERY),
-                principal,
+                authedAccessor(),
             )
         }
         assertEquals("NOT_YOUR_TURN", ex.errorCode)
@@ -333,10 +336,10 @@ class GameControllerTest {
         val gameId = 1
         val playerId = 10
 
-        controller.leaveFinishedGame(LeaveFinishedGameRequest(gameId, playerId), principal)
+        controller.leaveFinishedGame(LeaveFinishedGameRequest(gameId, playerId), authedAccessor())
 
         val order = inOrder(gameStateGuard, leaveFinishedGameService, messagingTemplate)
-        order.verify(gameStateGuard).ensureSenderOwnsPlayer(gameId, playerId, principal)
+        order.verify(gameStateGuard).ensureSenderOwnsPlayer(gameId, playerId, alice)
         order.verify(leaveFinishedGameService).leaveFinishedGame(gameId, playerId)
         order.verify(messagingTemplate).convertAndSend(eq("/topic/game/$gameId"), any<WebSocketMessage>())
     }
@@ -350,7 +353,7 @@ class GameControllerTest {
             .thenThrow(RuntimeException("boom"))
 
         org.junit.jupiter.api.assertThrows<RuntimeException> {
-            controller.leaveFinishedGame(LeaveFinishedGameRequest(gameId, playerId), principal)
+            controller.leaveFinishedGame(LeaveFinishedGameRequest(gameId, playerId), authedAccessor())
         }
     }
 
@@ -359,7 +362,7 @@ class GameControllerTest {
         val gameId = 5
         val playerId = 20
 
-        controller.leaveFinishedGame(LeaveFinishedGameRequest(gameId, playerId), principal)
+        controller.leaveFinishedGame(LeaveFinishedGameRequest(gameId, playerId), authedAccessor())
 
         verify(messagingTemplate).convertAndSend(eq("/topic/game/$gameId"), any<WebSocketMessage>())
     }
@@ -369,7 +372,7 @@ class GameControllerTest {
         val gameId = 3
         val playerId = 99
 
-        controller.leaveFinishedGame(LeaveFinishedGameRequest(gameId, playerId), principal)
+        controller.leaveFinishedGame(LeaveFinishedGameRequest(gameId, playerId), authedAccessor())
 
         val captor = argumentCaptor<WebSocketMessage>()
         verify(messagingTemplate).convertAndSend(eq("/topic/game/$gameId"), captor.capture())
@@ -383,11 +386,11 @@ class GameControllerTest {
     fun `leaveFinishedGame propagates NOT_YOUR_PLAYER and does not call service`() {
         val gameId = 3
         val playerId = 99
-        whenever(gameStateGuard.ensureSenderOwnsPlayer(gameId, playerId, principal))
+        whenever(gameStateGuard.ensureSenderOwnsPlayer(gameId, playerId, alice))
             .thenThrow(CustomWebSocketException("NOT_YOUR_PLAYER", "You do not own player 99"))
 
         val ex = assertThrows<CustomWebSocketException> {
-            controller.leaveFinishedGame(LeaveFinishedGameRequest(gameId, playerId), principal)
+            controller.leaveFinishedGame(LeaveFinishedGameRequest(gameId, playerId), authedAccessor())
         }
         assertEquals("NOT_YOUR_PLAYER", ex.errorCode)
         verify(leaveFinishedGameService, never()).leaveFinishedGame(any(), any())
@@ -405,9 +408,9 @@ class GameControllerTest {
 
         whenever(diceService.rollDice(request)).thenReturn(response)
 
-        controller.rollDice(request, principal)
+        controller.rollDice(request, authedAccessor())
 
-        verify(gameStateGuard).ensureSenderIsActivePlayer(gameId, principal)
+        verify(gameStateGuard).ensureSenderIsActivePlayer(gameId, alice)
         val captor = argumentCaptor<WebSocketMessage>()
         verify(messagingTemplate).convertAndSend(eq("/topic/game/$gameId"), captor.capture())
 
@@ -426,7 +429,7 @@ class GameControllerTest {
 
         whenever(diceService.rollDice(request)).thenThrow(RuntimeException("dice exploded"))
 
-        controller.rollDice(request, principal)
+        controller.rollDice(request, authedAccessor())
 
         val captor = argumentCaptor<WebSocketMessage>()
         verify(messagingTemplate).convertAndSend(eq("/topic/game/$gameId"), captor.capture())
@@ -445,14 +448,63 @@ class GameControllerTest {
         val gameId = 1
         val playerId = 2
         val request = RollDiceRequest(gameId = gameId, playerId = playerId)
-        whenever(gameStateGuard.ensureSenderIsActivePlayer(gameId, principal))
+        whenever(gameStateGuard.ensureSenderIsActivePlayer(gameId, alice))
             .thenThrow(CustomWebSocketException("NOT_YOUR_TURN", "It is not your turn"))
 
         val ex = assertThrows<CustomWebSocketException> {
-            controller.rollDice(request, principal)
+            controller.rollDice(request, authedAccessor())
         }
         assertEquals("NOT_YOUR_TURN", ex.errorCode)
         verify(diceService, never()).rollDice(any())
         verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
+    }
+
+    // ── UNAUTHENTICATED at the controller boundary ────────────────────────────
+    // The full helper is tested in UserPrincipalAccessorTest; these confirm
+    // that every endpoint short-circuits before reaching the guard or
+    // downstream service, so a missed `requireUserPrincipal()` wiring would
+    // not slip through.
+
+    private fun assertUnauthenticated(call: (SimpMessageHeaderAccessor) -> Unit) {
+        val unauthed = SimpMessageHeaderAccessor.create()
+        val ex = assertThrows<CustomWebSocketException> { call(unauthed) }
+        assertEquals("UNAUTHENTICATED", ex.errorCode)
+        verify(gameStateGuard, never()).ensureSenderIsActivePlayer(any(), any())
+        verify(gameStateGuard, never()).ensureSenderOwnsPlayer(any(), any(), any())
+    }
+
+    @Test
+    fun `advancePhase throws UNAUTHENTICATED when accessor has no principal`() {
+        assertUnauthenticated { controller.advancePhase(AdvancePhaseRequest(42), it) }
+        verify(gamePhaseService, never()).advancePhase(any())
+    }
+
+    @Test
+    fun `purchase throws UNAUTHENTICATED when accessor has no principal`() {
+        assertUnauthenticated {
+            controller.purchase(
+                PurchaseRequest(42, PurchaseType.ESTABLISHMENT, cardType = CardType.BAKERY),
+                it,
+            )
+        }
+        verify(purchaseService, never()).purchase(any(), any(), any(), any())
+    }
+
+    @Test
+    fun `endTurn throws UNAUTHENTICATED when accessor has no principal`() {
+        assertUnauthenticated { controller.endTurn(EndTurnRequest(42), it) }
+        verify(gamePhaseService, never()).endTurn(any())
+    }
+
+    @Test
+    fun `rollDice throws UNAUTHENTICATED when accessor has no principal`() {
+        assertUnauthenticated { controller.rollDice(RollDiceRequest(gameId = 42, playerId = 1), it) }
+        verify(diceService, never()).rollDice(any())
+    }
+
+    @Test
+    fun `leaveFinishedGame throws UNAUTHENTICATED when accessor has no principal`() {
+        assertUnauthenticated { controller.leaveFinishedGame(LeaveFinishedGameRequest(42, 99), it) }
+        verify(leaveFinishedGameService, never()).leaveFinishedGame(any(), any())
     }
 }

--- a/src/test/kotlin/org/machikoro/server/service/GameStateGuardTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GameStateGuardTest.kt
@@ -1,6 +1,5 @@
 package org.machikoro.server.service
 
-import java.security.Principal
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertThrows
@@ -146,18 +145,16 @@ class GameStateGuardTest {
     // ── ensureSenderIsActivePlayer ────────────────────────────────────────────
 
     @Test
-    fun `ensureSenderIsActivePlayer returns the principal when caller is the active player`() {
+    fun `ensureSenderIsActivePlayer succeeds when caller is the active player`() {
         val gameId = 1
         whenever(gameDao.findById(gameId))
             .thenReturn(game(gameId, GameStatus.IN_PROGRESS, currentTurnIndex = 0))
         whenever(playerDao.getPlayers(gameId)).thenReturn(
             listOf(player(id = 10, userId = 7), player(id = 11, userId = 8, turnOrder = 1)),
         )
-        val principal = UserPrincipal(userId = 7, username = "alice")
+        val user = UserPrincipal(userId = 7, username = "alice")
 
-        val result = guard.ensureSenderIsActivePlayer(gameId, principal)
-
-        assertEquals(principal, result)
+        guard.ensureSenderIsActivePlayer(gameId, user)
     }
 
     @Test
@@ -168,33 +165,12 @@ class GameStateGuardTest {
         whenever(playerDao.getPlayers(gameId)).thenReturn(
             listOf(player(id = 10, userId = 7), player(id = 11, userId = 8, turnOrder = 1)),
         )
-        val principal = UserPrincipal(userId = 8, username = "bob")
+        val user = UserPrincipal(userId = 8, username = "bob")
 
         val ex = assertThrows(CustomWebSocketException::class.java) {
-            guard.ensureSenderIsActivePlayer(gameId, principal)
+            guard.ensureSenderIsActivePlayer(gameId, user)
         }
         assertEquals("NOT_YOUR_TURN", ex.errorCode)
-    }
-
-    @Test
-    fun `ensureSenderIsActivePlayer throws UNAUTHENTICATED when principal is not a UserPrincipal`() {
-        val gameId = 1
-        val foreignPrincipal = Principal { "anon" }
-
-        val ex = assertThrows(CustomWebSocketException::class.java) {
-            guard.ensureSenderIsActivePlayer(gameId, foreignPrincipal)
-        }
-        assertEquals("UNAUTHENTICATED", ex.errorCode)
-    }
-
-    @Test
-    fun `ensureSenderIsActivePlayer throws UNAUTHENTICATED when principal is null`() {
-        val gameId = 1
-
-        val ex = assertThrows(CustomWebSocketException::class.java) {
-            guard.ensureSenderIsActivePlayer(gameId, null)
-        }
-        assertEquals("UNAUTHENTICATED", ex.errorCode)
     }
 
     @Test
@@ -203,10 +179,10 @@ class GameStateGuardTest {
         whenever(gameDao.findById(gameId))
             .thenReturn(game(gameId, GameStatus.IN_PROGRESS, currentTurnIndex = 5))
         whenever(playerDao.getPlayers(gameId)).thenReturn(listOf(player(id = 10, userId = 7)))
-        val principal = UserPrincipal(userId = 7, username = "alice")
+        val user = UserPrincipal(userId = 7, username = "alice")
 
         val ex = assertThrows(CustomWebSocketException::class.java) {
-            guard.ensureSenderIsActivePlayer(gameId, principal)
+            guard.ensureSenderIsActivePlayer(gameId, user)
         }
         assertEquals("NO_ACTIVE_PLAYER", ex.errorCode)
     }
@@ -215,10 +191,10 @@ class GameStateGuardTest {
     fun `ensureSenderIsActivePlayer propagates GAME_FINISHED when game has ended`() {
         val gameId = 1
         whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.FINISHED))
-        val principal = UserPrincipal(userId = 7, username = "alice")
+        val user = UserPrincipal(userId = 7, username = "alice")
 
         val ex = assertThrows(CustomWebSocketException::class.java) {
-            guard.ensureSenderIsActivePlayer(gameId, principal)
+            guard.ensureSenderIsActivePlayer(gameId, user)
         }
         assertEquals("GAME_FINISHED", ex.errorCode)
     }
@@ -226,17 +202,15 @@ class GameStateGuardTest {
     // ── ensureSenderOwnsPlayer ────────────────────────────────────────────────
 
     @Test
-    fun `ensureSenderOwnsPlayer returns the principal when caller owns the player`() {
+    fun `ensureSenderOwnsPlayer succeeds when caller owns the player`() {
         val gameId = 1
         val playerId = 10
         whenever(playerDao.getPlayers(gameId)).thenReturn(
             listOf(player(id = playerId, userId = 7), player(id = 11, userId = 8, turnOrder = 1)),
         )
-        val principal = UserPrincipal(userId = 7, username = "alice")
+        val user = UserPrincipal(userId = 7, username = "alice")
 
-        val result = guard.ensureSenderOwnsPlayer(gameId, playerId, principal)
-
-        assertEquals(principal, result)
+        guard.ensureSenderOwnsPlayer(gameId, playerId, user)
     }
 
     @Test
@@ -246,10 +220,10 @@ class GameStateGuardTest {
         whenever(playerDao.getPlayers(gameId)).thenReturn(
             listOf(player(id = playerId, userId = 7), player(id = 11, userId = 8, turnOrder = 1)),
         )
-        val principal = UserPrincipal(userId = 8, username = "bob")
+        val user = UserPrincipal(userId = 8, username = "bob")
 
         val ex = assertThrows(CustomWebSocketException::class.java) {
-            guard.ensureSenderOwnsPlayer(gameId, playerId, principal)
+            guard.ensureSenderOwnsPlayer(gameId, playerId, user)
         }
         assertEquals("NOT_YOUR_PLAYER", ex.errorCode)
     }
@@ -260,22 +234,11 @@ class GameStateGuardTest {
         whenever(playerDao.getPlayers(gameId)).thenReturn(
             listOf(player(id = 11, userId = 8, turnOrder = 1)),
         )
-        val principal = UserPrincipal(userId = 7, username = "alice")
+        val user = UserPrincipal(userId = 7, username = "alice")
 
         val ex = assertThrows(CustomWebSocketException::class.java) {
-            guard.ensureSenderOwnsPlayer(gameId, playerId = 99, principal)
+            guard.ensureSenderOwnsPlayer(gameId, playerId = 99, user)
         }
         assertEquals("PLAYER_NOT_IN_GAME", ex.errorCode)
-    }
-
-    @Test
-    fun `ensureSenderOwnsPlayer throws UNAUTHENTICATED when principal is not a UserPrincipal`() {
-        val gameId = 1
-        val foreignPrincipal = Principal { "anon" }
-
-        val ex = assertThrows(CustomWebSocketException::class.java) {
-            guard.ensureSenderOwnsPlayer(gameId, playerId = 10, foreignPrincipal)
-        }
-        assertEquals("UNAUTHENTICATED", ex.errorCode)
     }
 }


### PR DESCRIPTION
Closes #218. Stacks on top of #217 — GitHub will auto-retarget this PR to \`main\` once #217 merges.

## Summary

Same root cause as #217: Spring's \`accessor.user\` is null on every SEND frame in our setup, so \`GameStateGuard.requireUserPrincipal\` would always throw \`UNAUTHENTICATED\` for game-mutating actions. The "guard" was silently fail-closed for everyone rather than turn-checking, and #160's tests passed because they constructed \`Principal\` parameters directly, bypassing Spring's resolution path.

This PR routes every game-mutating endpoint through the \`SimpMessageHeaderAccessor.requireUserPrincipal()\` helper introduced in #217's followup.

## Changes

- **New**: \`SimpMessageHeaderAccessor.requireUserPrincipal()\` — non-null variant of the helper, throws \`CustomWebSocketException(\"UNAUTHENTICATED\", ...)\` so failures route via \`GlobalWebSocketExceptionHandler\` like other handled cases. Single place where \`UNAUTHENTICATED\` is raised.
- **Refactored**: \`GameStateGuard.ensureSenderIsActivePlayer\` / \`ensureSenderOwnsPlayer\` now take \`UserPrincipal\` directly (was \`Principal?\`). Drops the private \`requireUserPrincipal\` helper — the cast was load-bearing only because the caller couldn't guarantee a non-null \`UserPrincipal\`. Now it can.
- **Affected endpoints** (\`principal: Principal\` → \`headerAccessor: SimpMessageHeaderAccessor\`, resolved via the helper):
  - \`GameController.advancePhase\`, \`purchase\`, \`endTurn\`, \`rollDice\`, \`leaveFinishedGame\`
  - \`EarningsController.resolveEffects\`
- **In GameController**: two small private helpers (\`requireActivePlayer\`, \`requireOwnerOfPlayer\`) collapse the resolve+guard pair to one line per endpoint.

## Tests

- New \`UserPrincipalAccessorTest\` — both helper variants, both source paths (\`accessor.user\` + \`sessionAttributes\`), null case, foreign-Principal-type case, exact UNAUTHENTICATED exception message.
- \`GameStateGuardTest\` — drops the \`UNAUTHENTICATED\` tests for the two main methods (responsibility moved to the helper); existing return-value assertions become void-call assertions since the methods no longer return \`UserPrincipal\`.
- \`GameControllerTest\` / \`EarningsControllerTest\` — pass \`authedAccessor()\` instead of \`Principal\`; new \`assertUnauthenticated\` helper + boundary-pinned UNAUTHENTICATED test on **every** affected endpoint so a missed \`requireUserPrincipal()\` wiring can't slip through.

## Test plan

- [x] \`./gradlew check --warning-mode=all\` — green, no compile warnings, JaCoCo coverage verification passes
- [x] All existing tests still green
- [ ] Manual: full game flow (login → lobby → start game → roll dice → resolve effects → purchase → end turn → leave finished game) on a live server + Android client. Worth doing once #217 merges so this isn't tested against a still-broken interceptor.