### PR TITLE
287 joining a lobby does not deliver the existing roster to the joining player2.0

### DIFF
--- a/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
@@ -3,6 +3,7 @@ package org.machikoro.server.controller
 import io.github.springwolf.core.asyncapi.annotations.AsyncListener
 import io.github.springwolf.core.asyncapi.annotations.AsyncOperation
 import org.machikoro.server.auth.userPrincipal
+import org.machikoro.server.dto.LobbyRosterDto
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.WebSocketMessage
 import org.machikoro.server.exception.CustomWebSocketException
@@ -140,6 +141,21 @@ class LobbyWebSocketController(
             return
         }
 
+        // Send current roster only to the joining player so they see who is already in the lobby
+        if (sessionId != null) {
+            val roster = lobbyService.getLobbyRoster(player.gameId)
+            messagingTemplate.convertAndSend(
+                "/queue/lobby-user$sessionId",
+                WebSocketMessage(
+                    type = MessageType.LOBBY_ROSTER,
+                    sender = "SERVER",
+                    content = "Lobby roster",
+                    gameId = player.gameId,
+                    payload = LobbyRosterDto(players = roster)
+                )
+            )
+        }
+
         // Broadcast join to all members already subscribed to this lobby's topic
         messagingTemplate.convertAndSend(
             "/topic/game/${player.gameId}",
@@ -157,20 +173,5 @@ class LobbyWebSocketController(
                 )
             )
         )
-
-        // Send current roster only to the joining player so they see who is already in the lobby
-        if (sessionId != null) {
-            val roster = lobbyService.getLobbyRoster(player.gameId)
-            messagingTemplate.convertAndSend(
-                "/queue/lobby-user$sessionId",
-                WebSocketMessage(
-                    type = MessageType.LOBBY_ROSTER,
-                    sender = "SERVER",
-                    content = "Lobby roster",
-                    gameId = player.gameId,
-                    payload = roster
-                )
-            )
-        }
     }
 }

--- a/src/main/kotlin/org/machikoro/server/dao/PlayerDao.kt
+++ b/src/main/kotlin/org/machikoro/server/dao/PlayerDao.kt
@@ -12,8 +12,10 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
 import org.machikoro.server.database.Games
 import org.machikoro.server.database.Players
+import org.machikoro.server.database.Users
 import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.models.PlayerModel
+import org.machikoro.server.dto.LobbyRosterPlayerDto
 import org.machikoro.server.exception.PlayerNotFoundException
 import org.springframework.stereotype.Repository
 
@@ -51,6 +53,30 @@ class PlayerDao {
             .where { Players.gameId eq gameId }
             .orderBy(Players.turnOrder to SortOrder.ASC)
             .map { it.toModel() }
+    }
+
+    /**
+     * Retrieves the current lobby roster with usernames for a given game.
+     */
+    fun getLobbyRoster(gameId: Int): List<LobbyRosterPlayerDto> = transaction {
+        Players.join(
+            Users,
+            JoinType.INNER,
+            additionalConstraint = { Players.userId eq Users.id }
+        )
+            .selectAll()
+            .where { Players.gameId eq gameId }
+            .orderBy(Players.turnOrder to SortOrder.ASC)
+            .map {
+                LobbyRosterPlayerDto(
+                    playerId = it[Players.id].value,
+                    userId = it[Players.userId].value,
+                    username = it[Users.username],
+                    gameId = it[Players.gameId].value,
+                    turnOrder = it[Players.turnOrder],
+                    coins = it[Players.coins],
+                )
+            }
     }
 
     /**

--- a/src/main/kotlin/org/machikoro/server/dto/LobbyRosterDto.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/LobbyRosterDto.kt
@@ -1,0 +1,14 @@
+package org.machikoro.server.dto
+
+data class LobbyRosterDto(
+    val players: List<LobbyRosterPlayerDto>,
+)
+
+data class LobbyRosterPlayerDto(
+    val playerId: Int,
+    val userId: Int,
+    val username: String,
+    val gameId: Int,
+    val turnOrder: Int,
+    val coins: Int,
+)

--- a/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
@@ -8,11 +8,11 @@ import org.machikoro.server.dao.LandmarkDao
 import org.machikoro.server.dao.PlayerCardDao
 import org.machikoro.server.dao.PlayerDao
 import org.machikoro.server.dao.PlayerLandmarkDao
-import org.machikoro.server.dao.UserDao
 import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.models.GameModel
 import org.machikoro.server.domain.models.PlayerModel
 import org.machikoro.server.dto.GameStateDto
+import org.machikoro.server.dto.LobbyRosterPlayerDto
 import org.machikoro.server.dto.toDefinitionDto
 import org.machikoro.server.exception.GameFinishedException
 import org.machikoro.server.exception.GameNotFoundException
@@ -27,7 +27,6 @@ import java.util.concurrent.ConcurrentHashMap
 open class LobbyService(
     private val gameDao: GameDao,
     private val playerDao: PlayerDao,
-    private val userDao: UserDao,
     private val gameMarketplaceDao: GameMarketplaceDao,
     private val playerLandmarkDao: PlayerLandmarkDao,
     private val initializationService: InitializationService,
@@ -96,20 +95,10 @@ open class LobbyService(
     }
 
     /**
-     * Returns the current lobby roster for [gameId] as a list of player maps.
-     * Each entry contains playerId, userId, username, and coins.
-     * Players whose user record cannot be found are silently skipped.
+     * Returns the current lobby roster for [gameId], including usernames, ordered by turn order.
      */
