### PR TITLE
Fix/301 presentation bugs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,6 @@ DB_PASSWORD=secret
 # PGAdmin4 (local dev only - see compose-dev.yaml)
 PGADMIN_EMAIL=admin@admin.com
 PGADMIN_PASSWORD=admin
+
+#Debugging
+DEBUG_ENABLED=true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,8 +46,12 @@ sonar {
         property("sonar.coverage.exclusions", "src/main/kotlin/**/dto/**,src/main/kotlin/**/config/**,src/main/kotlin/**/ServerApplication.kt")
         property("sonar.newCode.referenceBranch", "main")
         property("sonar.qualitygate.wait", "true")
-        // Exclude Flyway SQL migrations — plain DDL, not PL/SQL; no data dictionary needed
-        property("sonar.exclusions", "src/main/resources/db/migration/**")
+        property("sonar.issue.ignore.multicriteria", "e1")
+        property("sonar.issue.ignore.multicriteria.e1.ruleKey", "sql:S1192")
+        property(
+            "sonar.issue.ignore.multicriteria.e1.resourceKey",
+            "src/main/resources/db/migration/V1__init_schema.sql",
+        )
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,12 +46,8 @@ sonar {
         property("sonar.coverage.exclusions", "src/main/kotlin/**/dto/**,src/main/kotlin/**/config/**,src/main/kotlin/**/ServerApplication.kt")
         property("sonar.newCode.referenceBranch", "main")
         property("sonar.qualitygate.wait", "true")
-        property("sonar.issue.ignore.multicriteria", "e1")
-        property("sonar.issue.ignore.multicriteria.e1.ruleKey", "sql:S1192")
-        property(
-            "sonar.issue.ignore.multicriteria.e1.resourceKey",
-            "src/main/resources/db/migration/V1__init_schema.sql",
-        )
+        // Exclude Flyway SQL migrations — plain DDL, not PL/SQL; no data dictionary needed
+        property("sonar.exclusions", "src/main/resources/db/migration/**")
     }
 }
 

--- a/src/main/kotlin/org/machikoro/server/config/SecurityConfig.kt
+++ b/src/main/kotlin/org/machikoro/server/config/SecurityConfig.kt
@@ -1,5 +1,6 @@
 package org.machikoro.server.config
 
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
@@ -10,7 +11,10 @@ import org.springframework.security.web.SecurityFilterChain
 
 @Configuration
 @EnableWebSecurity
-class SecurityConfig {
+class SecurityConfig(
+    // Mirror the same default as DebugController so security rules match controller availability
+    @Value("\${debug.enabled:false}") private val debugEnabled: Boolean
+) {
 
     /**
      * Configure security filter chain.
@@ -21,16 +25,16 @@ class SecurityConfig {
      * and for the public auth endpoints since clients (e.g. the Android app) post JSON
      * without a session-bound CSRF token.
      * CSRF remains enabled for all other endpoints including API routes.
+     * Debug endpoints are only opened when debug.enabled=true (set via DEBUG_ENABLED env var).
      */
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
         http
             .csrf { csrf ->
-                csrf.ignoringRequestMatchers(
-                    "/ws", "/ws/**", "/ws-sockjs", "/ws-sockjs/**",
-                    "/auth/**",
-                    "/debug/**",
-                )
+                // Only exempt /debug/** from CSRF when debug endpoints are active
+                val csrfExempt = mutableListOf("/ws", "/ws/**", "/ws-sockjs", "/ws-sockjs/**", "/auth/**")
+                if (debugEnabled) csrfExempt.add("/debug/**")
+                csrf.ignoringRequestMatchers(*csrfExempt.toTypedArray())
             }
             .authorizeHttpRequests { auth ->
                 auth.requestMatchers("/", "/index.html", "/css/**", "/js/**", "/webjars/**").permitAll()
@@ -46,8 +50,8 @@ class SecurityConfig {
                     "/springwolf/**"
                 ).permitAll()
                 auth.requestMatchers("/auth/**").permitAll()
-                // Debug endpoint is open so frontend can call it without a session
-                auth.requestMatchers("/debug/**").permitAll()
+                // Only open /debug/** when debug endpoints are enabled
+                if (debugEnabled) auth.requestMatchers("/debug/**").permitAll()
                 auth.requestMatchers("/api/**").authenticated()
                 auth.anyRequest().authenticated()
             }

--- a/src/main/kotlin/org/machikoro/server/controller/DebugController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/DebugController.kt
@@ -61,4 +61,17 @@ class DebugController(private val debugService: DebugService) {
             ResponseEntity.internalServerError().build()
         }
     }
+
+    @PostMapping("/reset-lobby")
+    @Operation(summary = "Remove all dummy players from a lobby and broadcast LOBBY_LEFT events")
+    fun resetLobby(@RequestBody request: FillLobbyRequest): ResponseEntity<Map<String, Int>> {
+        return try {
+            val removed = debugService.resetLobby(request.lobbyCode)
+            logger.info("Reset lobby '{}': removed {} dummy players", request.lobbyCode, removed)
+            ResponseEntity.ok(mapOf("removedPlayers" to removed))
+        } catch (e: Exception) {
+            logger.error("Reset lobby failed for '{}': {}", request.lobbyCode, e.message)
+            ResponseEntity.internalServerError().build()
+        }
+    }
 }

--- a/src/main/kotlin/org/machikoro/server/controller/DebugController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/DebugController.kt
@@ -9,6 +9,7 @@ import org.machikoro.server.service.DebugService
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -31,6 +32,19 @@ class DebugController(private val debugService: DebugService) {
             ResponseEntity.ok(result)
         } catch (e: Exception) {
             logger.error("Debug seed failed: {}", e.message)
+            ResponseEntity.internalServerError().build()
+        }
+    }
+
+    @DeleteMapping("/purge")
+    @Operation(summary = "Delete all games and players from the database")
+    fun purge(): ResponseEntity<Map<String, Int>> {
+        return try {
+            val deleted = debugService.purgeGames()
+            logger.info("Debug purge deleted {} games", deleted)
+            ResponseEntity.ok(mapOf("deletedGames" to deleted))
+        } catch (e: Exception) {
+            logger.error("Debug purge failed: {}", e.message)
             ResponseEntity.internalServerError().build()
         }
     }

