### PR TITLE
fix: reject lobby joins for FINISHED games and route lobby exceptions through CustomWebSocketException

### DIFF
--- a/src/main/kotlin/org/machikoro/server/exception/CustomWebSocketException.kt
+++ b/src/main/kotlin/org/machikoro/server/exception/CustomWebSocketException.kt
@@ -3,9 +3,16 @@ package org.machikoro.server.exception
 /**
  * Application-level exception for handled WebSocket/STOMP message failures.
  *
+ * Open so that domain-specific exceptions (e.g. [GameNotFoundException],
+ * [GameStartedException]) can extend it and inherit the routing through
+ * `GlobalWebSocketExceptionHandler` while still being catchable by their
+ * specific type — see [GameStartedException]'s race-condition catch in
+ * `WebSocketController.addUser` for an example of why the type-safe catch
+ * matters.
+ *
  * @property errorCode stable functional code consumed by clients.
  */
-class CustomWebSocketException(
+open class CustomWebSocketException(
     val errorCode: String,
     override val message: String,
     cause: Throwable? = null

--- a/src/main/kotlin/org/machikoro/server/exception/GameFinishedException.kt
+++ b/src/main/kotlin/org/machikoro/server/exception/GameFinishedException.kt
@@ -1,0 +1,13 @@
+package org.machikoro.server.exception
+
+/**
+ * Raised when a lobby join is attempted on a game that has already moved to
+ * `FINISHED`. Carries the stable [errorCode] `GAME_FINISHED` — the same code
+ * `GameStateGuard.ensureGameIsRunning` raises for the equivalent in-game
+ * condition, so the client can handle one signal across both lobby-join and
+ * turn-action attempts.
+ */
+class GameFinishedException(message: String) : CustomWebSocketException(
+    errorCode = "GAME_FINISHED",
+    message = message,
+)

--- a/src/main/kotlin/org/machikoro/server/exception/GameNotFoundException.kt
+++ b/src/main/kotlin/org/machikoro/server/exception/GameNotFoundException.kt
@@ -1,3 +1,15 @@
 package org.machikoro.server.exception
 
-class GameNotFoundException(message: String) : RuntimeException(message)
+/**
+ * Raised when a service looks up a game id (or lobby code) that doesn't exist.
+ * Carries the stable [errorCode] `GAME_NOT_FOUND`.
+ *
+ * Used by both WS and REST callers — for the REST path (`LobbyController`),
+ * the catch-all `Exception` handler returns HTTP 400 with the message, so
+ * the inherited `CustomWebSocketException` machinery doesn't change the
+ * REST contract.
+ */
+class GameNotFoundException(message: String) : CustomWebSocketException(
+    errorCode = "GAME_NOT_FOUND",
+    message = message,
+)

--- a/src/main/kotlin/org/machikoro/server/exception/GameStartedException.kt
+++ b/src/main/kotlin/org/machikoro/server/exception/GameStartedException.kt
@@ -1,3 +1,15 @@
 package org.machikoro.server.exception
 
-class GameStartedException(message: String) : RuntimeException(message)
+/**
+ * Raised when a lobby join is attempted on a game that has already moved to
+ * `IN_PROGRESS`. Carries the stable [errorCode] `GAME_STARTED` so the client
+ * can distinguish this from other join-time failures.
+ *
+ * Kept as a concrete subclass (not a raw `CustomWebSocketException("GAME_STARTED", ...)`)
+ * so `WebSocketController.addUser` can still catch it specifically for its
+ * race-condition remap path without string-comparing error codes.
+ */
+class GameStartedException(message: String) : CustomWebSocketException(
+    errorCode = "GAME_STARTED",
+    message = message,
+)

--- a/src/main/kotlin/org/machikoro/server/exception/LobbyFullException.kt
+++ b/src/main/kotlin/org/machikoro/server/exception/LobbyFullException.kt
@@ -1,3 +1,10 @@
 package org.machikoro.server.exception
 
-class LobbyFullException(message: String) : RuntimeException(message)
+/**
+ * Raised when a lobby join is attempted on a game that has already reached
+ * its `maxPlayers` cap. Carries the stable [errorCode] `LOBBY_FULL`.
+ */
+class LobbyFullException(message: String) : CustomWebSocketException(
+    errorCode = "LOBBY_FULL",
+    message = message,
+)

--- a/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
@@ -9,6 +9,7 @@ import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.models.GameModel
 import org.machikoro.server.domain.models.PlayerModel
 import org.machikoro.server.dto.GameStateDto
+import org.machikoro.server.exception.GameFinishedException
 import org.machikoro.server.exception.GameNotFoundException
 import org.machikoro.server.exception.GameStartedException
 import org.machikoro.server.exception.LobbyFullException
@@ -76,6 +77,7 @@ open class LobbyService(
      *
      * @throws GameNotFoundException if no lobby with [lobbyCode] exists.
      * @throws GameStartedException  if the game has already started.
+     * @throws GameFinishedException if the game has already ended.
      * @throws LobbyFullException    if the lobby has already reached its player cap.
      */
     fun joinLobby(lobbyCode: String, userId: Int): PlayerModel = runInTransaction {
@@ -89,19 +91,31 @@ open class LobbyService(
      * Adds [userId] to the lobby for [gameId] if the game exists, is still in the
      * WAITING state and has not yet reached its player cap.
      *
-     * @throws GameNotFoundException  if no game with [gameId] exists.
-     * @throws GameStartedException   if the game has already moved to IN_PROGRESS.
-     * @throws LobbyFullException     if the lobby already has reached its player cap.
+     * Existing players in the game can rejoin regardless of status (including
+     * FINISHED) — the reconnect short-circuit returns their record without any
+     * status check or DB write. New joins are rejected for both IN_PROGRESS and
+     * FINISHED games.
+     *
+     * @throws GameNotFoundException        if no game with [gameId] exists.
+     * @throws GameStartedException         if the game has already moved to IN_PROGRESS.
+     * @throws GameFinishedException        if the game has already ended.
+     * @throws LobbyFullException           if the lobby already has reached its player cap.
      */
     fun addUserToLobby(gameId: Int, userId: Int): PlayerModel {
         val game = gameDao.findById(gameId)
             ?: throw GameNotFoundException("Game $gameId not found")
 
         // Reconnect path: player already belongs to this game, so do not re-insert.
+        // Allowed regardless of game status — a player rejoining a FINISHED game
+        // can still pull their final state via the same record.
         playerDao.findByGameIdAndUserId(gameId, userId)?.let { return it }
 
         if (game.status == GameStatus.IN_PROGRESS) {
             throw GameStartedException("Game $gameId has already started")
+        }
+
+        if (game.status == GameStatus.FINISHED) {
+            throw GameFinishedException("Game $gameId has already finished")
         }
 
         synchronized(lobbyLocks.getOrPut(gameId) { Any() }) {

--- a/src/test/kotlin/org/machikoro/server/exception/LobbyExceptionsTest.kt
+++ b/src/test/kotlin/org/machikoro/server/exception/LobbyExceptionsTest.kt
@@ -1,19 +1,51 @@
 package org.machikoro.server.exception
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Test
 
+/**
+ * Pins the wire contract for the lobby/game exception family:
+ *  - each exception preserves its constructor message,
+ *  - each exposes the stable `errorCode` clients match on,
+ *  - each is a `CustomWebSocketException` so `GlobalWebSocketExceptionHandler`
+ *    routes it via `/user/queue/errors` with the correct code.
+ *
+ * A future refactor that swaps the hardcoded code (or unhooks the hierarchy)
+ * has to update these tests, which makes the contract change visible in code
+ * review.
+ */
 class LobbyExceptionsTest {
 
     @Test
-    fun `GameStartedException retains message`() {
+    fun `GameStartedException carries message, GAME_STARTED code, and extends CustomWebSocketException`() {
         val ex = GameStartedException("test msg")
         assertEquals("test msg", ex.message)
+        assertEquals("GAME_STARTED", ex.errorCode)
+        assertInstanceOf(CustomWebSocketException::class.java, ex)
     }
 
     @Test
-    fun `LobbyFullException retains message`() {
+    fun `LobbyFullException carries message, LOBBY_FULL code, and extends CustomWebSocketException`() {
         val ex = LobbyFullException("test msg 2")
         assertEquals("test msg 2", ex.message)
+        assertEquals("LOBBY_FULL", ex.errorCode)
+        assertInstanceOf(CustomWebSocketException::class.java, ex)
+    }
+
+    @Test
+    fun `GameNotFoundException carries message, GAME_NOT_FOUND code, and extends CustomWebSocketException`() {
+        val ex = GameNotFoundException("nope")
+        assertEquals("nope", ex.message)
+        assertEquals("GAME_NOT_FOUND", ex.errorCode)
+        assertInstanceOf(CustomWebSocketException::class.java, ex)
+    }
+
+    @Test
+    fun `GameFinishedException carries message, GAME_FINISHED code, and extends CustomWebSocketException`() {
+        val ex = GameFinishedException("done")
+        assertEquals("done", ex.message)
+        assertEquals("GAME_FINISHED", ex.errorCode)
+        assertInstanceOf(CustomWebSocketException::class.java, ex)
     }
 }

--- a/src/test/kotlin/org/machikoro/server/service/LobbyServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/LobbyServiceTest.kt
@@ -1,6 +1,8 @@
 package org.machikoro.server.service
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.machikoro.server.dao.GameDao
@@ -10,12 +12,14 @@ import org.machikoro.server.dao.PlayerLandmarkDao
 import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.models.GameModel
 import org.machikoro.server.domain.models.PlayerModel
+import org.machikoro.server.exception.GameFinishedException
 import org.machikoro.server.exception.GameNotFoundException
 import org.machikoro.server.exception.GameStartedException
 import org.machikoro.server.exception.LobbyFullException
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -87,6 +91,44 @@ class LobbyServiceTest {
         assertThrows<GameStartedException> {
             lobbyService.addUserToLobby(gameId, 10)
         }
+    }
+
+    @Test
+    fun `addUserToLobby throws GameFinishedException when game is finished and user is not a player`() {
+        val gameId = 5
+        val userId = 10
+        whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.FINISHED))
+        // playerDao.findByGameIdAndUserId returns null by default → user is not
+        // an existing player, so the reconnect short-circuit doesn't apply and
+        // the FINISHED check must fire.
+
+        val ex = assertThrows<GameFinishedException> {
+            lobbyService.addUserToLobby(gameId, userId)
+        }
+
+        // GAME_FINISHED is the contract code the client matches on — assert
+        // both the type and the code so a future refactor that changes the
+        // exception hierarchy can't silently drop the code.
+        assertEquals("GAME_FINISHED", ex.errorCode)
+        // No player row must be inserted into a finished game.
+        verify(playerDao, never()).addPlayer(any(), any())
+    }
+
+    @Test
+    fun `addUserToLobby returns existing player on reconnect to FINISHED game without throwing`() {
+        // Pins the design choice: existing players can rejoin a finished game
+        // (to pull final state). The reconnect short-circuit runs before any
+        // status check, mirroring how IN_PROGRESS games already behave.
+        val gameId = 6
+        val userId = 11
+        val existing = player(99).copy(gameId = gameId, userId = userId)
+        whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.FINISHED))
+        whenever(playerDao.findByGameIdAndUserId(gameId, userId)).thenReturn(existing)
+
+        val result = lobbyService.addUserToLobby(gameId, userId)
+
+        assertSame(existing, result)
+        verify(playerDao, never()).addPlayer(any(), any())
     }
 
     @Test


### PR DESCRIPTION
Closes #202.

## Summary

Before this PR, \`LobbyService.addUserToLobby\` only checked for \`IN_PROGRESS\` — a user joining a \`FINISHED\` game fell through to \`playerDao.addPlayer\` and inserted a new player row into a finished game. The fix is small (a status check next to the existing IN_PROGRESS one), but I expanded the PR scope slightly to also fix a related inconsistency that surfaces in the same diff: lobby exceptions weren't routing through \`GlobalWebSocketExceptionHandler\` with stable error codes.

### What changed

**Bug fix (#202):**
- New explicit \`FINISHED\` check in \`addUserToLobby\`, placed between the reconnect short-circuit and the \`IN_PROGRESS\` check. The two terminal-state branches now sit next to each other and read as a pair.
- Design choice: existing players **can** rejoin a \`FINISHED\` game to pull their final state — mirrors how \`IN_PROGRESS\` already behaves. The short-circuit runs before any status check, so this is a no-DB-write reconnect. Pinned by a new test.
- New joins to a \`FINISHED\` game are rejected with \`GameFinishedException\` (code \`GAME_FINISHED\`), and \`playerDao.addPlayer\` is never reached — proven by \`verify(playerDao, never()).addPlayer(...)\` in the test.

**Exception-routing cleanup:**
- \`CustomWebSocketException\` is now \`open\`.
- \`GameStartedException\`, \`LobbyFullException\`, \`GameNotFoundException\` now extend \`CustomWebSocketException\` with stable error codes (\`GAME_STARTED\`, \`LOBBY_FULL\`, \`GAME_NOT_FOUND\`).
- New \`GameFinishedException\` (\`GAME_FINISHED\`) reuses the same code \`GameStateGuard.ensureGameIsRunning\` raises for the in-game condition — single signal across both lobby-join and turn-action attempts.
- Constructor signatures are **unchanged**, so all existing \`throw …Exception(msg)\` callers and \`assertThrows<…Exception>\` test cases keep working. The race-condition catch on \`GameStartedException\` in \`WebSocketController.addUser\` is preserved by the subclass relationship.

## Behavior changes

| Caller path | Before | After |
|---|---|---|
| WS handler → \`GameStartedException\` | client sees \`INTERNAL_ERROR\` | client sees \`GAME_STARTED\` |
| WS handler → \`LobbyFullException\` | \`INTERNAL_ERROR\` | \`LOBBY_FULL\` |
| WS handler → \`GameNotFoundException\` (thrown from 7 sites in GameDao + services) | \`INTERNAL_ERROR\` | \`GAME_NOT_FOUND\` |
| New: WS handler → \`GameFinishedException\` | (didn't exist — row silently inserted) | \`GAME_FINISHED\`, no DB write |
| REST \`LobbyController.startGame\` | HTTP 400 via \`catch (Exception)\` | HTTP 400 — **unchanged** |

Strict UX improvement on the WS side, no-op on REST.

## Tests

- \`LobbyServiceTest\`:
  - \`addUserToLobby throws GameFinishedException when game is finished and user is not a player\` — asserts the type, the \`GAME_FINISHED\` code, AND that \`playerDao.addPlayer\` is never called.
  - \`addUserToLobby returns existing player on reconnect to FINISHED game without throwing\` — pins the design choice.
- \`LobbyExceptionsTest\` — expanded from two tests to four covering all four lobby exceptions, asserting both the error code and the \`CustomWebSocketException\` hierarchy.

## Test plan

- [x] \`./gradlew compileKotlin compileTestKotlin --warning-mode=all\` — no new warnings.
- [x] \`./gradlew test --tests <affected classes>\` — all green: \`LobbyServiceTest\`, \`LobbyExceptionsTest\`, \`LobbyControllerTests\`, \`WebSocketControllerTests\`, \`GameStateGuardTest\`, \`GameControllerTest\`, \`EarningsControllerTest\`, \`DiceServiceTests\`, \`GameSyncServiceTest\`, \`WinConditionServiceTest\`, \`GlobalWebSocketExceptionHandlerTests\`.
- [x] Testcontainers-backed integration tests not run locally (Docker not available); CI will exercise.
- [x] Sonar runs in CI.