### PR TITLE
76 cleanup finished game session

### DIFF
--- a/src/main/kotlin/org/machikoro/server/dao/PlayerDao.kt
+++ b/src/main/kotlin/org/machikoro/server/dao/PlayerDao.kt
@@ -14,7 +14,6 @@ import org.machikoro.server.database.Games
 import org.machikoro.server.database.Players
 import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.models.PlayerModel
-import org.machikoro.server.exception.GameNotFoundException
 import org.machikoro.server.exception.PlayerNotFoundException
 import org.springframework.stereotype.Repository
 
@@ -139,8 +138,6 @@ class PlayerDao {
         Players.selectAll().map { it.toModel() }
     }
 
-
-
     /**
      * Updates the turn order for a player.
      * @param playerId Player ID
@@ -179,7 +176,6 @@ class PlayerDao {
     * @param gameId Game ID
     */
     fun deleteByGameId(gameId: Int): Unit = transaction {
-        val deletedRows = Players.deleteWhere { Players.gameId eq gameId }
-        if (deletedRows == 0) throw PlayerNotFoundException("Game $gameId not found")
+        Players.deleteWhere { Players.gameId eq gameId }
     }
 }

--- a/src/test/kotlin/org/machikoro/server/dao/PlayerDaoTest.kt
+++ b/src/test/kotlin/org/machikoro/server/dao/PlayerDaoTest.kt
@@ -216,4 +216,8 @@ class PlayerDaoTest : AbstractDBSetup() {
         assertTrue(playerDao.getPlayers(gameId).isEmpty())
     }
 
+    @Test
+    fun `deleteByGameId does not throw when game has no players`() {
+        assertDoesNotThrow { playerDao.deleteByGameId(gameId) }
+    }
 }


### PR DESCRIPTION
- As requested, this was adjusted:
  
  1. Critical Bug: PlayerDao.deleteByGameId should be idempotent
  Location: src/main/kotlin/org/machikoro/server/dao/PlayerDao.kt
  
  Why it's a bug: Bulk delete operations like deleteByGameId should be idempotent. If there are no players matching the gameId (meaning they might have already been deleted), the desired state is already met, and it should silently succeed rather than throwing an exception.
  The issue: Throwing a PlayerNotFoundException with the message "Game $gameId not found" is confusing and semantically incorrect. If this cleanup function ever runs on a game that has 0 players, or if it gets called twice due to network retries, it will crash the server request.
  Recommendation:
  Remove the if (deletedRows == 0) check entirely so the method completes successfully even if no rows were modified.

Test Request: Please add a unit test in PlayerDaoTest.kt to ensure calling deleteByGameId on an empty game does not throw an exception.

- This was not changes since clean up requires game status finished to delete data

2. Logical Inconsistency: Redundant updateStatus
  Location: src/main/kotlin/org/machikoro/server/service/GamePhaseService.kt
  
  The issue: Right before returning the Won outcome, the game status is updated to FINISHED. However, immediately after the turn ends, the GameController calls gamePhaseService.cleanupFinishedGameData(request.gameId), which completely deletes the game from the database via gameDao.delete(gameId).
  Why it matters: Updating the status in the database to FINISHED just milliseconds before completely deleting the row is redundant and causes an unnecessary database write.
  Recommendation:
  You can safely remove gameDao.updateStatus(gameId, GameStatus.FINISHED) from GamePhaseService.kt since the game record is about to be deleted anyway.