--- a/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
@@ -35,11 +35,13 @@ class LobbyWebSocketController(
      * username spoofing.
      */
     @MessageMapping("/lobby.create")
-    @AsyncListener(operation = AsyncOperation(
-        channelName = "/lobby.create",
-        description = "Creates a new lobby for the authenticated user and delivers LOBBY_CREATED only to the creator.",
-        payloadType = WebSocketMessage::class,
-    ))
+    @AsyncListener(
+        operation = AsyncOperation(
+            channelName = "/lobby.create",
+            description = "Creates a new lobby for the authenticated user and delivers LOBBY_CREATED only to the creator.",
+            payloadType = WebSocketMessage::class,
+        )
+    )
     @Suppress("UNUSED_PARAMETER") // Spring requires a @Payload parameter to deserialize the STOMP frame body
     fun createLobby(
         @Payload message: WebSocketMessage,
@@ -90,11 +92,13 @@ class LobbyWebSocketController(
      * the WebSocket payload is ignored to prevent username spoofing.
      */
     @MessageMapping("/lobby.join")
-    @AsyncListener(operation = AsyncOperation(
-        channelName = "/lobby.join",
-        description = "Joins an existing lobby by lobby code and broadcasts LOBBY_JOINED to /topic/game/{gameId}.",
-        payloadType = WebSocketMessage::class,
-    ))
+    @AsyncListener(
+        operation = AsyncOperation(
+            channelName = "/lobby.join",
+            description = "Joins an existing lobby by lobby code and broadcasts LOBBY_JOINED to /topic/game/{gameId}.",
+            payloadType = WebSocketMessage::class,
+        )
+    )
     fun joinLobby(
         @Payload message: WebSocketMessage,
         headerAccessor: SimpMessageHeaderAccessor,

--- a/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
@@ -174,4 +174,68 @@ class LobbyWebSocketController(
             )
         )
     }
+
+    /**
+     * Handles a player leaving a lobby via WebSocket.
+     *
+     * Client sends a message to /app/lobby.leave with the gameId in the payload.
+     * The player is removed from the lobby roster. If the lobby becomes empty, the
+     * game record is deleted. Otherwise LOBBY_LEFT is broadcast to the remaining
+     * members so they can update the player list.
+     */
+    @MessageMapping("/lobby.leave")
+    @Suppress("UNUSED_PARAMETER")
+    fun leaveLobby(
+        @Payload message: WebSocketMessage,
+        headerAccessor: SimpMessageHeaderAccessor,
+    ) {
+        val principal = headerAccessor.userPrincipal()
+            ?: throw CustomWebSocketException(
+                errorCode = "UNAUTHENTICATED",
+                message = "Authenticated principal not found",
+            )
+
+        val payload = message.payload as? Map<*, *>
+            ?: throw CustomWebSocketException(
+                errorCode = "INVALID_PAYLOAD",
+                message = "lobby.leave payload must contain a gameId",
+            )
+
+        val gameId = (payload["gameId"] as? Number)?.toInt()
+            ?: throw CustomWebSocketException(
+                errorCode = "MISSING_GAME_ID",
+                message = "gameId is missing or not a number",
+            )
+
+        logger.info("User '{}' leaving lobby {}", principal.username, gameId)
+
+        val result = lobbyService.leaveLobby(gameId, principal.userId)
+        if (result == null) {
+            logger.warn("leaveLobby: user '{}' is not in game {}", principal.username, gameId)
+            return
+        }
+
+        if (!result.gameDeleted) {
+            // Notify remaining players so they can remove the leaver from the UI
+            messagingTemplate.convertAndSend(
+                "/topic/game/$gameId",
+                WebSocketMessage(
+                    type = MessageType.LOBBY_LEFT,
+                    sender = "SERVER",
+                    content = "Player left lobby",
+                    gameId = gameId,
+                    payload = mapOf(
+                        "playerId" to result.playerId,
+                        "userId" to principal.userId,
+                        "username" to principal.username,
+                    )
+                )
+            )
+        }
+        // If game was deleted there are no remaining subscribers to notify
+        logger.info(
+            "User '{}' left lobby {} — gameDeleted={}",
+            principal.username, gameId, result.gameDeleted
+        )
+    }
 }

--- a/src/main/kotlin/org/machikoro/server/dao/UserDao.kt
+++ b/src/main/kotlin/org/machikoro/server/dao/UserDao.kt
@@ -142,4 +142,12 @@ class UserDao {
         val deletedRows = Users.deleteWhere { Users.id eq id }
         if (deletedRows == 0) throw UserNotFoundException("User $id not found")
     }
+
+    // Deletes all users whose username starts with [prefix] — debug cleanup only
+    fun deleteByUsernamePrefix(prefix: String): Int = transaction {
+        findAll()
+            .filter { it.username.startsWith(prefix) }
+            .onEach { Users.deleteWhere { Users.id eq it.id } }
+            .size
+    }
 }

