### PR TITLE
fix: Update .dockerignore to include docker directory and app.jar for…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,8 @@
 .idea
 .vscode
 build/
+!build/docker/
+!build/docker/app.jar
 out/
 bin/
 *.log


### PR DESCRIPTION
This pull request makes a small update to the `.dockerignore` file to improve Docker build context handling. The change ensures that the `build/docker/` directory and the `build/docker/app.jar` file are not ignored during Docker builds.… build context