### PR TITLE
feat: include playerLandmarks in GameStateDto and sync snapshot

### DIFF
--- a/src/main/kotlin/org/machikoro/server/dao/PlayerLandmarkDao.kt
+++ b/src/main/kotlin/org/machikoro/server/dao/PlayerLandmarkDao.kt
@@ -1,6 +1,7 @@
 package org.machikoro.server.dao
 
 import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
@@ -29,12 +30,17 @@ class PlayerLandmarkDao {
     )
 
     /**
-     * Finds all landmarks for a given player
+     * Finds all landmarks for a given player, ordered alphabetically by
+     * landmark type. Stable ordering matters because the result is surfaced
+     * in `GameStateDto.playerLandmarks` and serialized to clients — without
+     * an explicit order, the JSON output (and any downstream test assertions)
+     * would be at the mercy of the DB's row-return order.
      */
     fun findByPlayerId(playerId: Int): List<PlayerLandmarkModel> = transaction {
         (PlayerLandmarks innerJoin Landmarks)
             .selectAll()
             .where { PlayerLandmarks.playerId eq playerId }
+            .orderBy(Landmarks.landmarkType to SortOrder.ASC)
             .map { it.toPlayerLandmarkModel() }
     }
 

--- a/src/main/kotlin/org/machikoro/server/dto/GameStateDto.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/GameStateDto.kt
@@ -3,18 +3,21 @@ package org.machikoro.server.dto
 import io.swagger.v3.oas.annotations.media.Schema
 import org.machikoro.server.domain.models.GameModel
 import org.machikoro.server.domain.models.PlayerCardModel
+import org.machikoro.server.domain.models.PlayerLandmarkModel
 import org.machikoro.server.domain.models.PlayerModel
 
 /**
- * Full snapshot of the game state broadcast to every player when the game starts.
+ * Full snapshot of the game state broadcast to every player when the game
+ * starts and returned by `/app/game.sync` on reconnect.
  *
- * @property game        Updated [GameModel] (status = IN_PROGRESS).
- * @property players     Sanitized, active player list for this game.
- * @property playerCards Map of playerId → list of [PlayerCardModel] representing each player's hand.
- * @property turnOrder   Ordered list of **player IDs** representing the randomized turn order
- *                       (index 0 goes first).
+ * @property game             Updated [GameModel] (status = IN_PROGRESS).
+ * @property players          Sanitized, active player list for this game.
+ * @property playerCards      Map of playerId → list of [PlayerCardModel] representing each player's hand.
+ * @property playerLandmarks  Map of playerId → list of [PlayerLandmarkModel] with each landmark's built / unbuilt state.
+ * @property turnOrder        Ordered list of **player IDs** representing the randomized turn order
+ *                            (index 0 goes first).
  */
