### PR TITLE
feat: include marketplace supply in GameStateDto snapshot

### DIFF
--- a/src/main/kotlin/org/machikoro/server/dao/GameMarketplaceDao.kt
+++ b/src/main/kotlin/org/machikoro/server/dao/GameMarketplaceDao.kt
@@ -41,6 +41,13 @@ class GameMarketplaceDao {
     }
 
     /**
+     * Returns the marketplace for [gameId] as a cardType → remaining-quantity map,
+     * the shape that callers building [org.machikoro.server.dto.GameStateDto] need.
+     */
+    fun findByGameIdAsMap(gameId: Int): Map<CardType, Int> =
+        findByGameId(gameId).associate { it.cardType to it.quantityAvailable }
+
+    /**
      * Retrieves a specific card entry from marketplace for a game
      * Returns null if card is not present
      */

--- a/src/main/kotlin/org/machikoro/server/dto/GameStateDto.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/GameStateDto.kt
@@ -1,6 +1,7 @@
 package org.machikoro.server.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.machikoro.server.domain.enums.CardType
 import org.machikoro.server.domain.models.GameModel
 import org.machikoro.server.domain.models.PlayerCardModel
 import org.machikoro.server.domain.models.PlayerLandmarkModel
@@ -14,6 +15,7 @@ import org.machikoro.server.domain.models.PlayerModel
  * @property players          Sanitized, active player list for this game.
  * @property playerCards      Map of playerId → list of [PlayerCardModel] representing each player's hand.
  * @property playerLandmarks  Map of playerId → list of [PlayerLandmarkModel] with each landmark's built / unbuilt state.
+ * @property marketplace      Map of [CardType] → remaining quantity in the game's marketplace supply.
  * @property turnOrder        Ordered list of **player IDs** representing the randomized turn order
  *                            (index 0 goes first).
  */