--- a/src/main/kotlin/org/machikoro/server/dto/ChatMessage.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/ChatMessage.kt
@@ -15,6 +15,7 @@ enum class MessageType {
     SYNC,
     GAME_ACTION,
     GAME_END,
+    LOBBY_LEFT,
     PLAYER_LEFT_FINISHED_GAME,
     ERROR,
     ROLL_DICE,

--- a/src/main/kotlin/org/machikoro/server/dto/GameStateDto.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/GameStateDto.kt
@@ -50,4 +50,7 @@ data class GameStateDto(
 
     @Schema(description = "userId of the player whose turn it is (matches the userId the client received at login)")
     val activePlayerId: Int? = null,
+
+    @Schema(description = "Map of playerId to username for display name resolution on the client")
+    val playerUsernames: Map<Int, String> = emptyMap(),
 )

--- a/src/main/kotlin/org/machikoro/server/service/DebugService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/DebugService.kt
@@ -25,6 +25,7 @@ class DebugService(
     companion object {
         // Fixed credentials so callers always know which users own the debug game
         private val PLAYER_USERNAMES = listOf("debug_player1", "debug_player2", "debug_player3", "debug_player4")
+
         // Dummy players used to fill an existing lobby (skips debug_player1 who is the seed host)
         private val FILL_USERNAMES = listOf("debug_player2", "debug_player3", "debug_player4")
         private const val DEBUG_PASSWORD = "debug_password"

--- a/src/main/kotlin/org/machikoro/server/service/DebugService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/DebugService.kt
@@ -89,6 +89,8 @@ class DebugService(
         return added
     }
 
+    fun purgeGames(): Int = lobbyService.purgeAllGames()
+
     // Creates the user if absent, then issues a fresh session token
     private fun ensureUser(username: String): LoginResponse {
         val existing = userDao.findByUsername(username)

--- a/src/main/kotlin/org/machikoro/server/service/DebugService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/DebugService.kt
@@ -109,7 +109,12 @@ class DebugService(
         return removed.size
     }
 
-    fun purgeGames(): Int = lobbyService.purgeAllGames()
+    fun purgeGames(): Int {
+        val deleted = lobbyService.purgeAllGames()
+        // Delete debug users so they get fresh IDs (and names reset to debug_player1 etc.) next fill
+        userDao.deleteByUsernamePrefix(LobbyService.DEBUG_USER_PREFIX)
+        return deleted
+    }
 
     // Creates the user if absent, then issues a fresh session token
     private fun ensureUser(username: String): LoginResponse {

--- a/src/main/kotlin/org/machikoro/server/service/DebugService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/DebugService.kt
@@ -60,9 +60,9 @@ class DebugService(
             val creds = ensureUser(username)
             try {
                 val player = lobbyService.addUserToLobby(game.id, creds.userId)
-                // Broadcast so the real client's handleLobbyJoined picks it up
+                // Broadcast to per-lobby topic, matching the real join path
                 messagingTemplate.convertAndSend(
-                    "/topic/public",
+                    "/topic/game/${player.gameId}",
                     WebSocketMessage(
                         type = MessageType.LOBBY_JOINED,
                         sender = "SERVER",
@@ -97,7 +97,7 @@ class DebugService(
         val removed = lobbyService.resetLobby(lobbyCode)
         removed.forEach { player ->
             messagingTemplate.convertAndSend(
-                "/topic/public",
+                "/topic/game/${player.gameId}",
                 WebSocketMessage(
                     type = MessageType.LOBBY_LEFT,
                     sender = "SERVER",

--- a/src/main/kotlin/org/machikoro/server/service/DebugService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/DebugService.kt
@@ -89,6 +89,26 @@ class DebugService(
         return added
     }
 
+    /**
+     * Removes all dummy players from the lobby and broadcasts LOBBY_LEFT for each.
+     */
+    fun resetLobby(lobbyCode: String): Int {
+        val removed = lobbyService.resetLobby(lobbyCode)
+        removed.forEach { player ->
+            messagingTemplate.convertAndSend(
+                "/topic/public",
+                WebSocketMessage(
+                    type = MessageType.LOBBY_LEFT,
+                    sender = "SERVER",
+                    content = "Player left lobby",
+                    gameId = player.gameId,
+                    payload = mapOf("playerId" to player.playerId)
+                )
+            )
+        }
+        return removed.size
+    }
+
     fun purgeGames(): Int = lobbyService.purgeAllGames()
 
     // Creates the user if absent, then issues a fresh session token

--- a/src/main/kotlin/org/machikoro/server/service/GameSyncService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/GameSyncService.kt
@@ -46,6 +46,7 @@ class GameSyncService(
         val marketplace = gameMarketplaceDao.findByGameIdAsMap(gameId)
         val cardDefinitions = cardDao.findAll().map { it.toDefinitionDto() }
         val landmarkDefinitions = landmarkDao.findAll().map { it.toDefinitionDto() }
+        val playerUsernames = playerDao.getLobbyRoster(gameId).associate { it.playerId to it.username }
 
         val sortedPlayers = players.sortedBy { it.turnOrder }
         return GameStateDto(
@@ -58,6 +59,7 @@ class GameSyncService(
             landmarkDefinitions = landmarkDefinitions,
             turnOrder = sortedPlayers.map { it.userId },
             activePlayerId = sortedPlayers.getOrNull(game.currentTurnIndex)?.userId,
+            playerUsernames = playerUsernames,
         )
     }
 

--- a/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
@@ -204,6 +204,18 @@ open class LobbyService(
     }
 
     /**
+     * Removes all dummy players from the lobby and returns their roster entries.
+     */
+    fun resetLobby(lobbyCode: String): List<LobbyRosterPlayerDto> = runInTransaction {
+        val game = gameDao.findByLobbyCode(lobbyCode)
+            ?: throw GameNotFoundException("Lobby with code $lobbyCode not found")
+        val dummies = playerDao.getLobbyRoster(game.id)
+            .filter { it.username.startsWith(DEBUG_USER_PREFIX) }
+        dummies.forEach { playerDao.deleteByPlayerId(it.playerId) }
+        dummies
+    }
+
+    /**
      * Starts the game identified by [gameId].
      *
      * When [requestingUserId] is provided, the caller must be the lobby host —

--- a/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
@@ -262,6 +262,7 @@ open class LobbyService(
                 val marketplace = gameMarketplaceDao.findByGameIdAsMap(gameId)
                 val cardDefinitions = cardDao.findAll().map { it.toDefinitionDto() }
                 val landmarkDefinitions = landmarkDao.findAll().map { it.toDefinitionDto() }
+                val playerUsernames = playerDao.getLobbyRoster(gameId).associate { it.playerId to it.username }
 
                 GameStateDto(
                     game = updatedGame,
@@ -273,6 +274,7 @@ open class LobbyService(
                     landmarkDefinitions = landmarkDefinitions,
                     turnOrder = shuffled.map { it.userId },
                     activePlayerId = shuffled.firstOrNull()?.userId,
+                    playerUsernames = playerUsernames,
                 )
             }
         }

--- a/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
@@ -148,6 +148,21 @@ open class LobbyService(
     }
 
     /**
+     * Deletes every game and its players from the database.
+     * Debug-only — do not expose in production.
+     * Returns the number of games deleted.
+     */
+    fun purgeAllGames(): Int = runInTransaction {
+        val games = gameDao.findAll()
+        games.forEach { game ->
+            playerDao.deleteByGameId(game.id)
+            gameDao.delete(game.id)
+        }
+        lobbyLocks.clear()
+        games.size
+    }
+
+    /**
      * Represents the result of a player leaving a lobby.
      *
      * @property playerId The DB player ID of the player who left.

--- a/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
@@ -50,6 +50,8 @@ open class LobbyService(
     companion object {
         // Machi Koro base game requires at least 2 players.
         const val MIN_PLAYERS = 2
+        // Must match DebugService.PLAYER_USERNAMES / FILL_USERNAMES prefix
+        const val DEBUG_USER_PREFIX = "debug_player"
     }
 
     /**
@@ -171,11 +173,15 @@ open class LobbyService(
     data class LeaveLobbyResult(val playerId: Int, val gameDeleted: Boolean)
 
     /**
-     * Removes [userId] from the lobby [gameId] and deletes the game if no players remain.
+     * Removes [userId] from the lobby [gameId] and deletes the game if no real players remain.
+     *
+     * "Real" means non-debug: any player whose username starts with [DEBUG_USER_PREFIX] is
+     * treated as a dummy and does not count toward keeping the lobby alive. This lets a real
+     * player leave a lobby that still has dummy fill-players and still have the game cleaned up.
      *
      * Returns null if the user was not a player in the given game.
-     * Returns [LeaveLobbyResult] with [LeaveLobbyResult.gameDeleted] = true when the last
-     * player left and the game row has been deleted.
+     * Returns [LeaveLobbyResult] with [LeaveLobbyResult.gameDeleted] = true when no real
+     * players remain and the game row (plus any leftover dummies) has been deleted.
      */
     fun leaveLobby(gameId: Int, userId: Int): LeaveLobbyResult? = runInTransaction {
         val player = playerDao.findByGameIdAndUserId(gameId, userId)
@@ -183,8 +189,12 @@ open class LobbyService(
 
         playerDao.deleteByPlayerId(player.id)
 
-        val remaining = playerDao.countByGameId(gameId)
-        if (remaining == 0) {
+        val realPlayersRemain = playerDao.getLobbyRoster(gameId)
+            .any { !it.username.startsWith(DEBUG_USER_PREFIX) }
+
+        if (!realPlayersRemain) {
+            // Clean up leftover dummy players before dropping the game row (FK constraint)
+            playerDao.deleteByGameId(gameId)
             gameDao.delete(gameId)
             lobbyLocks.remove(gameId)
             LeaveLobbyResult(playerId = player.id, gameDeleted = true)

--- a/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
@@ -148,6 +148,37 @@ open class LobbyService(
     }
 
     /**
+     * Represents the result of a player leaving a lobby.
+     *
+     * @property playerId The DB player ID of the player who left.
+     * @property gameDeleted True if the lobby was deleted because it is now empty.
+     */
+    data class LeaveLobbyResult(val playerId: Int, val gameDeleted: Boolean)
+
+    /**
+     * Removes [userId] from the lobby [gameId] and deletes the game if no players remain.
+     *
+     * Returns null if the user was not a player in the given game.
+     * Returns [LeaveLobbyResult] with [LeaveLobbyResult.gameDeleted] = true when the last
+     * player left and the game row has been deleted.
+     */
+    fun leaveLobby(gameId: Int, userId: Int): LeaveLobbyResult? = runInTransaction {
+        val player = playerDao.findByGameIdAndUserId(gameId, userId)
+            ?: return@runInTransaction null
+
+        playerDao.deleteByPlayerId(player.id)
+
+        val remaining = playerDao.countByGameId(gameId)
+        if (remaining == 0) {
+            gameDao.delete(gameId)
+            lobbyLocks.remove(gameId)
+            LeaveLobbyResult(playerId = player.id, gameDeleted = true)
+        } else {
+            LeaveLobbyResult(playerId = player.id, gameDeleted = false)
+        }
+    }
+
+    /**
      * Starts the game identified by [gameId].
      *
      * When [requestingUserId] is provided, the caller must be the lobby host —

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,8 +11,8 @@ springdoc.swagger-ui.operationsSorter=method
 
 websocket.allowed-origins=${WEBSOCKET_ALLOWED_ORIGINS:http://localhost:8080,http://localhost:3000}
 machikoro.db.init.enabled=true
-# Set to true in dev to enable POST /debug/seed
-debug.enabled=true
+# Enable debug endpoints via env var — off by default for safety
+debug.enabled=${DEBUG_ENABLED:false}
 
 spring.datasource.url=jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:machikoro}
 spring.datasource.username=${DB_USERNAME:}

--- a/src/test/kotlin/org/machikoro/server/controller/DebugControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/DebugControllerTest.kt
@@ -127,4 +127,50 @@ class DebugControllerTest {
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.statusCode)
         assertNull(response.body)
     }
+
+    // === DELETE /debug/purge ===
+
+    @Test
+    fun `purge returns 200 OK with deleted game count`() {
+        whenever(debugService.purgeGames()).thenReturn(5)
+
+        val response = controller.purge()
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals(mapOf("deletedGames" to 5), response.body)
+    }
+
+    @Test
+    fun `purge returns 500 when service throws`() {
+        whenever(debugService.purgeGames()).thenThrow(RuntimeException("DB error"))
+
+        val response = controller.purge()
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.statusCode)
+        assertNull(response.body)
+    }
+
+    // === POST /debug/reset-lobby ===
+
+    @Test
+    fun `resetLobby returns 200 OK with removed player count`() {
+        val request = FillLobbyRequest(lobbyCode = "ABC123")
+        whenever(debugService.resetLobby("ABC123")).thenReturn(2)
+
+        val response = controller.resetLobby(request)
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals(mapOf("removedPlayers" to 2), response.body)
+    }
+
+    @Test
+    fun `resetLobby returns 500 when service throws`() {
+        val request = FillLobbyRequest(lobbyCode = "NOPE")
+        whenever(debugService.resetLobby("NOPE")).thenThrow(GameNotFoundException("not found"))
+
+        val response = controller.resetLobby(request)
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.statusCode)
+        assertNull(response.body)
+    }
 }

--- a/src/test/kotlin/org/machikoro/server/controller/LobbyWebSocketControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/LobbyWebSocketControllerTest.kt
@@ -276,6 +276,108 @@ class LobbyWebSocketControllerTest {
         assertEquals("INVALID_LOBBY_CODE", payload["errorCode"])
     }
 
+    // === leaveLobby() ===
+
+    @Test
+    fun `leaveLobby throws when no authenticated principal is present`() {
+        val accessor = SimpMessageHeaderAccessor.create().apply { sessionId = "sess-1" }
+
+        val ex = assertThrows<CustomWebSocketException> {
+            controller.leaveLobby(
+                WebSocketMessage(type = MessageType.JOIN, sender = "ghost", payload = mapOf("gameId" to 1)),
+                accessor,
+            )
+        }
+
+        assertEquals("UNAUTHENTICATED", ex.errorCode)
+        verify(lobbyService, never()).leaveLobby(any(), any())
+        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
+    }
+
+    @Test
+    fun `leaveLobby throws when payload is not a Map`() {
+        val accessor = authenticatedAccessor(userId = 10, username = "Player1")
+
+        val ex = assertThrows<CustomWebSocketException> {
+            controller.leaveLobby(
+                WebSocketMessage(type = MessageType.JOIN, sender = "Player1", payload = "not-a-map"),
+                accessor,
+            )
+        }
+
+        assertEquals("INVALID_PAYLOAD", ex.errorCode)
+        verify(lobbyService, never()).leaveLobby(any(), any())
+    }
+
+    @Test
+    fun `leaveLobby throws when gameId is missing from payload`() {
+        val accessor = authenticatedAccessor(userId = 10, username = "Player1")
+
+        val ex = assertThrows<CustomWebSocketException> {
+            controller.leaveLobby(
+                WebSocketMessage(type = MessageType.JOIN, sender = "Player1", payload = emptyMap<String, Any>()),
+                accessor,
+            )
+        }
+
+        assertEquals("MISSING_GAME_ID", ex.errorCode)
+        verify(lobbyService, never()).leaveLobby(any(), any())
+    }
+
+    @Test
+    fun `leaveLobby does nothing when player is not in game`() {
+        whenever(lobbyService.leaveLobby(1, 10)).thenReturn(null)
+        val accessor = authenticatedAccessor(userId = 10, username = "Player1")
+
+        controller.leaveLobby(
+            WebSocketMessage(type = MessageType.JOIN, sender = "Player1", payload = mapOf("gameId" to 1)),
+            accessor,
+        )
+
+        verify(lobbyService).leaveLobby(1, 10)
+        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
+    }
+
+    @Test
+    fun `leaveLobby broadcasts LOBBY_LEFT to game topic when lobby persists`() {
+        val result = LobbyService.LeaveLobbyResult(playerId = 5, gameDeleted = false)
+        whenever(lobbyService.leaveLobby(1, 10)).thenReturn(result)
+        val accessor = authenticatedAccessor(userId = 10, username = "Player1", sessionId = "sess-leave")
+
+        controller.leaveLobby(
+            WebSocketMessage(type = MessageType.JOIN, sender = "Player1", payload = mapOf("gameId" to 1)),
+            accessor,
+        )
+
+        val destCaptor = argumentCaptor<String>()
+        val msgCaptor = argumentCaptor<WebSocketMessage>()
+        verify(messagingTemplate).convertAndSend(destCaptor.capture(), msgCaptor.capture())
+
+        assertEquals("/topic/game/1", destCaptor.firstValue)
+        val msg = msgCaptor.firstValue
+        assertEquals(MessageType.LOBBY_LEFT, msg.type)
+        assertEquals("SERVER", msg.sender)
+        assertEquals(1, msg.gameId)
+        val payload = msg.payload as? Map<*, *> ?: throw AssertionError("Payload is not a Map")
+        assertEquals(5, payload["playerId"])
+        assertEquals(10, payload["userId"])
+        assertEquals("Player1", payload["username"])
+    }
+
+    @Test
+    fun `leaveLobby does not broadcast when game was deleted`() {
+        val result = LobbyService.LeaveLobbyResult(playerId = 5, gameDeleted = true)
+        whenever(lobbyService.leaveLobby(1, 10)).thenReturn(result)
+        val accessor = authenticatedAccessor(userId = 10, username = "Player1")
+
+        controller.leaveLobby(
+            WebSocketMessage(type = MessageType.JOIN, sender = "Player1", payload = mapOf("gameId" to 1)),
+            accessor,
+        )
+
+        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
+    }
+
     @Test
     fun `joinLobby skips LOBBY_ROSTER when sessionId is null`() {
         whenever(lobbyService.joinLobby("ABC1234", 20)).thenReturn(player())

--- a/src/test/kotlin/org/machikoro/server/dao/UserDaoTest.kt
+++ b/src/test/kotlin/org/machikoro/server/dao/UserDaoTest.kt
@@ -190,4 +190,30 @@ class UserDaoTest : AbstractDBSetup() {
 
         assertTrue(result.isEmpty())
     }
+
+    @Test
+    fun `deleteByUsernamePrefix removes only matching users and returns count`() {
+        dao.create("debug_player1")
+        dao.create("debug_player2")
+        dao.create("alice")
+
+        val count = dao.deleteByUsernamePrefix("debug_player")
+
+        assertEquals(2, count)
+        assertNull(dao.findByUsername("debug_player1"))
+        assertNull(dao.findByUsername("debug_player2"))
+        assertNotNull(dao.findByUsername("alice"))
+    }
+
+    @Test
+    fun `deleteByUsernamePrefix returns 0 when no users match prefix`() {
+        dao.create("alice")
+        dao.create("bob")
+
+        val count = dao.deleteByUsernamePrefix("debug_")
+
+        assertEquals(0, count)
+        assertNotNull(dao.findByUsername("alice"))
+        assertNotNull(dao.findByUsername("bob"))
+    }
 }

--- a/src/test/kotlin/org/machikoro/server/dto/ChatMessageTests.kt
+++ b/src/test/kotlin/org/machikoro/server/dto/ChatMessageTests.kt
@@ -10,8 +10,21 @@ class ChatMessageTests {
     @Test
     fun messageTypeShouldExposeAllSupportedValues() {
         val expected = setOf(
-            "CHAT", "JOIN", "LEAVE", "LOBBY_CREATED", "LOBBY_JOINED", "LOBBY_ROSTER", "GAME_START", "GAME_STARTED", "SYNC", "GAME_ACTION", "GAME_END",
-            "PLAYER_LEFT_FINISHED_GAME", "ERROR", "ROLL_DICE"
+            "CHAT",
+            "JOIN",
+            "LEAVE",
+            "LOBBY_CREATED",
+            "LOBBY_JOINED",
+            "LOBBY_ROSTER",
+            "GAME_START",
+            "GAME_STARTED",
+            "SYNC",
+            "GAME_ACTION",
+            "GAME_END",
+            "LOBBY_LEFT",
+            "PLAYER_LEFT_FINISHED_GAME",
+            "ERROR",
+            "ROLL_DICE"
         )
         val actual = MessageType.entries.map { it.name }.toSet()
 

--- a/src/test/kotlin/org/machikoro/server/service/DebugServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/DebugServiceTest.kt
@@ -162,7 +162,7 @@ class DebugServiceTest {
         assertEquals("debug_player2", result[0].username)
         assertEquals("debug_player4", result[2].username)
         verify(lobbyService, times(3)).addUserToLobby(eq(5), any())
-        verify(messagingTemplate, times(3)).convertAndSend(eq("/topic/public"), any<Any>())
+        verify(messagingTemplate, times(3)).convertAndSend(eq("/topic/game/5"), any<Any>())
     }
 
     @Test
@@ -180,7 +180,7 @@ class DebugServiceTest {
 
         assertEquals(1, result.size)
         assertEquals("debug_player2", result[0].username)
-        verify(messagingTemplate, times(1)).convertAndSend(eq("/topic/public"), any<Any>())
+        verify(messagingTemplate, times(1)).convertAndSend(eq("/topic/game/5"), any<Any>())
     }
 
     @Test
@@ -216,7 +216,7 @@ class DebugServiceTest {
         assertEquals("debug_player3", result[0].username)
         assertEquals("debug_player4", result[1].username)
         // Only 2 broadcasts — skipped dummy must not get one
-        verify(messagingTemplate, times(2)).convertAndSend(eq("/topic/public"), any<Any>())
+        verify(messagingTemplate, times(2)).convertAndSend(eq("/topic/game/5"), any<Any>())
     }
 
     @Test
@@ -244,7 +244,7 @@ class DebugServiceTest {
         val count = service.resetLobby("ABC123")
 
         assertEquals(2, count)
-        verify(messagingTemplate, times(2)).convertAndSend(eq("/topic/public"), any<Any>())
+        verify(messagingTemplate, times(2)).convertAndSend(eq("/topic/game/5"), any<Any>())
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/service/DebugServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/DebugServiceTest.kt
@@ -10,6 +10,7 @@ import org.machikoro.server.domain.models.GameModel
 import org.machikoro.server.domain.models.PlayerModel
 import org.machikoro.server.domain.models.UserModel
 import org.machikoro.server.dto.GameStateDto
+import org.machikoro.server.dto.LobbyRosterPlayerDto
 import org.machikoro.server.exception.GameNotFoundException
 import org.machikoro.server.exception.GameStartedException
 import org.machikoro.server.exception.LobbyFullException
@@ -228,5 +229,55 @@ class DebugServiceTest {
 
         verify(lobbyService, never()).addUserToLobby(any(), any())
         verify(messagingTemplate, never()).convertAndSend(any<String>(), any<Any>())
+    }
+
+    // === resetLobby() ===
+
+    @Test
+    fun `resetLobby broadcasts LOBBY_LEFT for each removed dummy and returns count`() {
+        val removed = listOf(
+            LobbyRosterPlayerDto(playerId = 2, userId = 2, username = "debug_player2", gameId = 5, turnOrder = 1, coins = 3),
+            LobbyRosterPlayerDto(playerId = 3, userId = 3, username = "debug_player3", gameId = 5, turnOrder = 2, coins = 3),
+        )
+        whenever(lobbyService.resetLobby("ABC123")).thenReturn(removed)
+
+        val count = service.resetLobby("ABC123")
+
+        assertEquals(2, count)
+        verify(messagingTemplate, times(2)).convertAndSend(eq("/topic/public"), any<Any>())
+    }
+
+    @Test
+    fun `resetLobby sends no broadcasts and returns 0 when no dummies were removed`() {
+        whenever(lobbyService.resetLobby("ABC123")).thenReturn(emptyList())
+
+        val count = service.resetLobby("ABC123")
+
+        assertEquals(0, count)
+        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<Any>())
+    }
+
+    @Test
+    fun `resetLobby propagates GameNotFoundException when lobby code not found`() {
+        whenever(lobbyService.resetLobby("NOPE")).thenThrow(GameNotFoundException("not found"))
+
+        assertThrows<GameNotFoundException> {
+            service.resetLobby("NOPE")
+        }
+
+        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<Any>())
+    }
+
+    // === purgeGames() ===
+
+    @Test
+    fun `purgeGames delegates to lobbyService and deletes debug users by prefix`() {
+        whenever(lobbyService.purgeAllGames()).thenReturn(3)
+
+        val count = service.purgeGames()
+
+        assertEquals(3, count)
+        verify(lobbyService).purgeAllGames()
+        verify(userDao).deleteByUsernamePrefix(LobbyService.DEBUG_USER_PREFIX)
     }
 }

--- a/src/test/kotlin/org/machikoro/server/service/GameSyncServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GameSyncServiceTest.kt
@@ -26,7 +26,9 @@ import org.machikoro.server.domain.models.LandmarkModel
 import org.machikoro.server.domain.models.PlayerCardModel
 import org.machikoro.server.domain.models.PlayerLandmarkModel
 import org.machikoro.server.domain.models.PlayerModel
+import org.machikoro.server.dto.LobbyRosterPlayerDto
 import org.machikoro.server.exception.GameNotFoundException
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -194,5 +196,30 @@ class GameSyncServiceTest {
 
         assertTrue(service.isUserInGame(50, 5))
         assertFalse(service.isUserInGame(50, 6))
+    }
+
+    @Test
+    fun `buildSnapshot playerUsernames populated from getLobbyRoster`() {
+        val gameId = 10
+        val p1 = PlayerModel(id = 1, gameId = gameId, userId = 11, turnOrder = 0, coins = 3, lastSeenAt = null)
+        val p2 = PlayerModel(id = 2, gameId = gameId, userId = 22, turnOrder = 1, coins = 3, lastSeenAt = null)
+
+        whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.IN_PROGRESS))
+        whenever(playerDao.getPlayers(gameId)).thenReturn(listOf(p1, p2))
+        whenever(playerCardDao.findByPlayerIds(any())).thenReturn(emptyMap())
+        whenever(playerLandmarkDao.findByPlayerId(any())).thenReturn(emptyList())
+        whenever(gameMarketplaceDao.findByGameIdAsMap(gameId)).thenReturn(emptyMap())
+        whenever(cardDao.findAll()).thenReturn(emptyList())
+        whenever(landmarkDao.findAll()).thenReturn(emptyList())
+        whenever(playerDao.getLobbyRoster(gameId)).thenReturn(
+            listOf(
+                LobbyRosterPlayerDto(playerId = 1, userId = 11, username = "alice", gameId = gameId, turnOrder = 0, coins = 3),
+                LobbyRosterPlayerDto(playerId = 2, userId = 22, username = "bob", gameId = gameId, turnOrder = 1, coins = 3),
+            )
+        )
+
+        val snapshot = service.buildSnapshot(gameId)
+
+        assertEquals(mapOf(1 to "alice", 2 to "bob"), snapshot.playerUsernames)
     }
 }

--- a/src/test/kotlin/org/machikoro/server/service/LobbyServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/LobbyServiceTest.kt
@@ -3,6 +3,7 @@ package org.machikoro.server.service
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.machikoro.server.dao.CardDao
@@ -80,6 +81,9 @@ class LobbyServiceTest {
 
     private fun player(id: Int) =
         PlayerModel(id = id, gameId = 1, userId = id, turnOrder = 0, coins = 3, lastSeenAt = null)
+
+    private fun rosterEntry(playerId: Int, username: String, gameId: Int = 1) =
+        LobbyRosterPlayerDto(playerId = playerId, userId = playerId, username = username, gameId = gameId, turnOrder = playerId - 1, coins = 3)
 
     @Test
     fun `addUserToLobby adds player successfully`() {
@@ -348,5 +352,101 @@ class LobbyServiceTest {
         }
 
         verify(initializationService, never()).initializeGame(any())
+    }
+
+    // === resetLobby() ===
+
+    @Test
+    fun `resetLobby removes only dummy players and returns their roster entries`() {
+        val lobbyCode = "ABC123"
+        val gameId = 1
+        whenever(gameDao.findByLobbyCode(lobbyCode)).thenReturn(game(gameId, GameStatus.WAITING))
+        val dummies = listOf(rosterEntry(2, "debug_player2", gameId), rosterEntry(3, "debug_player3", gameId))
+        whenever(playerDao.getLobbyRoster(gameId)).thenReturn(listOf(rosterEntry(1, "alice", gameId)) + dummies)
+
+        val removed = lobbyService.resetLobby(lobbyCode)
+
+        assertEquals(2, removed.size)
+        assertEquals("debug_player2", removed[0].username)
+        assertEquals("debug_player3", removed[1].username)
+        verify(playerDao).deleteByPlayerId(2)
+        verify(playerDao).deleteByPlayerId(3)
+        verify(playerDao, never()).deleteByPlayerId(1)
+    }
+
+    @Test
+    fun `resetLobby returns empty list when no dummy players are present`() {
+        val lobbyCode = "ABC123"
+        val gameId = 1
+        whenever(gameDao.findByLobbyCode(lobbyCode)).thenReturn(game(gameId, GameStatus.WAITING))
+        whenever(playerDao.getLobbyRoster(gameId)).thenReturn(
+            listOf(rosterEntry(1, "alice", gameId), rosterEntry(2, "bob", gameId))
+        )
+
+        val removed = lobbyService.resetLobby(lobbyCode)
+
+        assertTrue(removed.isEmpty())
+        verify(playerDao, never()).deleteByPlayerId(any())
+    }
+
+    @Test
+    fun `resetLobby throws GameNotFoundException when lobby code does not exist`() {
+        whenever(gameDao.findByLobbyCode("NOPE")).thenReturn(null)
+
+        assertThrows<GameNotFoundException> {
+            lobbyService.resetLobby("NOPE")
+        }
+
+        verify(playerDao, never()).getLobbyRoster(any())
+        verify(playerDao, never()).deleteByPlayerId(any())
+    }
+
+    // === purgeAllGames() ===
+
+    @Test
+    fun `purgeAllGames deletes players then game for every game and returns count`() {
+        val games = listOf(game(1, GameStatus.IN_PROGRESS), game(2, GameStatus.WAITING))
+        whenever(gameDao.findAll()).thenReturn(games)
+
+        val count = lobbyService.purgeAllGames()
+
+        assertEquals(2, count)
+        verify(playerDao).deleteByGameId(1)
+        verify(playerDao).deleteByGameId(2)
+        verify(gameDao).delete(1)
+        verify(gameDao).delete(2)
+    }
+
+    @Test
+    fun `purgeAllGames returns 0 and makes no deletions when no games exist`() {
+        whenever(gameDao.findAll()).thenReturn(emptyList())
+
+        val count = lobbyService.purgeAllGames()
+
+        assertEquals(0, count)
+        verify(playerDao, never()).deleteByGameId(any())
+        verify(gameDao, never()).delete(any())
+    }
+
+    // === startGame() — playerUsernames ===
+
+    @Test
+    fun `startGame snapshot includes playerUsernames resolved from getLobbyRoster`() {
+        val gameId = 1
+        val players = listOf(player(1), player(2))
+        val updatedGame = game(gameId, GameStatus.IN_PROGRESS)
+        whenever(gameDao.findById(gameId)).thenReturn(updatedGame)
+        whenever(playerDao.getPlayers(gameId)).thenReturn(players)
+        whenever(initializationService.initializeGame(gameId)).thenReturn(players)
+        whenever(playerCardDao.findByPlayerIds(any())).thenReturn(emptyMap())
+        whenever(playerLandmarkDao.findByPlayerId(any())).thenReturn(emptyList())
+        whenever(gameMarketplaceDao.findByGameIdAsMap(gameId)).thenReturn(emptyMap())
+        whenever(playerDao.getLobbyRoster(gameId)).thenReturn(
+            listOf(rosterEntry(1, "alice", gameId), rosterEntry(2, "bob", gameId))
+        )
+
+        val result = lobbyService.startGame(gameId)
+
+        assertEquals(mapOf(1 to "alice", 2 to "bob"), result.playerUsernames)
     }
 }

--- a/src/test/kotlin/org/machikoro/server/service/LobbyServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/LobbyServiceTest.kt
@@ -1,7 +1,9 @@
 package org.machikoro.server.service
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -352,6 +354,67 @@ class LobbyServiceTest {
         }
 
         verify(initializationService, never()).initializeGame(any())
+    }
+
+    // === leaveLobby() ===
+
+    @Test
+    fun `leaveLobby returns null when player is not in the game`() {
+        whenever(playerDao.findByGameIdAndUserId(1, 99)).thenReturn(null)
+
+        val result = lobbyService.leaveLobby(1, 99)
+
+        assertNull(result)
+        verify(playerDao, never()).deleteByPlayerId(any())
+    }
+
+    @Test
+    fun `leaveLobby returns gameDeleted=false when real players still remain`() {
+        val p = player(5).copy(gameId = 1, userId = 10)
+        whenever(playerDao.findByGameIdAndUserId(1, 10)).thenReturn(p)
+        whenever(playerDao.getLobbyRoster(1)).thenReturn(
+            listOf(rosterEntry(6, "alice", 1))
+        )
+
+        val result = lobbyService.leaveLobby(1, 10)
+
+        assertNotNull(result)
+        assertEquals(5, result!!.playerId)
+        assertFalse(result.gameDeleted)
+        verify(playerDao).deleteByPlayerId(5)
+        verify(gameDao, never()).delete(any())
+    }
+
+    @Test
+    fun `leaveLobby returns gameDeleted=true and purges game when only dummy players remain`() {
+        val p = player(5).copy(gameId = 1, userId = 10)
+        whenever(playerDao.findByGameIdAndUserId(1, 10)).thenReturn(p)
+        whenever(playerDao.getLobbyRoster(1)).thenReturn(
+            listOf(rosterEntry(2, "debug_player2", 1))
+        )
+
+        val result = lobbyService.leaveLobby(1, 10)
+
+        assertNotNull(result)
+        assertEquals(5, result!!.playerId)
+        assertTrue(result.gameDeleted)
+        verify(playerDao).deleteByPlayerId(5)
+        verify(playerDao).deleteByGameId(1)
+        verify(gameDao).delete(1)
+    }
+
+    @Test
+    fun `leaveLobby returns gameDeleted=true when roster is empty after player leaves`() {
+        val p = player(5).copy(gameId = 1, userId = 10)
+        whenever(playerDao.findByGameIdAndUserId(1, 10)).thenReturn(p)
+        whenever(playerDao.getLobbyRoster(1)).thenReturn(emptyList())
+
+        val result = lobbyService.leaveLobby(1, 10)
+
+        assertNotNull(result)
+        assertTrue(result!!.gameDeleted)
+        verify(playerDao).deleteByGameId(1)
+        verify(gameDao).delete(1)
     }
 
     // === resetLobby() ===


### PR DESCRIPTION
This PR fixes a lot of of things.

- Adds a purge endpoint for debugging purposes that deletes all games and usernames starting with "debug" (for the dummies)
- Adds functionality to reset the lobby to get rid of the dummies
- Adds functionality to delete a lobby if no real players are in there anymore

Merge this before Client PR.