-    fun getLobbyRoster(gameId: Int): List<Map<String, Any>> = runInTransaction {
-        playerDao.getPlayers(gameId).mapNotNull { player ->
-            val user = userDao.findById(player.userId) ?: return@mapNotNull null
-            mapOf(
-                "playerId" to player.id,
-                "userId" to player.userId,
-                "username" to user.username,
-                "coins" to player.coins,
-            )
-        }
+    fun getLobbyRoster(gameId: Int): List<LobbyRosterPlayerDto> = runInTransaction {
+        playerDao.getLobbyRoster(gameId)
     }
 
     /**

--- a/src/test/kotlin/org/machikoro/server/controller/LobbyWebSocketControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/LobbyWebSocketControllerTest.kt
@@ -13,6 +13,8 @@ import org.machikoro.server.service.LobbyService
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.machikoro.server.domain.models.PlayerModel
+import org.machikoro.server.dto.LobbyRosterDto
+import org.machikoro.server.dto.LobbyRosterPlayerDto
 import org.machikoro.server.exception.GameNotFoundException
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
@@ -153,7 +155,10 @@ class LobbyWebSocketControllerTest {
 
     @Test
     fun `joinLobby broadcasts LOBBY_JOINED to the lobby's game topic`() {
-        val roster = listOf(mapOf("playerId" to 5, "userId" to 20, "username" to "Player2", "coins" to 3))
+        val roster = listOf(
+            LobbyRosterPlayerDto(playerId = 1, userId = 10, username = "Player1", gameId = 1, turnOrder = 0, coins = 3),
+            LobbyRosterPlayerDto(playerId = 5, userId = 20, username = "Player2", gameId = 1, turnOrder = 1, coins = 3),
+        )
         whenever(lobbyService.joinLobby("ABC1234", 20)).thenReturn(player())
         whenever(lobbyService.getLobbyRoster(1)).thenReturn(roster)
 
@@ -166,12 +171,20 @@ class LobbyWebSocketControllerTest {
 
         val destCaptor = argumentCaptor<String>()
         val msgCaptor = argumentCaptor<WebSocketMessage>()
-        // Expect two sends: LOBBY_JOINED to topic, then LOBBY_ROSTER to the joiner's queue
+        // Expect two sends: LOBBY_ROSTER to the joiner's queue, then LOBBY_JOINED to the topic
         verify(messagingTemplate, times(2)).convertAndSend(destCaptor.capture(), msgCaptor.capture())
 
-        // First send: LOBBY_JOINED to the lobby's game topic
-        assertEquals("/topic/game/1", destCaptor.allValues[0])
-        val joinMsg = msgCaptor.allValues[0]
+        // First send: LOBBY_ROSTER only to the joiner's session queue
+        assertEquals("/queue/lobby-usersess-77", destCaptor.allValues[0])
+        val rosterMsg = msgCaptor.allValues[0]
+        assertEquals(MessageType.LOBBY_ROSTER, rosterMsg.type)
+        assertEquals("SERVER", rosterMsg.sender)
+        assertEquals(1, rosterMsg.gameId)
+        assertEquals(LobbyRosterDto(players = roster), rosterMsg.payload)
+
+        // Second send: LOBBY_JOINED to the lobby's game topic
+        assertEquals("/topic/game/1", destCaptor.allValues[1])
+        val joinMsg = msgCaptor.allValues[1]
         assertEquals(MessageType.LOBBY_JOINED, joinMsg.type)
         assertEquals("SERVER", joinMsg.sender)
         assertEquals("Player joined lobby", joinMsg.content)
@@ -181,14 +194,6 @@ class LobbyWebSocketControllerTest {
         assertEquals(20, joinPayload["userId"])
         assertEquals(1, joinPayload["gameId"])
         assertEquals(3, joinPayload["coins"])
-
-        // Second send: LOBBY_ROSTER only to the joiner's session queue
-        assertEquals("/queue/lobby-usersess-77", destCaptor.allValues[1])
-        val rosterMsg = msgCaptor.allValues[1]
-        assertEquals(MessageType.LOBBY_ROSTER, rosterMsg.type)
-        assertEquals("SERVER", rosterMsg.sender)
-        assertEquals(1, rosterMsg.gameId)
-        assertEquals(roster, rosterMsg.payload)
 
         verify(lobbyService).joinLobby("ABC1234", 20)
         verify(lobbyService).getLobbyRoster(1)

--- a/src/test/kotlin/org/machikoro/server/dao/PlayerDaoTest.kt
+++ b/src/test/kotlin/org/machikoro/server/dao/PlayerDaoTest.kt
@@ -70,6 +70,30 @@ class PlayerDaoTest : AbstractDBSetup() {
     }
 
     @Test
+    fun `getLobbyRoster returns usernames and preserves turn order`() {
+        val userId2 = userDao.create("player_user_2")
+        val player1 = playerDao.addPlayer(gameId, userId)
+        val player2 = playerDao.addPlayer(gameId, userId2)
+        playerDao.updateCoins(player2.id, 7)
+
+        val roster = playerDao.getLobbyRoster(gameId)
+
+        assertEquals(2, roster.size)
+        assertEquals(player1.id, roster[0].playerId)
+        assertEquals(userId, roster[0].userId)
+        assertEquals("player_user", roster[0].username)
+        assertEquals(gameId, roster[0].gameId)
+        assertEquals(0, roster[0].turnOrder)
+        assertEquals(3, roster[0].coins)
+        assertEquals(player2.id, roster[1].playerId)
+        assertEquals(userId2, roster[1].userId)
+        assertEquals("player_user_2", roster[1].username)
+        assertEquals(gameId, roster[1].gameId)
+        assertEquals(1, roster[1].turnOrder)
+        assertEquals(7, roster[1].coins)
+    }
+
+    @Test
     fun `updateCoins sets new coin count`() {
         val player = playerDao.addPlayer(gameId, userId)
         playerDao.updateCoins(player.id, 10)

--- a/src/test/kotlin/org/machikoro/server/service/LobbyServiceIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/LobbyServiceIntegrationTest.kt
@@ -232,7 +232,6 @@ class LobbyServiceIntegrationTest : AbstractDBSetup() {
         val service = LobbyService(
             gameDao,
             playerDao,
-            userDao,
             gameMarketplaceDao,
             playerLandmarkDao,
             failingInitService,

--- a/src/test/kotlin/org/machikoro/server/service/LobbyServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/LobbyServiceTest.kt
@@ -12,13 +12,12 @@ import org.machikoro.server.dao.LandmarkDao
 import org.machikoro.server.dao.PlayerCardDao
 import org.machikoro.server.dao.PlayerDao
 import org.machikoro.server.dao.PlayerLandmarkDao
-import org.machikoro.server.dao.UserDao
-import org.machikoro.server.domain.models.UserModel
 import org.machikoro.server.domain.enums.CardType
 import org.machikoro.server.domain.models.PlayerCardModel
 import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.models.GameModel
 import org.machikoro.server.domain.models.PlayerModel
+import org.machikoro.server.dto.LobbyRosterPlayerDto
 import org.machikoro.server.exception.GameFinishedException
 import org.machikoro.server.exception.GameNotFoundException
 import org.machikoro.server.exception.GameStartedException
@@ -42,7 +41,6 @@ class LobbyServiceTest {
 
     private val gameDao = mock<GameDao>()
     private val playerDao = mock<PlayerDao>()
-    private val userDao = mock<UserDao>()
     private val gameMarketplaceDao = mock<GameMarketplaceDao>()
     private val playerLandmarkDao = mock<PlayerLandmarkDao>()
     private val initializationService = mock<InitializationService>()
@@ -56,7 +54,6 @@ class LobbyServiceTest {
     private val lobbyService = object : LobbyService(
         gameDao,
         playerDao,
-        userDao,
         gameMarketplaceDao,
         playerLandmarkDao,
         initializationService,
@@ -301,52 +298,28 @@ class LobbyServiceTest {
         verify(initializationService, never()).initializeGame(any())
     }
 
-    private fun user(id: Int) = UserModel(
-        id = id,
-        username = "user$id",
-        passwordHash = null,
-        sessionToken = null,
-        totalWins = 0,
-        totalGamesPlayed = 0,
-    )
-
     @Test
-    fun `getLobbyRoster returns mapped entries for all players whose user record exists`() {
-        whenever(playerDao.getPlayers(1)).thenReturn(listOf(player(10), player(20)))
-        whenever(userDao.findById(10)).thenReturn(user(10))
-        whenever(userDao.findById(20)).thenReturn(user(20))
+    fun `getLobbyRoster returns player dao roster`() {
+        val expected = listOf(
+            LobbyRosterPlayerDto(playerId = 10, userId = 10, username = "user10", gameId = 1, turnOrder = 0, coins = 3),
+            LobbyRosterPlayerDto(playerId = 20, userId = 20, username = "user20", gameId = 1, turnOrder = 1, coins = 3),
+        )
+        whenever(playerDao.getLobbyRoster(1)).thenReturn(expected)
 
         val roster = lobbyService.getLobbyRoster(1)
 
-        assertEquals(2, roster.size)
-        assertEquals(10, roster[0]["playerId"])
-        assertEquals(10, roster[0]["userId"])
-        assertEquals("user10", roster[0]["username"])
-        assertEquals(3, roster[0]["coins"])
-        assertEquals(20, roster[1]["playerId"])
-        assertEquals("user20", roster[1]["username"])
-    }
-
-    @Test
-    fun `getLobbyRoster silently skips players whose user record is not found`() {
-        whenever(playerDao.getPlayers(1)).thenReturn(listOf(player(10), player(99)))
-        whenever(userDao.findById(10)).thenReturn(user(10))
-        whenever(userDao.findById(99)).thenReturn(null)
-
-        val roster = lobbyService.getLobbyRoster(1)
-
-        // Player 99 has no user record — must be skipped, not cause an error
-        assertEquals(1, roster.size)
-        assertEquals(10, roster[0]["playerId"])
+        assertEquals(expected, roster)
+        verify(playerDao).getLobbyRoster(1)
     }
 
     @Test
     fun `getLobbyRoster returns empty list when game has no players`() {
-        whenever(playerDao.getPlayers(1)).thenReturn(emptyList())
+        whenever(playerDao.getLobbyRoster(1)).thenReturn(emptyList())
 
         val roster = lobbyService.getLobbyRoster(1)
 
         assertEquals(0, roster.size)
+        verify(playerDao).getLobbyRoster(1)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add a lobby roster DTO and DAO query that returns players with usernames in turn order.
- Send a private `LOBBY_ROSTER` snapshot to the joining player after successful `/app/lobby.join`.
- Keep the existing public `LOBBY_JOINED` broadcast unchanged for current lobby members.

## Changes
- Added `LobbyRosterDto` / `LobbyRosterPlayerDto`.
- Added `PlayerDao.getLobbyRoster(gameId)` joining `Players` with `Users`.
- Added `LobbyService.getLobbyRoster(gameId)` as the controller-facing roster API.
- Updated `LobbyWebSocketController.joinLobby` to send:
  - private `/queue/lobby-user{sessionId}` `LOBBY_ROSTER`
  - public `/topic/game/{gameId}` `LOBBY_JOINED`
- Added/updated tests for controller behavior, service delegation, and DAO roster ordering.