@@ -30,6 +32,9 @@ data class GameStateDto(
 
     @Schema(description = "Map of playerId to the player's landmarks (with built / unbuilt state)")
     val playerLandmarks: Map<Int, List<PlayerLandmarkModel>>,
+
+    @Schema(description = "Map of CardType to the remaining quantity available in the marketplace supply")
+    val marketplace: Map<CardType, Int>,
 
     @Schema(description = "Randomized turn order as a list of player IDs")
     val turnOrder: List<Int>,

--- a/src/main/kotlin/org/machikoro/server/service/GameSyncService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/GameSyncService.kt
@@ -38,8 +38,7 @@ class GameSyncService(
         val playerLandmarks = players.associate { player ->
             player.id to playerLandmarkDao.findByPlayerId(player.id)
         }
-        val marketplace = gameMarketplaceDao.findByGameId(gameId)
-            .associate { it.cardType to it.quantityAvailable }
+        val marketplace = gameMarketplaceDao.findByGameIdAsMap(gameId)
 
         return GameStateDto(
             game = game,

--- a/src/main/kotlin/org/machikoro/server/service/GameSyncService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/GameSyncService.kt
@@ -1,6 +1,7 @@
 package org.machikoro.server.service
 
 import org.machikoro.server.dao.GameDao
+import org.machikoro.server.dao.GameMarketplaceDao
 import org.machikoro.server.dao.PlayerCardDao
 import org.machikoro.server.dao.PlayerDao
 import org.machikoro.server.dao.PlayerLandmarkDao
@@ -15,6 +16,7 @@ class GameSyncService(
     private val playerDao: PlayerDao,
     private val playerCardDao: PlayerCardDao,
     private val playerLandmarkDao: PlayerLandmarkDao,
+    private val gameMarketplaceDao: GameMarketplaceDao,
 ) {
 
     fun findActiveInProgressGameId(userId: Int): Int? =
@@ -36,12 +38,15 @@ class GameSyncService(
         val playerLandmarks = players.associate { player ->
             player.id to playerLandmarkDao.findByPlayerId(player.id)
         }
+        val marketplace = gameMarketplaceDao.findByGameId(gameId)
+            .associate { it.cardType to it.quantityAvailable }
 
         return GameStateDto(
             game = game,
             players = players,
             playerCards = playerCards,
             playerLandmarks = playerLandmarks,
+            marketplace = marketplace,
             turnOrder = players.sortedBy { it.turnOrder }.map { it.id },
         )
     }

--- a/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
@@ -179,12 +179,18 @@ open class LobbyService(
         val playerLandmarks = shuffled.associate { player ->
             player.id to playerLandmarkDao.findByPlayerId(player.id)
         }
+        // Same reasoning for the marketplace — initForGame above seeded the
+        // full supply, so the client can render the buyable card grid on the
+        // first GAME_STARTED frame.
+        val marketplace = gameMarketplaceDao.findByGameId(gameId)
+            .associate { it.cardType to it.quantityAvailable }
 
         GameStateDto(
             game = updatedGame,
             players = shuffled,
             playerCards = emptyMap(),
             playerLandmarks = playerLandmarks,
+            marketplace = marketplace,
             turnOrder = shuffled.map { it.id },
         )
     }

--- a/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
@@ -182,8 +182,7 @@ open class LobbyService(
         // Same reasoning for the marketplace — initForGame above seeded the
         // full supply, so the client can render the buyable card grid on the
         // first GAME_STARTED frame.
-        val marketplace = gameMarketplaceDao.findByGameId(gameId)
-            .associate { it.cardType to it.quantityAvailable }
+        val marketplace = gameMarketplaceDao.findByGameIdAsMap(gameId)
 
         GameStateDto(
             game = updatedGame,

--- a/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
@@ -89,6 +89,7 @@ class GameControllerTest {
         ),
         playerCards = emptyMap(),
         playerLandmarks = emptyMap(),
+        marketplace = emptyMap(),
         turnOrder = listOf(1, 2),
     )
 

--- a/src/test/kotlin/org/machikoro/server/controller/LobbyControllerTests.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/LobbyControllerTests.kt
@@ -34,6 +34,7 @@ class LobbyControllerTests {
         players = emptyList(),
         playerCards = emptyMap(),
         playerLandmarks = emptyMap(),
+        marketplace = emptyMap(),
         turnOrder = emptyList(),
     )
 

--- a/src/test/kotlin/org/machikoro/server/dao/GameMarketplaceDaoTest.kt
+++ b/src/test/kotlin/org/machikoro/server/dao/GameMarketplaceDaoTest.kt
@@ -238,6 +238,20 @@ class GameMarketplaceDaoTest : AbstractDBSetup() {
     }
 
     @Test
+    fun `findByGameIdAsMap returns empty map before init`() {
+        assertTrue(marketplaceDao.findByGameIdAsMap(gameId).isEmpty())
+    }
+
+    @Test
+    fun `findByGameIdAsMap returns cardType to quantity after init`() {
+        marketplaceDao.initForGame(gameId, supplyPerCard = 4)
+        val asMap = marketplaceDao.findByGameIdAsMap(gameId)
+        assertEquals(CardType.entries.size, asMap.size)
+        assertTrue(asMap.values.all { it == 4 })
+        assertEquals(4, asMap[CardType.BAKERY])
+    }
+
+    @Test
     fun `findAll returns empty list before init`() {
         assertTrue(marketplaceDao.findAll().isEmpty())
     }

--- a/src/test/kotlin/org/machikoro/server/service/GameSyncServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GameSyncServiceTest.kt
@@ -15,7 +15,6 @@ import org.machikoro.server.domain.enums.CardType
 import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.enums.LandmarkType
 import org.machikoro.server.domain.enums.TurnPhase
-import org.machikoro.server.domain.models.GameMarketplaceModel
 import org.machikoro.server.domain.models.GameModel
 import org.machikoro.server.domain.models.PlayerCardModel
 import org.machikoro.server.domain.models.PlayerLandmarkModel
@@ -94,11 +93,8 @@ class GameSyncServiceTest {
         whenever(playerLandmarkDao.findByPlayerId(2)).thenReturn(
             listOf(PlayerLandmarkModel(2, LandmarkType.TRAIN_STATION, isBuilt = false)),
         )
-        whenever(gameMarketplaceDao.findByGameId(gameId)).thenReturn(
-            listOf(
-                GameMarketplaceModel(gameId, CardType.BAKERY, 5),
-                GameMarketplaceModel(gameId, CardType.WHEAT_FIELD, 6),
-            ),
+        whenever(gameMarketplaceDao.findByGameIdAsMap(gameId)).thenReturn(
+            mapOf(CardType.BAKERY to 5, CardType.WHEAT_FIELD to 6),
         )
 
         val snapshot = service.buildSnapshot(gameId)
@@ -113,7 +109,8 @@ class GameSyncServiceTest {
         assertEquals(true, snapshot.playerLandmarks[1]?.first()?.isBuilt)
         assertEquals(1, snapshot.playerLandmarks[2]?.size)
         assertEquals(false, snapshot.playerLandmarks[2]?.first()?.isBuilt)
-        // Marketplace flattens GameMarketplaceModel rows to cardType → quantity.
+        // Marketplace is whatever the DAO helper returns — the flatten itself
+        // lives on the DAO and is covered by GameMarketplaceDaoTest.
         assertEquals(mapOf(CardType.BAKERY to 5, CardType.WHEAT_FIELD to 6), snapshot.marketplace)
     }
 
@@ -122,7 +119,7 @@ class GameSyncServiceTest {
         val gameId = 11
         whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.IN_PROGRESS))
         whenever(playerDao.getPlayers(gameId)).thenReturn(emptyList())
-        whenever(gameMarketplaceDao.findByGameId(gameId)).thenReturn(emptyList())
+        whenever(gameMarketplaceDao.findByGameIdAsMap(gameId)).thenReturn(emptyMap())
 
         val snapshot = service.buildSnapshot(gameId)
 

--- a/src/test/kotlin/org/machikoro/server/service/GameSyncServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GameSyncServiceTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.machikoro.server.dao.GameDao
+import org.machikoro.server.dao.GameMarketplaceDao
 import org.machikoro.server.dao.PlayerCardDao
 import org.machikoro.server.dao.PlayerDao
 import org.machikoro.server.dao.PlayerLandmarkDao
@@ -14,6 +15,7 @@ import org.machikoro.server.domain.enums.CardType
 import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.enums.LandmarkType
 import org.machikoro.server.domain.enums.TurnPhase
+import org.machikoro.server.domain.models.GameMarketplaceModel
 import org.machikoro.server.domain.models.GameModel
 import org.machikoro.server.domain.models.PlayerCardModel
 import org.machikoro.server.domain.models.PlayerLandmarkModel
@@ -29,7 +31,14 @@ class GameSyncServiceTest {
     private val playerDao = mock<PlayerDao>()
     private val playerCardDao = mock<PlayerCardDao>()
     private val playerLandmarkDao = mock<PlayerLandmarkDao>()
-    private val service = GameSyncService(gameDao, playerDao, playerCardDao, playerLandmarkDao)
+    private val gameMarketplaceDao = mock<GameMarketplaceDao>()
+    private val service = GameSyncService(
+        gameDao,
+        playerDao,
+        playerCardDao,
+        playerLandmarkDao,
+        gameMarketplaceDao,
+    )
 
     private fun game(id: Int, status: GameStatus) = GameModel(
         id = id,
@@ -85,6 +94,12 @@ class GameSyncServiceTest {
         whenever(playerLandmarkDao.findByPlayerId(2)).thenReturn(
             listOf(PlayerLandmarkModel(2, LandmarkType.TRAIN_STATION, isBuilt = false)),
         )
+        whenever(gameMarketplaceDao.findByGameId(gameId)).thenReturn(
+            listOf(
+                GameMarketplaceModel(gameId, CardType.BAKERY, 5),
+                GameMarketplaceModel(gameId, CardType.WHEAT_FIELD, 6),
+            ),
+        )
 
         val snapshot = service.buildSnapshot(gameId)
 
@@ -98,6 +113,20 @@ class GameSyncServiceTest {
         assertEquals(true, snapshot.playerLandmarks[1]?.first()?.isBuilt)
         assertEquals(1, snapshot.playerLandmarks[2]?.size)
         assertEquals(false, snapshot.playerLandmarks[2]?.first()?.isBuilt)
+        // Marketplace flattens GameMarketplaceModel rows to cardType → quantity.
+        assertEquals(mapOf(CardType.BAKERY to 5, CardType.WHEAT_FIELD to 6), snapshot.marketplace)
+    }
+
+    @Test
+    fun `buildSnapshot returns empty marketplace when DAO returns no rows`() {
+        val gameId = 12
+        whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.IN_PROGRESS))
+        whenever(playerDao.getPlayers(gameId)).thenReturn(emptyList())
+        whenever(gameMarketplaceDao.findByGameId(gameId)).thenReturn(emptyList())
+
+        val snapshot = service.buildSnapshot(gameId)
+
+        assertTrue(snapshot.marketplace.isEmpty())
     }
 
     @Test
@@ -105,6 +134,7 @@ class GameSyncServiceTest {
         val gameId = 11
         whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.IN_PROGRESS))
         whenever(playerDao.getPlayers(gameId)).thenReturn(emptyList())
+        whenever(gameMarketplaceDao.findByGameId(gameId)).thenReturn(emptyList())
 
         val snapshot = service.buildSnapshot(gameId)
 
@@ -113,6 +143,7 @@ class GameSyncServiceTest {
         assertTrue(snapshot.turnOrder.isEmpty())
         assertTrue(snapshot.playerCards.isEmpty())
         assertTrue(snapshot.playerLandmarks.isEmpty())
+        assertTrue(snapshot.marketplace.isEmpty())
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/service/GameSyncServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GameSyncServiceTest.kt
@@ -118,18 +118,6 @@ class GameSyncServiceTest {
     }
 
     @Test
-    fun `buildSnapshot returns empty marketplace when DAO returns no rows`() {
-        val gameId = 12
-        whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.IN_PROGRESS))
-        whenever(playerDao.getPlayers(gameId)).thenReturn(emptyList())
-        whenever(gameMarketplaceDao.findByGameId(gameId)).thenReturn(emptyList())
-
-        val snapshot = service.buildSnapshot(gameId)
-
-        assertTrue(snapshot.marketplace.isEmpty())
-    }
-
-    @Test
     fun `buildSnapshot works with zero players`() {
         val gameId = 11
         whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.IN_PROGRESS))

--- a/src/test/kotlin/org/machikoro/server/service/LobbyServiceIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/LobbyServiceIntegrationTest.kt
@@ -112,6 +112,11 @@ class LobbyServiceIntegrationTest : AbstractDBSetup() {
         assertTrue(result.playerLandmarks[secondPlayerId]?.isNotEmpty() == true)
         // All landmarks start unbuilt at game start.
         assertTrue(result.playerLandmarks.values.flatten().all { !it.isBuilt })
+        // Marketplace must also ride along on the initial snapshot — same
+        // motivation as landmarks, this time for #248. Only BAKERY is seeded
+        // in the Cards table by setup(), so initForGame skips the other types
+        // (cardId lookup misses) and only BAKERY shows up at the default supply.
+        assertEquals(6, result.marketplace[CardType.BAKERY])
     }
 
     @Test


### PR DESCRIPTION
Closes #248. Part of #246 (full reconnect snapshot).

## Summary

- Adds `marketplace: Map<CardType, Int>` to `GameStateDto`. Populated by `GameSyncService.buildSnapshot` (for `/app/game.sync` reconnects) and by `LobbyService.startGame` (so the initial `GAME_STARTED` frame already carries the supply — no extra round-trip).
- Extracts `GameMarketplaceDao.findByGameIdAsMap()` so both call sites share a single source for the cardType → quantity view; the flatten is exercised by `GameMarketplaceDaoTest` instead of two separate service mocks.
- Mirrors the #247 (`playerLandmarks`) pattern in shape, test layout, and KDoc.

## Test plan

- [x] `./gradlew check` green locally (260 tests pass; JaCoCo coverage gate passes).
- [x] `GameSyncServiceTest.buildSnapshot returns players cards and sorted turnOrder` asserts `mapOf(BAKERY to 5, WHEAT_FIELD to 6)` flows through.
- [x] `GameSyncServiceTest.buildSnapshot works with zero players` asserts empty marketplace fallback.
- [x] `GameMarketplaceDaoTest.findByGameIdAsMap returns empty map before init` + `…returns cardType to quantity after init` (Testcontainers).
- [x] `LobbyServiceIntegrationTest.startGame sets status and initializes marketplace and landmark rows` asserts `result.marketplace[CardType.BAKERY] == 6` so the initial snapshot contract is locked in.
- [x] `GameControllerTest` / `LobbyControllerTests` factory backfills keep the build green for the new required field.