### PR TITLE
Fix/static analysis findings index

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,3 +388,23 @@ To roll back to a previous image, edit the production `.env` on the server and s
 `IMAGE_TAG=sha-<short-commit>` (or any other tag published to GHCR), then trigger a
 manual `docker compose up -d` or a doco-cd reconcile. The `compose.yaml` resolves the image as
 `ghcr.io/se2-machi-koro/server:${IMAGE_TAG:-latest}`.
+
+## Frontend dependencies (Subresource Integrity)
+
+The static landing page at [`src/main/resources/static/index.html`](src/main/resources/static/index.html)
+loads three pinned assets from the cdnjs CDN (Bootstrap 4.6.0, SockJS-client 1.1.4,
+stomp.js 2.3.3). Each `<link>`/`<script>` tag includes a `sha512` Subresource Integrity
+(SRI) hash plus `crossorigin="anonymous"` and `referrerpolicy="no-referrer"`, so the
+browser refuses to execute any payload that does not match the pinned hash. This
+satisfies SonarCloud rule *"Make sure not using resource integrity feature is safe here"*
+(CWE / former-hotspot) and protects users if the CDN is ever compromised.
+
+When bumping any of these CDN versions, regenerate the matching hash:
+
+```bash
+curl -sSL <new-cdn-url> | openssl dgst -sha512 -binary | openssl base64 -A
+```
+
+Replace the `integrity="sha512-..."` value on the same tag and verify in the browser
+DevTools console that no *"Failed to find a valid digest in the 'integrity' attribute"*
+error is logged.

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,9 +1,13 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
     <title>Machi Koro WebSocket Chat</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.0/css/bootstrap.min.css" />
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.0/css/bootstrap.min.css"
+          integrity="sha512-P5MgMn1jBN01asBgU0z60Qk4QxiXo86+wlFahKrsQf37c9cro517WzVSPPV1tDKzhku2iJ2FVgL67wG03SGnNA=="
+          crossorigin="anonymous"
+          referrerpolicy="no-referrer" />
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
@@ -168,8 +172,14 @@
     </div>
 </div>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/sockjs-client/1.1.4/sockjs.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/sockjs-client/1.1.4/sockjs.min.js"
+        integrity="sha512-NtCC/sD+1gAeYGmT1LVVdi5kVMu5BTDxjeovYsuQP+w7wcsvNtUn2CsqJ348NEosjUCL8EZrDHrptytxiDpL7g=="
+        crossorigin="anonymous"
+        referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"
+        integrity="sha512-iKDtgDyTHjAitUDdLljGhenhPwrbBfqTKWO1mkhSFH3A7blITC9MhYon6SjnMhp4o0rADGw9yAC6EW4t5a4K3g=="
+        crossorigin="anonymous"
+        referrerpolicy="no-referrer"></script>
 <script>
     'use strict';
 


### PR DESCRIPTION
This pull request enhances the security of the static landing page by adding Subresource Integrity (SRI) to all CDN-loaded frontend dependencies and documents the process for maintaining these hashes. This ensures that browsers will only execute scripts and stylesheets if they match the expected cryptographic hash, protecting users from compromised third-party assets.

Security improvements for CDN assets:

* Added `integrity`, `crossorigin="anonymous"`, and `referrerpolicy="no-referrer"` attributes to Bootstrap, SockJS-client, and stomp.js CDN links in `index.html` to enforce Subresource Integrity and comply with SonarCloud recommendations. [[1]](diffhunk://#diff-36ac5dbb447ef006f7626236e877ac15575119dbc3b8f477a4780dd3b2d7fbdeL2-R10) [[2]](diffhunk://#diff-36ac5dbb447ef006f7626236e877ac15575119dbc3b8f477a4780dd3b2d7fbdeL171-R182)

Documentation updates:

* Added a new section to `README.md` explaining Subresource Integrity for frontend dependencies, including instructions for updating SRI hashes when bumping CDN versions.