### PR TITLE
feat: Enable layered bootJar for improved Docker image optimization

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,9 +15,42 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  build-jar:
+    name: Build jar
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build boot jar
+        run: |
+          ./gradlew bootJar -x test
+          mkdir -p build/docker
+          cp build/libs/*.jar build/docker/app.jar
+
+      - name: Upload boot jar
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-jar
+          path: build/docker/app.jar
+          if-no-files-found: error
+          retention-days: 1
+
   build-and-push:
     name: Build & push image
     runs-on: ubuntu-latest
+    needs: build-jar
 
     steps:
       - name: Checkout code
@@ -49,6 +82,12 @@ jobs:
             type=ref,event=tag
             type=sha,prefix=sha-,format=short
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+
+      - name: Download boot jar
+        uses: actions/download-artifact@v4
+        with:
+          name: app-jar
+          path: build/docker
 
       - name: Build and push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 concurrency:
   group: ghcr-publish-${{ github.ref }}
@@ -51,6 +50,9 @@ jobs:
     name: Build & push image
     runs-on: ubuntu-latest
     needs: build-jar
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout code

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -94,6 +94,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          target: runtime-from-workspace
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,37 @@
-FROM eclipse-temurin:21.0.6_7-jre-jammy
+# syntax=docker/dockerfile:1.7
+
+FROM --platform=$BUILDPLATFORM eclipse-temurin:21.0.6_7-jdk-jammy AS builder
+WORKDIR /app
+COPY gradlew .
+COPY gradle gradle
+COPY build.gradle.kts .
+COPY settings.gradle.kts .
+COPY gradle.properties .
+COPY gradle.lockfile .
+COPY src src
+RUN chmod +x ./gradlew
+RUN --mount=type=cache,target=/root/.gradle \
+    ./gradlew bootJar -x test
+
+FROM scratch AS packaged-jar
+COPY build/docker/app.jar /app.jar
+
+FROM eclipse-temurin:21.0.6_7-jre-jammy AS runtime-base
 WORKDIR /app
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/*
 RUN groupadd --system app && useradd --no-log-init --system --create-home --home-dir /app --gid app app
-COPY build/docker/app.jar app.jar
-RUN chown -R app:app /app
 EXPOSE 8080
+
+FROM runtime-base AS runtime-from-workspace
+COPY --chown=app:app --from=packaged-jar /app.jar /app/app.jar
 USER app
 ENTRYPOINT ["java", "-jar", "app.jar"]
+
+FROM runtime-base AS runtime-from-builder
+COPY --chown=app:app --from=builder /app/build/libs/*.jar /app/app.jar
+USER app
+ENTRYPOINT ["java", "-jar", "app.jar"]
+
+FROM runtime-from-builder AS final

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,10 @@
-FROM eclipse-temurin:21.0.6_7-jdk-jammy AS builder
-WORKDIR /app
-COPY gradlew .
-COPY gradle gradle
-COPY build.gradle.kts .
-COPY settings.gradle.kts .
-COPY src src
-RUN chmod +x ./gradlew
-RUN ./gradlew bootJar -x test
-
 FROM eclipse-temurin:21.0.6_7-jre-jammy
 WORKDIR /app
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/*
 RUN groupadd --system app && useradd --no-log-init --system --create-home --home-dir /app --gid app app
-COPY --from=builder /app/build/libs/*.jar app.jar
+COPY build/docker/app.jar app.jar
 RUN chown -R app:app /app
 EXPOSE 8080
 USER app

--- a/README.md
+++ b/README.md
@@ -209,6 +209,19 @@ Run the server locally:
 
 The backend will be available at: `http://localhost:8080`
 
+### Local Docker build
+
+For an end-to-end local run that mirrors the production container, use the compose
+override that builds the backend image from source:
+
+```bash
+docker compose -f compose.yaml -f compose.local-test.yaml --env-file .env.test up -d --build
+```
+
+This local Docker path keeps the source-based fallback in the `Dockerfile`, while
+the GitHub publish workflow uses a faster CI-only path that builds the Spring Boot
+jar once and reuses it for the multi-architecture image push.
+
 ## Testing
 
 Run the full test suite (unit + integration):
@@ -257,15 +270,23 @@ repository's `compose.yaml` on every push to `main`.
 ### Pipeline overview
 
 1. A push to `main` triggers the [`Publish Docker image to GHCR`](.github/workflows/docker-publish.yml)
-   workflow, which builds the backend image and pushes it to
+  workflow.
+2. The workflow first runs a `build-jar` job on `ubuntu-latest`, sets up JDK 21 with
+  Gradle dependency caching, and executes `./gradlew bootJar -x test` exactly once.
+  The resulting application jar is uploaded as a short-lived workflow artifact.
+3. The `build-and-push` job downloads that artifact and uses Docker Buildx to package
+  and push the multi-architecture runtime image for `linux/amd64` and `linux/arm64`
+  without recompiling the application per architecture. This avoids the slow Gradle
+  build under QEMU emulation on `arm64`.
+4. The published image is pushed to
    `ghcr.io/se2-machi-koro/server` with the tags:
    - `latest` (only on `main`)
    - `sha-<short-commit>` (every build, used for rollback)
    - `v*` (when a Git tag matching `v*` is pushed)
-2. doco-cd on the AAU server detects the change, pulls the new image (`pull_policy: always`),
+5. doco-cd on the AAU server detects the change, pulls the new image (`pull_policy: always`),
    and restarts the `backend` service defined in [compose.yaml](compose.yaml), when the
    course deployment config contains a stack entry for this repository.
-3. The Postgres service runs alongside the backend on the internal compose network and is
+6. The Postgres service runs alongside the backend on the internal compose network and is
    **not exposed to the host** — only the backend is published on `PUBLIC_PORT` (`53210`).
 
 ### Live endpoints

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,6 +82,12 @@ tasks.withType<Test> {
     finalizedBy(tasks.jacocoTestReport)
 }
 
+tasks.bootJar {
+    layered {
+        enabled.set(true)
+    }
+}
+
 tasks.jacocoTestReport {
     dependsOn(tasks.test)
     reports {


### PR DESCRIPTION
This pull request significantly improves the Docker build and CI workflow for the backend, optimizing for both local development and CI/CD. The main changes include splitting the Docker image build into separate build and runtime stages, introducing a CI workflow that builds the Spring Boot jar only once and reuses it for multi-architecture image publishing, and updating documentation to reflect these improvements.

**CI/CD and Docker build improvements:**

* Added a new `build-jar` job in `.github/workflows/docker-publish.yml` to build the Spring Boot jar once using Gradle with dependency caching, upload it as a workflow artifact, and reuse it in the subsequent `build-and-push` job, avoiding redundant builds for each architecture.
* Modified the Docker build process to use a multi-stage Dockerfile with explicit `builder`, `packaged-jar`, `runtime-base`, and `runtime-from-workspace` stages, supporting both CI and local development scenarios. The Dockerfile now uses BuildKit features and supports cross-platform builds more efficiently.
* Updated the Docker publish workflow to download the pre-built jar artifact and use a new Docker build target (`runtime-from-workspace`), ensuring the application is not rebuilt for each architecture during image publishing.

**Documentation updates:**

* Added documentation in `README.md` for running the backend locally using Docker Compose with a local build override, clarifying the distinction between local development and CI/CD image build paths.
* Expanded the pipeline overview in `README.md` to explain the new CI flow, including artifact upload/download and multi-architecture image publishing, and clarified the deployment process.