### PR TITLE
fix(session): clarify reconnect state and dice roll completion

### DIFF
--- a/src/main/kotlin/org/machikoro/server/controller/AuthController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/AuthController.kt
@@ -7,6 +7,7 @@ import org.machikoro.server.dto.LogoutRequest
 import org.machikoro.server.dto.RegisterRequest
 import org.machikoro.server.exception.InvalidCredentialsException
 import org.machikoro.server.service.AuthService
+import org.machikoro.server.service.GameSyncService
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -18,7 +19,10 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/auth")
 @Tag(name = "Authentication", description = "User registration, login, and session management")
-class AuthController(private val authService: AuthService) {
+class AuthController(
+    private val authService: AuthService,
+    private val gameSyncService: GameSyncService,
+) {
     private val logger = LoggerFactory.getLogger(AuthController::class.java)
 
     @PostMapping("/register")
@@ -39,8 +43,9 @@ class AuthController(private val authService: AuthService) {
     fun login(@RequestBody request: LoginRequest): ResponseEntity<Any> {
         return try {
             val response = authService.login(request.username, request.password)
+            val sessionState = gameSyncService.resolveSessionState(response.userId)
             logger.info("Logged in user '{}'", response.username)
-            ResponseEntity.ok(response)
+            ResponseEntity.ok(response.copy(sessionState = sessionState))
         } catch (e: InvalidCredentialsException) {
             logger.warn("Login failed for '{}': invalid credentials", request.username)
             ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.message)

--- a/src/main/kotlin/org/machikoro/server/controller/GameController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/GameController.kt
@@ -215,6 +215,7 @@ class GameController(
     ))
     fun rollDice(@Payload request: RollDiceRequest, headerAccessor: SimpMessageHeaderAccessor) {
         requireActivePlayer(request.gameId, headerAccessor)
+        requireOwnerOfPlayer(request.gameId, request.playerId, headerAccessor)
         val gameTopic = "/topic/game/${request.gameId}"
         logger.info("Roll dice request from player ${request.playerId} in game ${request.gameId}")
         try {
@@ -228,7 +229,10 @@ class GameController(
                     payload = mapOf(
                         "playerId" to request.playerId,
                         "result" to result.dice,
-                        "timestamp" to System.currentTimeMillis()
+                        "total" to result.total,
+                        "completed" to result.completed,
+                        "turnPhase" to result.turnPhase.name,
+                        "timestamp" to System.currentTimeMillis(),
                     )
                 )
             )

--- a/src/main/kotlin/org/machikoro/server/controller/GameController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/GameController.kt
@@ -3,6 +3,7 @@ package org.machikoro.server.controller
 import org.machikoro.server.auth.requireUserPrincipal
 import org.machikoro.server.dao.PlayerDao
 import org.machikoro.server.domain.enums.TurnPhase
+import org.machikoro.server.domain.models.PlayerModel
 import org.machikoro.server.dto.EndTurnOutcome
 import org.machikoro.server.dto.AdvancePhaseRequest
 import org.machikoro.server.dto.EndTurnRequest
@@ -214,20 +215,19 @@ class GameController(
         payloadType = RollDiceRequest::class,
     ))
     fun rollDice(@Payload request: RollDiceRequest, headerAccessor: SimpMessageHeaderAccessor) {
-        requireActivePlayer(request.gameId, headerAccessor)
-        requireOwnerOfPlayer(request.gameId, request.playerId, headerAccessor)
+        val rollingPlayer = requireActivePlayer(request.gameId, headerAccessor)
         val gameTopic = "/topic/game/${request.gameId}"
-        logger.info("Roll dice request from player ${request.playerId} in game ${request.gameId}")
+        logger.info("Roll dice request from player ${rollingPlayer.id} in game ${request.gameId}")
         try {
-            val result = diceService.rollDice(request)
+            val result = diceService.rollDice(request, rollingPlayer.id)
             messagingTemplate.convertAndSend(
                 gameTopic,
                 WebSocketMessage(
                     type = MessageType.ROLL_DICE,
                     sender = "SERVER",
-                    content = "Player ${request.playerId} rolled: ${result.total}",
+                    content = "Player ${rollingPlayer.id} rolled: ${result.total}",
                     payload = mapOf(
-                        "playerId" to request.playerId,
+                        "playerId" to rollingPlayer.id,
                         "result" to result.dice,
                         "total" to result.total,
                         "completed" to result.completed,
@@ -311,8 +311,8 @@ class GameController(
      * `NOT_YOUR_TURN` / `NO_ACTIVE_PLAYER` / `GAME_FINISHED` per the helper
      * and guard contracts.
      */
-    private fun requireActivePlayer(gameId: Int, headerAccessor: SimpMessageHeaderAccessor) {
-        gameStateGuard.ensureSenderIsActivePlayer(gameId, headerAccessor.requireUserPrincipal())
+    private fun requireActivePlayer(gameId: Int, headerAccessor: SimpMessageHeaderAccessor): PlayerModel {
+        return gameStateGuard.ensureSenderIsActivePlayer(gameId, headerAccessor.requireUserPrincipal())
     }
 
     private fun requireOwnerOfPlayer(gameId: Int, playerId: Int, headerAccessor: SimpMessageHeaderAccessor) {

--- a/src/main/kotlin/org/machikoro/server/dao/PlayerDao.kt
+++ b/src/main/kotlin/org/machikoro/server/dao/PlayerDao.kt
@@ -14,6 +14,7 @@ import org.machikoro.server.database.Games
 import org.machikoro.server.database.Players
 import org.machikoro.server.database.Users
 import org.machikoro.server.domain.enums.GameStatus
+import org.machikoro.server.domain.models.GameModel
 import org.machikoro.server.domain.models.PlayerModel
 import org.machikoro.server.dto.LobbyRosterPlayerDto
 import org.machikoro.server.exception.PlayerNotFoundException
@@ -22,6 +23,11 @@ import org.springframework.stereotype.Repository
 @Repository
 class PlayerDao {
 
+    data class PlayerGameMembership(
+        val player: PlayerModel,
+        val game: GameModel,
+    )
+
     private fun ResultRow.toModel() = PlayerModel(
         id = this[Players.id].value,
         gameId = this[Players.gameId].value,
@@ -29,6 +35,19 @@ class PlayerDao {
         turnOrder = this[Players.turnOrder],
         coins = this[Players.coins],
         lastSeenAt = this[Players.lastSeenAt]
+    )
+
+    private fun ResultRow.toGameModel() = GameModel(
+        id = this[Games.id].value,
+        status = this[Games.status],
+        hostUserId = this[Games.hostUserId].value,
+        lobbyCode = this[Games.lobbyCode],
+        maxPlayers = this[Games.maxPlayers],
+        currentTurnIndex = this[Games.currentTurnIndex],
+        turnPhase = this[Games.turnPhase],
+        lastDiceRoll = this[Games.lastDiceRoll],
+        roundNumber = this[Games.roundNumber],
+        hasPurchasedThisTurn = this[Games.hasPurchasedThisTurn],
     )
 
     /**
@@ -104,6 +123,36 @@ class PlayerDao {
             .firstOrNull()
             ?.get(Players.gameId)
             ?.value
+    }
+
+    /**
+     * Returns the newest valid membership for a reconnect/login decision.
+     *
+     * IN_PROGRESS games take precedence over WAITING lobbies so a client that
+     * missed the start transition is sent to the game screen instead of back to
+     * lobby creation. FINISHED games are intentionally ignored because they are
+     * not a current navigation target after a fresh login.
+     */
+    fun findCurrentMembershipByUserId(userId: Int): PlayerGameMembership? = transaction {
+        fun newestMembershipByStatus(status: GameStatus): PlayerGameMembership? =
+            Players.join(
+                Games,
+                JoinType.INNER,
+                additionalConstraint = { Players.gameId eq Games.id }
+            )
+                .selectAll()
+                .where { (Players.userId eq userId) and (Games.status eq status) }
+                .orderBy(Games.id to SortOrder.DESC)
+                .firstOrNull()
+                ?.let { row ->
+                    PlayerGameMembership(
+                        player = row.toModel(),
+                        game = row.toGameModel(),
+                    )
+                }
+
+        newestMembershipByStatus(GameStatus.IN_PROGRESS)
+            ?: newestMembershipByStatus(GameStatus.WAITING)
     }
 
     /**

--- a/src/main/kotlin/org/machikoro/server/dto/LoginResponse.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/LoginResponse.kt
@@ -1,6 +1,32 @@
 package org.machikoro.server.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import org.machikoro.server.domain.enums.GameStatus
+import org.machikoro.server.domain.enums.TurnPhase
+
+@Schema(description = "Client screen the server considers current for an authenticated user")
+enum class ClientScreen {
+    START,
+    MAIN,
+    LOBBY,
+    GAME,
+}
+
+@Schema(description = "Server-resolved navigation state for login and reconnect flows")
+data class SessionStateDto(
+    @Schema(description = "Current screen the client should display")
+    val screen: ClientScreen,
+    @Schema(description = "Current game ID when the user belongs to an active lobby or game")
+    val gameId: Int? = null,
+    @Schema(description = "Current player row ID for the user in that game")
+    val playerId: Int? = null,
+    @Schema(description = "Lobby code when the user is in a waiting lobby or active game")
+    val lobbyCode: String? = null,
+    @Schema(description = "Current game status when a valid game membership exists")
+    val gameStatus: GameStatus? = null,
+    @Schema(description = "Current turn phase when a valid game membership exists")
+    val turnPhase: TurnPhase? = null,
+)
 
 @Schema(description = "Response from a successful login — caller stores the session token and uses it for subsequent authenticated calls")
 data class LoginResponse(
@@ -10,4 +36,6 @@ data class LoginResponse(
     val username: String,
     @Schema(description = "Unique ID of the authenticated user", example = "42")
     val userId: Int,
+    @Schema(description = "Server-resolved state that tells the client whether to show main, lobby, or game UI")
+    val sessionState: SessionStateDto = SessionStateDto(screen = ClientScreen.MAIN),
 )

--- a/src/main/kotlin/org/machikoro/server/dto/RollDiceRequest.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/RollDiceRequest.kt
@@ -6,8 +6,22 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class RollDiceRequest(
     @Schema(description = "ID of the game", example = "1")
     val gameId: Int,
-    @Schema(description = "ID of the rolling player", example = "42")
-    val playerId: Int,
+    @Schema(description = "Legacy client-supplied player ID. The server derives the rolling player from the authenticated active turn.")
+    val playerId: Int? = null,
+    @Schema(description = "Whether to roll two dice instead of one", example = "false")
+    val rollTwoDice: Boolean = false,
+    @Schema(description = "Legacy client dice count, where 2 means roll two dice")
+    val diceCount: Int? = null,
+    @Schema(description = "Wrapped WebSocket payload used by older clients")
+    val payload: RollDicePayload? = null,
+)
+
+@Schema(description = "Nested roll-dice payload accepted for backward-compatible WebSocket clients")
+data class RollDicePayload(
+    @Schema(description = "ID of the game", example = "1")
+    val gameId: Int? = null,
+    @Schema(description = "Legacy client dice count, where 2 means roll two dice")
+    val diceCount: Int? = null,
     @Schema(description = "Whether to roll two dice instead of one", example = "false")
     val rollTwoDice: Boolean = false,
 )

--- a/src/main/kotlin/org/machikoro/server/dto/RollDiceResponse.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/RollDiceResponse.kt
@@ -1,6 +1,10 @@
 package org.machikoro.server.dto
 
+import org.machikoro.server.domain.enums.TurnPhase
+
 data class RollDiceResponse(
     val dice: List<Int>,
-    val total: Int
+    val total: Int,
+    val completed: Boolean = true,
+    val turnPhase: TurnPhase = TurnPhase.RESOLVE_EFFECTS,
 )

--- a/src/main/kotlin/org/machikoro/server/service/DiceService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/DiceService.kt
@@ -18,16 +18,21 @@ class DiceService(
 ) {
     private val rollLocks = ConcurrentHashMap<Int, Any>()
 
-    fun rollDice(request: RollDiceRequest): RollDiceResponse = synchronized(rollLocks.computeIfAbsent(request.gameId) { Any() }) {
+    fun rollDice(request: RollDiceRequest, rollingPlayerId: Int): RollDiceResponse = synchronized(rollLocks.computeIfAbsent(request.gameId) { Any() }) {
         val game = gameStateGuard.ensureGameIsRunning(request.gameId)
 
         if (game.turnPhase != TurnPhase.ROLL_DICE) {
             throw CustomWebSocketException("ROLL_ALREADY_COMPLETED", "Dice have already been rolled for this turn")
         }
 
-        if (request.rollTwoDice) {
+        val rollTwoDice = request.rollTwoDice ||
+            request.diceCount == TWO_DICE_COUNT ||
+            request.payload?.rollTwoDice == true ||
+            request.payload?.diceCount == TWO_DICE_COUNT
+
+        if (rollTwoDice) {
             val hasTrainStation = playerLandmarkDao
-                .findByPlayerIdAndType(request.playerId, LandmarkType.TRAIN_STATION)
+                .findByPlayerIdAndType(rollingPlayerId, LandmarkType.TRAIN_STATION)
                 ?.isBuilt ?: false
 
             if (!hasTrainStation) {
@@ -35,7 +40,7 @@ class DiceService(
             }
         }
 
-        val dice = if (request.rollTwoDice) {
+        val dice = if (rollTwoDice) {
             listOf((1..6).random(), (1..6).random())
         } else {
             listOf((1..6).random())
@@ -45,5 +50,9 @@ class DiceService(
         gameDao.updateAfterRoll(request.gameId, total, TurnPhase.RESOLVE_EFFECTS)
 
         return RollDiceResponse(dice = dice, total = total)
+    }
+
+    private companion object {
+        const val TWO_DICE_COUNT = 2
     }
 }

--- a/src/main/kotlin/org/machikoro/server/service/DiceService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/DiceService.kt
@@ -8,6 +8,7 @@ import org.machikoro.server.dto.RollDiceRequest
 import org.machikoro.server.dto.RollDiceResponse
 import org.machikoro.server.exception.CustomWebSocketException
 import org.springframework.stereotype.Service
+import java.util.concurrent.ConcurrentHashMap
 
 @Service
 class DiceService(
@@ -15,11 +16,13 @@ class DiceService(
     private val playerLandmarkDao: PlayerLandmarkDao,
     private val gameStateGuard: GameStateGuard,
 ) {
-    fun rollDice(request: RollDiceRequest): RollDiceResponse {
+    private val rollLocks = ConcurrentHashMap<Int, Any>()
+
+    fun rollDice(request: RollDiceRequest): RollDiceResponse = synchronized(rollLocks.computeIfAbsent(request.gameId) { Any() }) {
         val game = gameStateGuard.ensureGameIsRunning(request.gameId)
 
         if (game.turnPhase != TurnPhase.ROLL_DICE) {
-            throw CustomWebSocketException("WRONG_PHASE", "It's not the roll dice phase")
+            throw CustomWebSocketException("ROLL_ALREADY_COMPLETED", "Dice have already been rolled for this turn")
         }
 
         if (request.rollTwoDice) {

--- a/src/main/kotlin/org/machikoro/server/service/GameStateGuard.kt
+++ b/src/main/kotlin/org/machikoro/server/service/GameStateGuard.kt
@@ -5,6 +5,7 @@ import org.machikoro.server.dao.GameDao
 import org.machikoro.server.dao.PlayerDao
 import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.models.GameModel
+import org.machikoro.server.domain.models.PlayerModel
 import org.machikoro.server.exception.CustomWebSocketException
 import org.machikoro.server.exception.GameNotFoundException
 import org.springframework.stereotype.Service
@@ -62,7 +63,7 @@ class GameStateGuard(
      *  - `NO_ACTIVE_PLAYER`  — currentTurnIndex points outside the player list.
      *  - `NOT_YOUR_TURN`     — caller is authenticated but not the active player.
      */
-    fun ensureSenderIsActivePlayer(gameId: Int, user: UserPrincipal) {
+    fun ensureSenderIsActivePlayer(gameId: Int, user: UserPrincipal): PlayerModel {
         val game = ensureGameIsRunning(gameId)
         val active = playerDao.getPlayers(gameId).getOrNull(game.currentTurnIndex)
             ?: throw CustomWebSocketException(
@@ -75,6 +76,7 @@ class GameStateGuard(
                 message = "It is not your turn",
             )
         }
+        return active
     }
 
     /**

--- a/src/main/kotlin/org/machikoro/server/service/GameSyncService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/GameSyncService.kt
@@ -9,6 +9,8 @@ import org.machikoro.server.dao.PlayerDao
 import org.machikoro.server.dao.PlayerLandmarkDao
 import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.dto.GameStateDto
+import org.machikoro.server.dto.ClientScreen
+import org.machikoro.server.dto.SessionStateDto
 import org.machikoro.server.dto.toDefinitionDto
 import org.machikoro.server.exception.GameNotFoundException
 import org.springframework.stereotype.Service
@@ -26,6 +28,26 @@ class GameSyncService(
 
     fun findActiveInProgressGameId(userId: Int): Int? =
         playerDao.findActiveGameIdByUserId(userId)
+
+    fun resolveSessionState(userId: Int): SessionStateDto {
+        val membership = playerDao.findCurrentMembershipByUserId(userId)
+            ?: return SessionStateDto(screen = ClientScreen.MAIN)
+
+        val screen = when (membership.game.status) {
+            GameStatus.WAITING -> ClientScreen.LOBBY
+            GameStatus.IN_PROGRESS -> ClientScreen.GAME
+            GameStatus.FINISHED -> ClientScreen.MAIN
+        }
+
+        return SessionStateDto(
+            screen = screen,
+            gameId = membership.game.id,
+            playerId = membership.player.id,
+            lobbyCode = membership.game.lobbyCode,
+            gameStatus = membership.game.status,
+            turnPhase = membership.game.turnPhase,
+        )
+    }
 
     fun buildSnapshot(gameId: Int): GameStateDto {
         val game = gameDao.findById(gameId)

--- a/src/test/kotlin/org/machikoro/server/controller/AuthControllerTests.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/AuthControllerTests.kt
@@ -8,9 +8,12 @@ import org.machikoro.server.dto.LoginResponse
 import org.machikoro.server.dto.LogoutRequest
 import org.machikoro.server.dto.RegisterRequest
 import org.machikoro.server.dto.RegisterResponse
+import org.machikoro.server.dto.ClientScreen
+import org.machikoro.server.dto.SessionStateDto
 import org.machikoro.server.exception.DuplicateUserException
 import org.machikoro.server.exception.InvalidCredentialsException
 import org.machikoro.server.service.AuthService
+import org.machikoro.server.service.GameSyncService
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -19,7 +22,8 @@ import org.springframework.http.HttpStatus
 class AuthControllerTests {
 
     private val authService = mock<AuthService>()
-    private val controller = AuthController(authService)
+    private val gameSyncService = mock<GameSyncService>()
+    private val controller = AuthController(authService, gameSyncService)
 
     @Test
     fun `register returns ok with response body when service succeeds`() {
@@ -60,13 +64,17 @@ class AuthControllerTests {
     @Test
     fun `login returns ok with response body when service succeeds`() {
         val request = LoginRequest(username = "alice", password = "hunter2")
-        val expected = LoginResponse(sessionToken = "token-uuid", username = "alice", userId = 42) // NEU
-        whenever(authService.login("alice", "hunter2")).thenReturn(expected)
+        val loginResponse = LoginResponse(sessionToken = "token-uuid", username = "alice", userId = 42)
+        val sessionState = SessionStateDto(screen = ClientScreen.MAIN)
+        val expected = loginResponse.copy(sessionState = sessionState)
+        whenever(authService.login("alice", "hunter2")).thenReturn(loginResponse)
+        whenever(gameSyncService.resolveSessionState(42)).thenReturn(sessionState)
 
         val response = controller.login(request)
 
         assertEquals(HttpStatus.OK, response.statusCode)
         assertEquals(expected, response.body)
+        verify(gameSyncService).resolveSessionState(42)
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
@@ -357,7 +357,11 @@ class GameControllerTest {
         val payload = message.payload as Map<String, Any?>
         assertEquals(playerId, payload["playerId"])
         assertEquals(listOf(3, 4), payload["result"])
+        assertEquals(7, payload["total"])
+        assertEquals(true, payload["completed"])
+        assertEquals("RESOLVE_EFFECTS", payload["turnPhase"])
         assert(payload["timestamp"] is Long)
+        verify(gameStateGuard).ensureSenderOwnsPlayer(gameId, playerId, alice)
     }
 
     @Test
@@ -374,6 +378,7 @@ class GameControllerTest {
         val message = captor.firstValue
         assertEquals(MessageType.ERROR, message.type)
         assertEquals(mapOf("event" to "ROLL_FAILED", "message" to "dice exploded"), message.payload)
+        verify(gameStateGuard).ensureSenderOwnsPlayer(gameId, playerId, alice)
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
@@ -337,10 +337,11 @@ class GameControllerTest {
     @Test
     fun `rollDice broadcasts result with playerId, result and timestamp to correct game topic`() {
         val gameId = 1
-        val playerId = 2
-        val request = RollDiceRequest(gameId = gameId, playerId = playerId)
+        val activePlayer = PlayerModel(id = 9, gameId = gameId, userId = alice.userId, turnOrder = 0, coins = 3, lastSeenAt = null)
+        val request = RollDiceRequest(gameId = gameId, playerId = 999)
         val response = RollDiceResponse(dice = listOf(3, 4), total = 7)
-        whenever(diceService.rollDice(request)).thenReturn(response)
+        whenever(gameStateGuard.ensureSenderIsActivePlayer(gameId, alice)).thenReturn(activePlayer)
+        whenever(diceService.rollDice(request, activePlayer.id)).thenReturn(response)
 
         controller.rollDice(request, authedAccessor())
 
@@ -351,25 +352,27 @@ class GameControllerTest {
         val message = captor.firstValue
         assertEquals(MessageType.ROLL_DICE, message.type)
         assertEquals("SERVER", message.sender)
-        assertEquals("Player $playerId rolled: 7", message.content)
+        assertEquals("Player ${activePlayer.id} rolled: 7", message.content)
 
         @Suppress("UNCHECKED_CAST")
         val payload = message.payload as Map<String, Any?>
-        assertEquals(playerId, payload["playerId"])
+        assertEquals(activePlayer.id, payload["playerId"])
         assertEquals(listOf(3, 4), payload["result"])
         assertEquals(7, payload["total"])
         assertEquals(true, payload["completed"])
         assertEquals("RESOLVE_EFFECTS", payload["turnPhase"])
         assert(payload["timestamp"] is Long)
-        verify(gameStateGuard).ensureSenderOwnsPlayer(gameId, playerId, alice)
+        verify(diceService).rollDice(request, activePlayer.id)
+        verify(gameStateGuard, never()).ensureSenderOwnsPlayer(any(), any(), any())
     }
 
     @Test
     fun `rollDice broadcasts error to game topic on failure`() {
         val gameId = 1
-        val playerId = 2
-        val request = RollDiceRequest(gameId = gameId, playerId = playerId)
-        whenever(diceService.rollDice(request)).thenThrow(RuntimeException("dice exploded"))
+        val activePlayer = PlayerModel(id = 9, gameId = gameId, userId = alice.userId, turnOrder = 0, coins = 3, lastSeenAt = null)
+        val request = RollDiceRequest(gameId = gameId, playerId = null)
+        whenever(gameStateGuard.ensureSenderIsActivePlayer(gameId, alice)).thenReturn(activePlayer)
+        whenever(diceService.rollDice(request, activePlayer.id)).thenThrow(RuntimeException("dice exploded"))
 
         controller.rollDice(request, authedAccessor())
 
@@ -378,7 +381,8 @@ class GameControllerTest {
         val message = captor.firstValue
         assertEquals(MessageType.ERROR, message.type)
         assertEquals(mapOf("event" to "ROLL_FAILED", "message" to "dice exploded"), message.payload)
-        verify(gameStateGuard).ensureSenderOwnsPlayer(gameId, playerId, alice)
+        verify(diceService).rollDice(request, activePlayer.id)
+        verify(gameStateGuard, never()).ensureSenderOwnsPlayer(any(), any(), any())
     }
 
     @Test
@@ -393,7 +397,7 @@ class GameControllerTest {
             controller.rollDice(request, authedAccessor())
         }
         assertEquals("NOT_YOUR_TURN", ex.errorCode)
-        verify(diceService, never()).rollDice(any())
+        verify(diceService, never()).rollDice(any(), any())
         verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
     }
 
@@ -430,7 +434,7 @@ class GameControllerTest {
     @Test
     fun `rollDice throws UNAUTHENTICATED when accessor has no principal`() {
         assertUnauthenticated { controller.rollDice(RollDiceRequest(gameId = 42, playerId = 1), it) }
-        verify(diceService, never()).rollDice(any())
+        verify(diceService, never()).rollDice(any(), any())
     }
 
 }

--- a/src/test/kotlin/org/machikoro/server/dao/PlayerDaoTest.kt
+++ b/src/test/kotlin/org/machikoro/server/dao/PlayerDaoTest.kt
@@ -208,6 +208,46 @@ class PlayerDaoTest : AbstractDBSetup() {
     }
 
     @Test
+    fun `findCurrentMembershipByUserId prefers newest in-progress game over waiting lobby`() {
+        val waitingGameId = gameDao.create(userId)
+        val activeGameId = gameDao.create(userId)
+        val waitingPlayer = playerDao.addPlayer(waitingGameId, userId)
+        val activePlayer = playerDao.addPlayer(activeGameId, userId)
+        gameDao.updateStatus(activeGameId, GameStatus.IN_PROGRESS)
+
+        val membership = playerDao.findCurrentMembershipByUserId(userId)
+
+        assertNotNull(membership)
+        assertEquals(activeGameId, membership!!.game.id)
+        assertEquals(activePlayer.id, membership.player.id)
+        assertNotEquals(waitingPlayer.id, membership.player.id)
+    }
+
+    @Test
+    fun `findCurrentMembershipByUserId returns waiting lobby when no in-progress game exists`() {
+        val olderWaitingGameId = gameDao.create(userId)
+        val newerWaitingGameId = gameDao.create(userId)
+        playerDao.addPlayer(olderWaitingGameId, userId)
+        val expectedPlayer = playerDao.addPlayer(newerWaitingGameId, userId)
+
+        val membership = playerDao.findCurrentMembershipByUserId(userId)
+
+        assertNotNull(membership)
+        assertEquals(newerWaitingGameId, membership!!.game.id)
+        assertEquals(expectedPlayer.id, membership.player.id)
+        assertEquals(GameStatus.WAITING, membership.game.status)
+    }
+
+    @Test
+    fun `findCurrentMembershipByUserId ignores finished games`() {
+        val finishedGameId = gameDao.create(userId)
+        playerDao.addPlayer(finishedGameId, userId)
+        gameDao.updateStatus(finishedGameId, GameStatus.FINISHED)
+
+        assertNull(playerDao.findCurrentMembershipByUserId(userId))
+    }
+
+    @Test
     fun `updateLastSeen stores a timestamp for player`() {
         val player = playerDao.addPlayer(gameId, userId)
         val before = System.currentTimeMillis()

--- a/src/test/kotlin/org/machikoro/server/service/DiceServiceTests.kt
+++ b/src/test/kotlin/org/machikoro/server/service/DiceServiceTests.kt
@@ -10,6 +10,7 @@ import org.machikoro.server.domain.enums.LandmarkType
 import org.machikoro.server.domain.enums.TurnPhase
 import org.machikoro.server.domain.models.GameModel
 import org.machikoro.server.domain.models.PlayerLandmarkModel
+import org.machikoro.server.dto.RollDicePayload
 import org.machikoro.server.dto.RollDiceRequest
 import org.machikoro.server.exception.CustomWebSocketException
 import org.machikoro.server.exception.GameNotFoundException
@@ -47,8 +48,8 @@ class DiceServiceTests {
     fun rollDiceShouldReturnSingleDieValueBetween1And6() {
         whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(defaultGame)
 
-        val request = RollDiceRequest(gameId = 1, playerId = 2)
-        val result = diceService.rollDice(request)
+        val request = RollDiceRequest(gameId = 1)
+        val result = diceService.rollDice(request, rollingPlayerId = 2)
 
         assertEquals(1, result.dice.size)
         assert(result.total in 1..6)
@@ -63,7 +64,7 @@ class DiceServiceTests {
         val request = RollDiceRequest(gameId = 1, playerId = 2)
 
         assertThrows(GameNotFoundException::class.java) {
-            diceService.rollDice(request)
+            diceService.rollDice(request, rollingPlayerId = 2)
         }
         verify(gameDao, never()).updateAfterRoll(any(), any(), any())
     }
@@ -76,7 +77,7 @@ class DiceServiceTests {
         val request = RollDiceRequest(gameId = 1, playerId = 2)
 
         val ex = assertThrows(CustomWebSocketException::class.java) {
-            diceService.rollDice(request)
+            diceService.rollDice(request, rollingPlayerId = 2)
         }
         assertEquals("GAME_FINISHED", ex.errorCode)
         verify(gameDao, never()).updateAfterRoll(any(), any(), any())
@@ -90,7 +91,7 @@ class DiceServiceTests {
         val request = RollDiceRequest(gameId = 1, playerId = 2)
 
         val ex = assertThrows(CustomWebSocketException::class.java) {
-            diceService.rollDice(request)
+            diceService.rollDice(request, rollingPlayerId = 2)
         }
         assertEquals("ROLL_ALREADY_COMPLETED", ex.errorCode)
     }
@@ -102,12 +103,12 @@ class DiceServiceTests {
             .thenReturn(defaultGame.copy(turnPhase = TurnPhase.RESOLVE_EFFECTS, lastDiceRoll = 4))
 
         val request = RollDiceRequest(gameId = 1, playerId = 2)
-        val first = diceService.rollDice(request)
+        val first = diceService.rollDice(request, rollingPlayerId = 2)
 
         assertEquals(true, first.completed)
         assertEquals(TurnPhase.RESOLVE_EFFECTS, first.turnPhase)
         val ex = assertThrows(CustomWebSocketException::class.java) {
-            diceService.rollDice(request)
+            diceService.rollDice(request, rollingPlayerId = 2)
         }
         assertEquals("ROLL_ALREADY_COMPLETED", ex.errorCode)
     }
@@ -125,11 +126,11 @@ class DiceServiceTests {
         val request = RollDiceRequest(gameId = 1, playerId = 2)
         val executor = Executors.newFixedThreadPool(2)
         try {
-            val first = executor.submit(Callable { diceService.rollDice(request) })
+            val first = executor.submit(Callable { diceService.rollDice(request, rollingPlayerId = 2) })
             firstEntered.await(1, TimeUnit.SECONDS)
             val second = executor.submit(Callable {
                 assertThrows(CustomWebSocketException::class.java) {
-                    diceService.rollDice(request)
+                    diceService.rollDice(request, rollingPlayerId = 2)
                 }.errorCode
             })
             releaseFirst.countDown()
@@ -150,7 +151,7 @@ class DiceServiceTests {
         val request = RollDiceRequest(gameId = 1, playerId = 2, rollTwoDice = true)
 
         assertThrows(CustomWebSocketException::class.java) {
-            diceService.rollDice(request)
+            diceService.rollDice(request, rollingPlayerId = 2)
         }
     }
 
@@ -161,7 +162,21 @@ class DiceServiceTests {
             .thenReturn(PlayerLandmarkModel(playerId = 2, landmarkType = LandmarkType.TRAIN_STATION, isBuilt = true))
 
         val request = RollDiceRequest(gameId = 1, playerId = 2, rollTwoDice = true)
-        val result = diceService.rollDice(request)
+        val result = diceService.rollDice(request, rollingPlayerId = 2)
+
+        assertEquals(2, result.dice.size)
+        assert(result.total in 2..12)
+        assertEquals(result.dice.sum(), result.total)
+    }
+
+    @Test
+    fun rollTwoDiceShouldUseNestedLegacyDiceCountWhenTrainStationOwned() {
+        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(defaultGame)
+        whenever(playerLandmarkDao.findByPlayerIdAndType(2, LandmarkType.TRAIN_STATION))
+            .thenReturn(PlayerLandmarkModel(playerId = 2, landmarkType = LandmarkType.TRAIN_STATION, isBuilt = true))
+
+        val request = RollDiceRequest(gameId = 1, payload = RollDicePayload(gameId = 1, diceCount = 2))
+        val result = diceService.rollDice(request, rollingPlayerId = 2)
 
         assertEquals(2, result.dice.size)
         assert(result.total in 2..12)
@@ -174,7 +189,7 @@ class DiceServiceTests {
         whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(defaultGame)
 
         val request = RollDiceRequest(gameId = 1, playerId = 2)
-        val result = diceService.rollDice(request)
+        val result = diceService.rollDice(request, rollingPlayerId = 2)
 
         verify(gameDao).updateAfterRoll(1, result.total, TurnPhase.RESOLVE_EFFECTS)
         assertEquals(true, result.completed)
@@ -186,7 +201,7 @@ class DiceServiceTests {
         whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(defaultGame)
 
         val request = RollDiceRequest(gameId = 1, playerId = 2)
-        val result = diceService.rollDice(request)
+        val result = diceService.rollDice(request, rollingPlayerId = 2)
 
         verify(gameDao).updateAfterRoll(any(), any(), org.mockito.kotlin.eq(TurnPhase.RESOLVE_EFFECTS))
     }
@@ -199,7 +214,7 @@ class DiceServiceTests {
         val request = RollDiceRequest(gameId = 1, playerId = 2)
 
         assertThrows(CustomWebSocketException::class.java) {
-            diceService.rollDice(request)
+            diceService.rollDice(request, rollingPlayerId = 2)
         }
         verify(gameDao, never()).updateAfterRoll(any(), any(), any())
     }

--- a/src/test/kotlin/org/machikoro/server/service/DiceServiceTests.kt
+++ b/src/test/kotlin/org/machikoro/server/service/DiceServiceTests.kt
@@ -18,6 +18,10 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 class DiceServiceTests {
 
@@ -85,8 +89,55 @@ class DiceServiceTests {
 
         val request = RollDiceRequest(gameId = 1, playerId = 2)
 
-        assertThrows(CustomWebSocketException::class.java) {
+        val ex = assertThrows(CustomWebSocketException::class.java) {
             diceService.rollDice(request)
+        }
+        assertEquals("ROLL_ALREADY_COMPLETED", ex.errorCode)
+    }
+
+    @Test
+    fun rollDiceShouldRejectDuplicateAfterCompletedRoll() {
+        whenever(gameStateGuard.ensureGameIsRunning(1))
+            .thenReturn(defaultGame)
+            .thenReturn(defaultGame.copy(turnPhase = TurnPhase.RESOLVE_EFFECTS, lastDiceRoll = 4))
+
+        val request = RollDiceRequest(gameId = 1, playerId = 2)
+        val first = diceService.rollDice(request)
+
+        assertEquals(true, first.completed)
+        assertEquals(TurnPhase.RESOLVE_EFFECTS, first.turnPhase)
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            diceService.rollDice(request)
+        }
+        assertEquals("ROLL_ALREADY_COMPLETED", ex.errorCode)
+    }
+
+    @Test
+    fun rollDiceShouldSerializeConcurrentRequestsForSameGame() {
+        val firstEntered = CountDownLatch(1)
+        val releaseFirst = CountDownLatch(1)
+        whenever(gameStateGuard.ensureGameIsRunning(1)).thenAnswer {
+            firstEntered.countDown()
+            releaseFirst.await(1, TimeUnit.SECONDS)
+            defaultGame
+        }.thenReturn(defaultGame.copy(turnPhase = TurnPhase.RESOLVE_EFFECTS, lastDiceRoll = 5))
+
+        val request = RollDiceRequest(gameId = 1, playerId = 2)
+        val executor = Executors.newFixedThreadPool(2)
+        try {
+            val first = executor.submit(Callable { diceService.rollDice(request) })
+            firstEntered.await(1, TimeUnit.SECONDS)
+            val second = executor.submit(Callable {
+                assertThrows(CustomWebSocketException::class.java) {
+                    diceService.rollDice(request)
+                }.errorCode
+            })
+            releaseFirst.countDown()
+
+            assertEquals(true, first.get(1, TimeUnit.SECONDS).completed)
+            assertEquals("ROLL_ALREADY_COMPLETED", second.get(1, TimeUnit.SECONDS))
+        } finally {
+            executor.shutdownNow()
         }
     }
 
@@ -126,6 +177,8 @@ class DiceServiceTests {
         val result = diceService.rollDice(request)
 
         verify(gameDao).updateAfterRoll(1, result.total, TurnPhase.RESOLVE_EFFECTS)
+        assertEquals(true, result.completed)
+        assertEquals(TurnPhase.RESOLVE_EFFECTS, result.turnPhase)
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/service/GameStateGuardTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GameStateGuardTest.kt
@@ -147,14 +147,15 @@ class GameStateGuardTest {
     @Test
     fun `ensureSenderIsActivePlayer succeeds when caller is the active player`() {
         val gameId = 1
+        val activePlayer = player(id = 10, userId = 7)
         whenever(gameDao.findById(gameId))
             .thenReturn(game(gameId, GameStatus.IN_PROGRESS, currentTurnIndex = 0))
         whenever(playerDao.getPlayers(gameId)).thenReturn(
-            listOf(player(id = 10, userId = 7), player(id = 11, userId = 8, turnOrder = 1)),
+            listOf(activePlayer, player(id = 11, userId = 8, turnOrder = 1)),
         )
         val user = UserPrincipal(userId = 7, username = "alice")
 
-        guard.ensureSenderIsActivePlayer(gameId, user)
+        assertSame(activePlayer, guard.ensureSenderIsActivePlayer(gameId, user))
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/service/GameSyncServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GameSyncServiceTest.kt
@@ -26,6 +26,7 @@ import org.machikoro.server.domain.models.LandmarkModel
 import org.machikoro.server.domain.models.PlayerCardModel
 import org.machikoro.server.domain.models.PlayerLandmarkModel
 import org.machikoro.server.domain.models.PlayerModel
+import org.machikoro.server.dto.ClientScreen
 import org.machikoro.server.dto.LobbyRosterPlayerDto
 import org.machikoro.server.exception.GameNotFoundException
 import org.mockito.kotlin.any
@@ -81,6 +82,49 @@ class GameSyncServiceTest {
         assertNull(service.findActiveInProgressGameId(8))
 
         verify(playerDao).findActiveGameIdByUserId(8)
+    }
+
+    @Test
+    fun `resolveSessionState returns MAIN when user has no current membership`() {
+        whenever(playerDao.findCurrentMembershipByUserId(8)).thenReturn(null)
+
+        val state = service.resolveSessionState(8)
+
+        assertEquals(ClientScreen.MAIN, state.screen)
+        assertNull(state.gameId)
+        assertNull(state.playerId)
+    }
+
+    @Test
+    fun `resolveSessionState returns LOBBY for waiting lobby membership`() {
+        val player = PlayerModel(id = 15, gameId = 22, userId = 8, turnOrder = 0, coins = 3, lastSeenAt = null)
+        whenever(playerDao.findCurrentMembershipByUserId(8)).thenReturn(
+            PlayerDao.PlayerGameMembership(player = player, game = game(22, GameStatus.WAITING))
+        )
+
+        val state = service.resolveSessionState(8)
+
+        assertEquals(ClientScreen.LOBBY, state.screen)
+        assertEquals(22, state.gameId)
+        assertEquals(15, state.playerId)
+        assertEquals("ABC1234", state.lobbyCode)
+        assertEquals(GameStatus.WAITING, state.gameStatus)
+        assertEquals(TurnPhase.ROLL_DICE, state.turnPhase)
+    }
+
+    @Test
+    fun `resolveSessionState returns GAME for in-progress game membership`() {
+        val player = PlayerModel(id = 16, gameId = 23, userId = 9, turnOrder = 1, coins = 3, lastSeenAt = null)
+        whenever(playerDao.findCurrentMembershipByUserId(9)).thenReturn(
+            PlayerDao.PlayerGameMembership(player = player, game = game(23, GameStatus.IN_PROGRESS))
+        )
+
+        val state = service.resolveSessionState(9)
+
+        assertEquals(ClientScreen.GAME, state.screen)
+        assertEquals(23, state.gameId)
+        assertEquals(16, state.playerId)
+        assertEquals(GameStatus.IN_PROGRESS, state.gameStatus)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add server-resolved session state to login responses so clients can distinguish main, lobby, and game screens from valid current memberships.
- Resolve reconnect membership by preferring in-progress games, falling back to waiting lobbies, and ignoring finished games.
- Serialize dice rolls per game, reject duplicate completed rolls predictably, and broadcast stable completed roll payloads.
- Derive the rolling player from the authenticated active turn instead of trusting client-supplied player IDs.
- Accept the current client legacy wrapped dice payload, payload.diceCount, for backward-compatible roll requests.
- Unblocks https://github.com/SE2-Machi-Koro/Client/issues/175

## Tests
- ./gradlew test --tests org.machikoro.server.service.DiceServiceTests --tests org.machikoro.server.controller.GameControllerTest --tests org.machikoro.server.controller.AuthControllerTests --tests org.machikoro.server.service.GameSyncServiceTest --tests org.machikoro.server.service.GameStateGuardTest --tests org.machikoro.server.dto.RollDiceRequestTests

## Client compatibility
- The current Client checkout ignores the new login sessionState field safely because its auth JSON parser uses ignoreUnknownKeys = true.
- The dice endpoint remains compatible with the current Client payload shape while keeping server-side player ownership authoritative.