-@Schema(description = "Initial game state broadcast to all clients when the game starts")
+@Schema(description = "Full game state broadcast on game start and returned by /app/game.sync on reconnect")
 data class GameStateDto(
     @Schema(description = "Updated game model with status IN_PROGRESS")
     val game: GameModel,
@@ -24,6 +27,9 @@ data class GameStateDto(
 
     @Schema(description = "Map of playerId to the player's starting hand")
     val playerCards: Map<Int, List<PlayerCardModel>>,
+
+    @Schema(description = "Map of playerId to the player's landmarks (with built / unbuilt state)")
+    val playerLandmarks: Map<Int, List<PlayerLandmarkModel>>,
 
     @Schema(description = "Randomized turn order as a list of player IDs")
     val turnOrder: List<Int>,

--- a/src/main/kotlin/org/machikoro/server/service/GameSyncService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/GameSyncService.kt
@@ -3,6 +3,7 @@ package org.machikoro.server.service
 import org.machikoro.server.dao.GameDao
 import org.machikoro.server.dao.PlayerCardDao
 import org.machikoro.server.dao.PlayerDao
+import org.machikoro.server.dao.PlayerLandmarkDao
 import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.dto.GameStateDto
 import org.machikoro.server.exception.GameNotFoundException
@@ -13,6 +14,7 @@ class GameSyncService(
     private val gameDao: GameDao,
     private val playerDao: PlayerDao,
     private val playerCardDao: PlayerCardDao,
+    private val playerLandmarkDao: PlayerLandmarkDao,
 ) {
 
     fun findActiveInProgressGameId(userId: Int): Int? =
@@ -28,11 +30,18 @@ class GameSyncService(
         val playerCards = players.associate { player ->
             player.id to (playerCardsByPlayerId[player.id] ?: emptyList())
         }
+        // PlayerLandmarkDao has no batch lookup today; with maxPlayers = 4 the
+        // per-player iteration here is bounded at 4 queries per snapshot. If
+        // that ever matters, add findByPlayerIds() mirroring PlayerCardDao.
+        val playerLandmarks = players.associate { player ->
+            player.id to playerLandmarkDao.findByPlayerId(player.id)
+        }
 
         return GameStateDto(
             game = game,
             players = players,
             playerCards = playerCards,
+            playerLandmarks = playerLandmarks,
             turnOrder = players.sortedBy { it.turnOrder }.map { it.id },
         )
     }

--- a/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
@@ -173,10 +173,18 @@ open class LobbyService(
         gameDao.updateStatus(gameId, GameStatus.IN_PROGRESS)
         val updatedGame = gameDao.findById(gameId)!!
 
+        // After initForPlayer each player has all landmarks as unbuilt rows.
+        // Include them in the initial snapshot so clients can render the build
+        // grid immediately, without an extra round-trip.
+        val playerLandmarks = shuffled.associate { player ->
+            player.id to playerLandmarkDao.findByPlayerId(player.id)
+        }
+
         GameStateDto(
             game = updatedGame,
             players = shuffled,
             playerCards = emptyMap(),
+            playerLandmarks = playerLandmarks,
             turnOrder = shuffled.map { it.id },
         )
     }

--- a/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
@@ -78,6 +78,7 @@ class GameControllerTest {
             PlayerModel(id = 2, gameId = gameId, userId = 2, turnOrder = 1, coins = 3, lastSeenAt = null),
         ),
         playerCards = emptyMap(),
+        playerLandmarks = emptyMap(),
         turnOrder = listOf(1, 2),
     )
 

--- a/src/test/kotlin/org/machikoro/server/controller/LobbyControllerTests.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/LobbyControllerTests.kt
@@ -33,6 +33,7 @@ class LobbyControllerTests {
         ),
         players = emptyList(),
         playerCards = emptyMap(),
+        playerLandmarks = emptyMap(),
         turnOrder = emptyList(),
     )
 

--- a/src/test/kotlin/org/machikoro/server/service/GameSyncServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GameSyncServiceTest.kt
@@ -9,11 +9,14 @@ import org.junit.jupiter.api.assertThrows
 import org.machikoro.server.dao.GameDao
 import org.machikoro.server.dao.PlayerCardDao
 import org.machikoro.server.dao.PlayerDao
+import org.machikoro.server.dao.PlayerLandmarkDao
 import org.machikoro.server.domain.enums.CardType
 import org.machikoro.server.domain.enums.GameStatus
+import org.machikoro.server.domain.enums.LandmarkType
 import org.machikoro.server.domain.enums.TurnPhase
 import org.machikoro.server.domain.models.GameModel
 import org.machikoro.server.domain.models.PlayerCardModel
+import org.machikoro.server.domain.models.PlayerLandmarkModel
 import org.machikoro.server.domain.models.PlayerModel
 import org.machikoro.server.exception.GameNotFoundException
 import org.mockito.kotlin.mock
@@ -25,7 +28,8 @@ class GameSyncServiceTest {
     private val gameDao = mock<GameDao>()
     private val playerDao = mock<PlayerDao>()
     private val playerCardDao = mock<PlayerCardDao>()
-    private val service = GameSyncService(gameDao, playerDao, playerCardDao)
+    private val playerLandmarkDao = mock<PlayerLandmarkDao>()
+    private val service = GameSyncService(gameDao, playerDao, playerCardDao, playerLandmarkDao)
 
     private fun game(id: Int, status: GameStatus) = GameModel(
         id = id,
@@ -73,6 +77,14 @@ class GameSyncServiceTest {
                 // player 2 has no cards — absent from the map
             )
         )
+        // Per-player landmark lookup — see GameSyncService.buildSnapshot for
+        // the N=4 cap rationale on why this isn't a single batch query.
+        whenever(playerLandmarkDao.findByPlayerId(1)).thenReturn(
+            listOf(PlayerLandmarkModel(1, LandmarkType.TRAIN_STATION, isBuilt = true)),
+        )
+        whenever(playerLandmarkDao.findByPlayerId(2)).thenReturn(
+            listOf(PlayerLandmarkModel(2, LandmarkType.TRAIN_STATION, isBuilt = false)),
+        )
 
         val snapshot = service.buildSnapshot(gameId)
 
@@ -81,6 +93,11 @@ class GameSyncServiceTest {
         assertEquals(listOf(2, 1), snapshot.turnOrder)
         assertEquals(1, snapshot.playerCards[1]?.size)
         assertTrue(snapshot.playerCards[2].isNullOrEmpty())
+        // Landmarks are keyed by playerId and preserve isBuilt per row.
+        assertEquals(1, snapshot.playerLandmarks[1]?.size)
+        assertEquals(true, snapshot.playerLandmarks[1]?.first()?.isBuilt)
+        assertEquals(1, snapshot.playerLandmarks[2]?.size)
+        assertEquals(false, snapshot.playerLandmarks[2]?.first()?.isBuilt)
     }
 
     @Test
@@ -95,6 +112,7 @@ class GameSyncServiceTest {
         assertTrue(snapshot.players.isEmpty())
         assertTrue(snapshot.turnOrder.isEmpty())
         assertTrue(snapshot.playerCards.isEmpty())
+        assertTrue(snapshot.playerLandmarks.isEmpty())
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/service/LobbyServiceIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/LobbyServiceIntegrationTest.kt
@@ -105,6 +105,13 @@ class LobbyServiceIntegrationTest : AbstractDBSetup() {
         assertTrue(gameMarketplaceDao.findByGameId(gameId).isNotEmpty())
         assertTrue(playerLandmarkDao.findByPlayerId(firstPlayerId).isNotEmpty())
         assertTrue(playerLandmarkDao.findByPlayerId(secondPlayerId).isNotEmpty())
+        // Snapshot must include the freshly-initialized landmarks so the
+        // client renders the build grid without an extra round-trip — see
+        // SE2-Machi-Koro/Server#247.
+        assertTrue(result.playerLandmarks[firstPlayerId]?.isNotEmpty() == true)
+        assertTrue(result.playerLandmarks[secondPlayerId]?.isNotEmpty() == true)
+        // All landmarks start unbuilt at game start.
+        assertTrue(result.playerLandmarks.values.flatten().all { !it.isBuilt })
     }
 
     @Test


### PR DESCRIPTION
Closes #247. Part of #246 (Complete Game State Snapshot for Reconnect).

## Why

Reconnect via `/app/game.sync` currently returns players, coins, owned cards, and turn order — but not landmark build state. The client can't render the build grid on reconnect without an extra round-trip. The same gap exists for the initial \`GAME_STARTED\` broadcast.

## What changed

- **\`GameStateDto\`** gains a required \`playerLandmarks: Map<Int, List<PlayerLandmarkModel>>\` field, mirroring the existing \`playerCards\` shape. No default value, so every construction site is enforced at compile time. Swagger schema + KDoc updated to describe the dual purpose (game start broadcast + sync response).
- **\`GameSyncService.buildSnapshot\`** injects \`PlayerLandmarkDao\` and populates the new map. Per-player iteration is bounded at \`N = maxPlayers = 4\` — a comment points to where a batch DAO method would go if that ever matters.
- **\`LobbyService.startGame\`** includes the freshly-initialized landmarks in the initial snapshot — same transaction as \`initForPlayer\`, so reads see the just-written rows. Clients get the full build grid in one message instead of needing a follow-up sync.
- **\`PlayerLandmarkDao.findByPlayerId\`** adds \`.orderBy(Landmarks.landmarkType to SortOrder.ASC)\`. Stable ordering matters now that the result is serialized to clients — without it the JSON output (and any downstream tests, e.g. the integration test in #249) would be at the mercy of the DB's row-return order.

## Tests

- **\`GameSyncServiceTest\`** — added \`PlayerLandmarkDao\` mock; extended the primary snapshot test to stub one built and one unbuilt landmark and assert both round-trip per player; added \`playerLandmarks.isEmpty()\` assertion to the zero-players test.
- **\`LobbyServiceIntegrationTest.startGame ...\`** — now asserts the new field is populated for both players and that every landmark starts unbuilt.
- **\`GameControllerTest\` + \`LobbyControllerTests\`** — \`gameStateDto()\` helpers updated with \`playerLandmarks = emptyMap()\` (compile-forced since the field has no default).

## Wire-format note

This is an **additive** field on a JSON DTO. Existing clients that don't yet read \`playerLandmarks\` continue to work — Jackson's default deserializer ignores unknown-on-write fields. The matching client-side render work is tracked in [Client #140](https://github.com/SE2-Machi-Koro/Client/issues/140).

## Test plan

- [x] \`./gradlew compileKotlin compileTestKotlin --warning-mode=all\` — no warnings.
- [x] \`./gradlew test --tests <affected>\` — \`GameSyncServiceTest\`, \`LobbyServiceTest\`, \`GameControllerTest\`, \`LobbyControllerTests\` all green.
- [ ] Testcontainers integration tests (\`LobbyServiceIntegrationTest\`) — not run locally (Docker not available); will exercise in CI.
- [ ] Sonar runs in CI.