### PR TITLE
292 fix broadcast full game state snapshots after every state changing websocket action

### DIFF
--- a/src/main/kotlin/org/machikoro/server/controller/EarningsController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/EarningsController.kt
@@ -7,6 +7,7 @@ import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.ResolveEffectsRequest
 import org.machikoro.server.dto.WebSocketMessage
 import org.machikoro.server.service.GameStateGuard
+import org.machikoro.server.service.GameSyncService
 import org.machikoro.server.service.interfaces.EarningsService
 import org.slf4j.LoggerFactory
 import org.springframework.messaging.handler.annotation.MessageMapping
@@ -23,6 +24,7 @@ class EarningsController(
     private val earningsService: EarningsService,
     private val messagingTemplate: SimpMessagingTemplate,
     private val gameStateGuard: GameStateGuard,
+    private val gameSyncService: GameSyncService,
 ) {
     private val logger = LoggerFactory.getLogger(EarningsController::class.java)
 
@@ -42,13 +44,21 @@ class EarningsController(
         val gameTopic = "/topic/game/${request.gameId}"
         try {
             earningsService.resolveEffects(request.gameId)
+            val state = gameSyncService.buildSnapshot(request.gameId)
             logger.info("Resolved effects for game ${request.gameId}")
             messagingTemplate.convertAndSend(
                 gameTopic,
                 WebSocketMessage(
                     type = MessageType.GAME_ACTION,
                     sender = "server",
-                    payload = mapOf("event" to "EFFECTS_RESOLVED", "gameId" to request.gameId)
+                    payload = mapOf(
+                        "event" to "EFFECTS_RESOLVED",
+                        "gameId" to request.gameId,
+                        "turnPhase" to state.game.turnPhase.name,
+                        "activePlayerId" to state.activePlayerId,
+                        "state" to state,
+                    ),
+                    gameId = request.gameId,
                 )
             )
         } catch (e: Exception) {

--- a/src/main/kotlin/org/machikoro/server/controller/GameController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/GameController.kt
@@ -1,8 +1,6 @@
 package org.machikoro.server.controller
 
 import org.machikoro.server.auth.requireUserPrincipal
-import org.machikoro.server.dao.PlayerDao
-import org.machikoro.server.domain.enums.TurnPhase
 import org.machikoro.server.dto.EndTurnOutcome
 import org.machikoro.server.dto.AdvancePhaseRequest
 import org.machikoro.server.dto.EndTurnRequest
@@ -38,7 +36,6 @@ class GameController(
     private val lobbyService: LobbyService,
     private val connectionTracker: WebSocketConnectionTracker,
     private val gameStateGuard: GameStateGuard,
-    private val playerDao: PlayerDao,
     private val gameSyncService: GameSyncService,
 ) {
     private val logger = LoggerFactory.getLogger(GameController::class.java)
@@ -104,17 +101,17 @@ class GameController(
                 )
             )
 
-            // Immediately broadcast a GAME_ACTION so clients that only parse
-            // activePlayerId from GAME_ACTION frames know whose turn it is
-            // without waiting for the first advancePhase or endTurn call.
+            // Immediately broadcast a GAME_ACTION so clients that parse turn
+            // metadata from GAME_ACTION frames know whose turn it is without
+            // waiting for the first advancePhase or endTurn call.
             messagingTemplate.convertAndSend(
                 gameTopic,
                 WebSocketMessage(
                     type = MessageType.GAME_ACTION,
                     sender = "server",
-                    payload = mapOf(
-                        "turnPhase" to gameState.game.turnPhase.name,
-                        "activePlayerId" to gameState.activePlayerId,
+                    payload = buildGameActionPayload(
+                        state = gameState,
+                        event = "GAME_STARTED",
                     ),
                 )
             )
@@ -147,7 +144,7 @@ class GameController(
         requireActivePlayer(request.gameId, headerAccessor)
         val newPhase = gamePhaseService.advancePhase(request.gameId)
         logger.info("Advanced phase for game ${request.gameId} to $newPhase")
-        broadcastPhase(request.gameId, newPhase)
+        broadcastPhase(request.gameId, "PHASE_ADVANCED")
     }
 
     /**
@@ -190,7 +187,7 @@ class GameController(
         when (val result = gamePhaseService.endTurn(request.gameId)) {
             is EndTurnOutcome.Continue -> {
                 logger.info("Ended turn for game ${request.gameId}, new phase ${result.nextPhase}")
-                broadcastPhase(request.gameId, result.nextPhase)
+                broadcastPhase(request.gameId, "TURN_ENDED")
             }
             is EndTurnOutcome.Won -> {
                 logger.info("Game ${request.gameId} finished, winner=${result.winnerId}")
@@ -228,8 +225,10 @@ class GameController(
                     payload = mapOf(
                         "playerId" to request.playerId,
                         "result" to result.dice,
-                        "timestamp" to System.currentTimeMillis()
-                    )
+                        "timestamp" to System.currentTimeMillis(),
+                        "state" to gameSyncService.buildSnapshot(request.gameId),
+                    ),
+                    gameId = request.gameId,
                 )
             )
         } catch (e: Exception) {
@@ -250,30 +249,27 @@ class GameController(
      * subscribers of the game topic. The [activePlayerId] identifies the user
      * whose turn it is so clients can compare it against their own user ID.
      */
-    private fun broadcastPhase(gameId: Int, newPhase: TurnPhase) {
-        val game = gameStateGuard.ensureGameIsRunning(gameId)
-        val players = playerDao.getPlayers(gameId)
-        val activePlayerId = players.getOrNull(game.currentTurnIndex)?.userId
-
+    private fun broadcastPhase(gameId: Int, event: String) {
+        val state = gameSyncService.buildSnapshot(gameId)
         messagingTemplate.convertAndSend(
             "/topic/game/$gameId",
             WebSocketMessage(
                 type = MessageType.GAME_ACTION,
                 sender = "server",
-                payload = mapOf(
-                    "turnPhase" to newPhase.name,
-                    "activePlayerId" to activePlayerId,
+                payload = buildGameActionPayload(
+                    state = state,
+                    event = event,
                 ),
+                gameId = gameId,
             ),
         )
     }
 
     private fun broadcastPurchase(gameId: Int, result: PurchaseResult) {
-        val payload = linkedMapOf<String, Any?>(
-            "event" to "PURCHASE_COMPLETED",
-            "turnPhase" to result.turnPhase.name,
+        val payload = buildGameActionPayload(
+            state = gameSyncService.buildSnapshot(gameId),
+            event = "PURCHASE_COMPLETED",
             "purchaseType" to result.purchaseType.name,
-            "state" to gameSyncService.buildSnapshot(gameId),
         )
         result.cardType?.let { payload["cardType"] = it.name }
         result.landmarkType?.let { payload["landmarkType"] = it.name }
@@ -283,11 +279,13 @@ class GameController(
                 type = MessageType.GAME_ACTION,
                 sender = "server",
                 payload = payload,
+                gameId = gameId,
             ),
         )
     }
 
     private fun broadcastWin(gameId: Int, winnerId: Int, roundsPlayed: Int) {
+        val state = gameSyncService.buildSnapshot(gameId)
         messagingTemplate.convertAndSend(
             "/topic/game/$gameId",
             WebSocketMessage(
@@ -296,10 +294,26 @@ class GameController(
                 payload = mapOf(
                     "winnerId" to winnerId,
                     "roundsPlayed" to roundsPlayed,
+                    "state" to state,
                 ),
+                gameId = gameId,
             ),
         )
     }
+
+    private fun buildGameActionPayload(
+        state: GameStateDto,
+        event: String,
+        vararg entries: Pair<String, Any?>,
+    ): LinkedHashMap<String, Any?> =
+        linkedMapOf<String, Any?>(
+            "event" to event,
+            "turnPhase" to state.game.turnPhase.name,
+            "activePlayerId" to state.activePlayerId,
+            "state" to state,
+        ).apply {
+            entries.forEach { (key, value) -> this[key] = value }
+        }
 
     /**
      * Resolve the authenticated user from the STOMP session and assert they

--- a/src/main/kotlin/org/machikoro/server/controller/GameController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/GameController.kt
@@ -216,6 +216,7 @@ class GameController(
         logger.info("Roll dice request from player ${request.playerId} in game ${request.gameId}")
         try {
             val result = diceService.rollDice(request)
+            val state = gameSyncService.buildSnapshot(request.gameId)
             messagingTemplate.convertAndSend(
                 gameTopic,
                 WebSocketMessage(
@@ -223,10 +224,13 @@ class GameController(
                     sender = "SERVER",
                     content = "Player ${request.playerId} rolled: ${result.total}",
                     payload = mapOf(
+                        "event" to "DICE_ROLLED",
+                        "turnPhase" to state.game.turnPhase.name,
+                        "activePlayerId" to state.activePlayerId,
                         "playerId" to request.playerId,
                         "result" to result.dice,
                         "timestamp" to System.currentTimeMillis(),
-                        "state" to gameSyncService.buildSnapshot(request.gameId),
+                        "state" to state,
                     ),
                     gameId = request.gameId,
                 )
@@ -323,9 +327,5 @@ class GameController(
      */
     private fun requireActivePlayer(gameId: Int, headerAccessor: SimpMessageHeaderAccessor) {
         gameStateGuard.ensureSenderIsActivePlayer(gameId, headerAccessor.requireUserPrincipal())
-    }
-
-    private fun requireOwnerOfPlayer(gameId: Int, playerId: Int, headerAccessor: SimpMessageHeaderAccessor) {
-        gameStateGuard.ensureSenderOwnsPlayer(gameId, playerId, headerAccessor.requireUserPrincipal())
     }
 }

--- a/src/main/kotlin/org/machikoro/server/controller/GameController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/GameController.kt
@@ -114,6 +114,7 @@ class GameController(
                         state = gameState,
                         event = "GAME_STARTED",
                     ),
+                    gameId = request.gameId,
                 )
             )
         } catch (e: Exception) {
@@ -234,6 +235,22 @@ class GameController(
                         "completed" to result.completed,
                         "timestamp" to System.currentTimeMillis(),
                         "state" to state,
+                    ),
+                    gameId = request.gameId,
+                )
+            )
+            messagingTemplate.convertAndSend(
+                gameTopic,
+                WebSocketMessage(
+                    type = MessageType.GAME_ACTION,
+                    sender = "server",
+                    payload = buildGameActionPayload(
+                        state = state,
+                        event = "DICE_ROLLED",
+                        "playerId" to rollingPlayer.id,
+                        "result" to result.dice,
+                        "total" to result.total,
+                        "completed" to result.completed,
                     ),
                     gameId = request.gameId,
                 )

--- a/src/test/kotlin/org/machikoro/server/controller/EarningsControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/EarningsControllerTest.kt
@@ -3,12 +3,18 @@ package org.machikoro.server.controller
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.machikoro.server.auth.UserPrincipal
+import org.machikoro.server.domain.enums.GameStatus
+import org.machikoro.server.domain.enums.TurnPhase
+import org.machikoro.server.domain.models.GameModel
+import org.machikoro.server.domain.models.PlayerModel
+import org.machikoro.server.dto.GameStateDto
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.ResolveEffectsRequest
 import org.machikoro.server.dto.WebSocketMessage
 import org.machikoro.server.exception.CustomWebSocketException
 import org.machikoro.server.exception.GameNotFoundException
 import org.machikoro.server.service.GameStateGuard
+import org.machikoro.server.service.GameSyncService
 import org.machikoro.server.service.interfaces.EarningsService
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
@@ -27,16 +33,42 @@ class EarningsControllerTest {
     private val earningsService: EarningsService = mock()
     private val messagingTemplate: SimpMessagingTemplate = mock()
     private val gameStateGuard: GameStateGuard = mock()
-    private val controller = EarningsController(earningsService, messagingTemplate, gameStateGuard)
+    private val gameSyncService: GameSyncService = mock()
+    private val controller = EarningsController(earningsService, messagingTemplate, gameStateGuard, gameSyncService)
 
     private val alice = UserPrincipal(userId = 1, username = "alice")
 
     private fun authedAccessor(): SimpMessageHeaderAccessor =
         SimpMessageHeaderAccessor.create().apply { user = alice }
 
+    private fun gameStateDto(gameId: Int) = GameStateDto(
+        game = GameModel(
+            id = gameId,
+            status = GameStatus.IN_PROGRESS,
+            hostUserId = 1,
+            lobbyCode = "ABC123",
+            maxPlayers = 4,
+            currentTurnIndex = 0,
+            turnPhase = TurnPhase.BUY_OR_BUILD,
+            lastDiceRoll = 6,
+            hasPurchasedThisTurn = false,
+            roundNumber = 1,
+        ),
+        players = listOf(
+            PlayerModel(id = 1, gameId = gameId, userId = 1, turnOrder = 0, coins = 5, lastSeenAt = null),
+        ),
+        playerCards = emptyMap(),
+        playerLandmarks = emptyMap(),
+        marketplace = emptyMap(),
+        turnOrder = listOf(1),
+        activePlayerId = 1,
+    )
+
     @Test
     fun `resolveEffects calls service and broadcasts success`() {
         val request = ResolveEffectsRequest(gameId = 1)
+        val snapshot = gameStateDto(1)
+        whenever(gameSyncService.buildSnapshot(1)).thenReturn(snapshot)
 
         controller.resolveEffects(request, authedAccessor())
 
@@ -49,8 +81,13 @@ class EarningsControllerTest {
         val message = captor.firstValue
         assertEquals(MessageType.GAME_ACTION, message.type)
         assertEquals("server", message.sender)
-        assertEquals("EFFECTS_RESOLVED", (message.payload as Map<*, *>)["event"])
-        assertEquals(1, (message.payload as Map<*, *>)["gameId"])
+        assertEquals(1, message.gameId)
+        val payload = message.payload as Map<*, *>
+        assertEquals("EFFECTS_RESOLVED", payload["event"])
+        assertEquals(1, payload["gameId"])
+        assertEquals("BUY_OR_BUILD", payload["turnPhase"])
+        assertEquals(1, payload["activePlayerId"])
+        assertEquals(snapshot, payload["state"])
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
@@ -369,6 +369,9 @@ class GameControllerTest {
 
         @Suppress("UNCHECKED_CAST")
         val payload = message.payload as Map<String, Any?>
+        assertEquals("DICE_ROLLED", payload["event"])
+        assertEquals("ROLL_DICE", payload["turnPhase"])
+        assertEquals(1, payload["activePlayerId"])
         assertEquals(playerId, payload["playerId"])
         assertEquals(listOf(3, 4), payload["result"])
         assert(payload["timestamp"] is Long)

--- a/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.machikoro.server.auth.UserPrincipal
-import org.machikoro.server.dao.PlayerDao
 import org.machikoro.server.domain.enums.CardType
 import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.enums.LandmarkType
@@ -52,12 +51,11 @@ class GameControllerTest {
     private val lobbyService = mock<LobbyService>()
     private val connectionTracker = mock<WebSocketConnectionTracker>()
     private val gameStateGuard = mock<GameStateGuard>()
-    private val playerDao = mock<PlayerDao>()
     private val gameSyncService = mock<GameSyncService>()
     private val controller = GameController(
         gamePhaseService, messagingTemplate,
         purchaseService, diceService, lobbyService, connectionTracker,
-        gameStateGuard, playerDao, gameSyncService,
+        gameStateGuard, gameSyncService,
     )
 
     private val alice = UserPrincipal(userId = 1, username = "alice")
@@ -69,16 +67,15 @@ class GameControllerTest {
         hasPurchasedThisTurn = false, roundNumber = 1,
     )
 
-    private val defaultPlayers = listOf(
-        PlayerModel(id = 1, gameId = 1, userId = 10, turnOrder = 0, coins = 3, lastSeenAt = null),
-        PlayerModel(id = 2, gameId = 1, userId = 20, turnOrder = 1, coins = 3, lastSeenAt = null),
-    )
-
     private fun authedAccessor(): SimpMessageHeaderAccessor =
         SimpMessageHeaderAccessor.create().apply { user = alice }
 
-    private fun gameStateDto(gameId: Int) = GameStateDto(
-        game = defaultGame.copy(id = gameId),
+    private fun gameStateDto(
+        gameId: Int,
+        turnPhase: TurnPhase = defaultGame.turnPhase,
+        activePlayerId: Int? = 1,
+    ) = GameStateDto(
+        game = defaultGame.copy(id = gameId, turnPhase = turnPhase),
         players = listOf(
             PlayerModel(id = 1, gameId = gameId, userId = 1, turnOrder = 0, coins = 3, lastSeenAt = null),
             PlayerModel(id = 2, gameId = gameId, userId = 2, turnOrder = 1, coins = 3, lastSeenAt = null),
@@ -87,7 +84,7 @@ class GameControllerTest {
         playerLandmarks = emptyMap(),
         marketplace = emptyMap(),
         turnOrder = listOf(1, 2),
-        activePlayerId = 1,
+        activePlayerId = activePlayerId,
     )
 
     private fun headerWithSession(sessionId: String): SimpMessageHeaderAccessor {
@@ -103,8 +100,9 @@ class GameControllerTest {
     fun `startGame broadcasts GAME_STARTED on success`() {
         val gameId = 10
         val sessionId = "session-host"
+        val snapshot = gameStateDto(gameId)
         whenever(connectionTracker.getUserId(sessionId)).thenReturn(1)
-        whenever(lobbyService.startGame(gameId, 1)).thenReturn(gameStateDto(gameId))
+        whenever(lobbyService.startGame(gameId, 1)).thenReturn(snapshot)
 
         controller.startGame(StartGameRequest(gameId), headerWithSession(sessionId))
 
@@ -121,8 +119,10 @@ class GameControllerTest {
         assertEquals(MessageType.GAME_ACTION, phaseMessage.type)
         @Suppress("UNCHECKED_CAST")
         val payload = phaseMessage.payload as Map<String, Any?>
+        assertEquals("GAME_STARTED", payload["event"])
         assertEquals("ROLL_DICE", payload["turnPhase"])
         assertEquals(1, payload["activePlayerId"])
+        assertEquals(snapshot, payload["state"])
     }
 
     @Test
@@ -166,9 +166,9 @@ class GameControllerTest {
     @Test
     fun `advancePhase delegates to service with the requested game id`() {
         val gameId = 42
+        val snapshot = gameStateDto(gameId, turnPhase = TurnPhase.RESOLVE_EFFECTS)
         whenever(gamePhaseService.advancePhase(gameId)).thenReturn(TurnPhase.RESOLVE_EFFECTS)
-        whenever(gameStateGuard.ensureGameIsRunning(gameId)).thenReturn(defaultGame.copy(id = gameId))
-        whenever(playerDao.getPlayers(gameId)).thenReturn(defaultPlayers)
+        whenever(gameSyncService.buildSnapshot(gameId)).thenReturn(snapshot)
 
         controller.advancePhase(AdvancePhaseRequest(gameId), authedAccessor())
 
@@ -179,9 +179,9 @@ class GameControllerTest {
     @Test
     fun `advancePhase broadcasts new phase and activePlayerId as GAME_ACTION`() {
         val gameId = 42
+        val snapshot = gameStateDto(gameId, turnPhase = TurnPhase.RESOLVE_EFFECTS)
         whenever(gamePhaseService.advancePhase(gameId)).thenReturn(TurnPhase.RESOLVE_EFFECTS)
-        whenever(gameStateGuard.ensureGameIsRunning(gameId)).thenReturn(defaultGame.copy(id = gameId))
-        whenever(playerDao.getPlayers(gameId)).thenReturn(defaultPlayers)
+        whenever(gameSyncService.buildSnapshot(gameId)).thenReturn(snapshot)
 
         controller.advancePhase(AdvancePhaseRequest(gameId), authedAccessor())
 
@@ -193,8 +193,10 @@ class GameControllerTest {
         assertEquals("server", message.sender)
         @Suppress("UNCHECKED_CAST")
         val payload = message.payload as Map<String, Any?>
+        assertEquals("PHASE_ADVANCED", payload["event"])
         assertEquals("RESOLVE_EFFECTS", payload["turnPhase"])
-        assertEquals(10, payload["activePlayerId"])
+        assertEquals(1, payload["activePlayerId"])
+        assertEquals(snapshot, payload["state"])
     }
 
     @Test
@@ -216,9 +218,9 @@ class GameControllerTest {
     @Test
     fun `endTurn delegates to service with the requested game id`() {
         val gameId = 42
+        val snapshot = gameStateDto(gameId, turnPhase = TurnPhase.ROLL_DICE)
         whenever(gamePhaseService.endTurn(gameId)).thenReturn(EndTurnOutcome.Continue(TurnPhase.ROLL_DICE))
-        whenever(gameStateGuard.ensureGameIsRunning(gameId)).thenReturn(defaultGame.copy(id = gameId))
-        whenever(playerDao.getPlayers(gameId)).thenReturn(defaultPlayers)
+        whenever(gameSyncService.buildSnapshot(gameId)).thenReturn(snapshot)
 
         controller.endTurn(EndTurnRequest(gameId), authedAccessor())
 
@@ -229,9 +231,9 @@ class GameControllerTest {
     @Test
     fun `endTurn broadcasts resulting phase and activePlayerId as GAME_ACTION`() {
         val gameId = 42
+        val snapshot = gameStateDto(gameId, turnPhase = TurnPhase.ROLL_DICE)
         whenever(gamePhaseService.endTurn(gameId)).thenReturn(EndTurnOutcome.Continue(TurnPhase.ROLL_DICE))
-        whenever(gameStateGuard.ensureGameIsRunning(gameId)).thenReturn(defaultGame.copy(id = gameId))
-        whenever(playerDao.getPlayers(gameId)).thenReturn(defaultPlayers)
+        whenever(gameSyncService.buildSnapshot(gameId)).thenReturn(snapshot)
 
         controller.endTurn(EndTurnRequest(gameId), authedAccessor())
 
@@ -242,8 +244,10 @@ class GameControllerTest {
         assertEquals(MessageType.GAME_ACTION, message.type)
         @Suppress("UNCHECKED_CAST")
         val payload = message.payload as Map<String, Any?>
+        assertEquals("TURN_ENDED", payload["event"])
         assertEquals("ROLL_DICE", payload["turnPhase"])
-        assertEquals(10, payload["activePlayerId"])
+        assertEquals(1, payload["activePlayerId"])
+        assertEquals(snapshot, payload["state"])
     }
 
     @Test
@@ -251,7 +255,9 @@ class GameControllerTest {
         val gameId = 42
         val winnerId = 1
         val roundsPlayed = 10
+        val snapshot = gameStateDto(gameId)
         whenever(gamePhaseService.endTurn(gameId)).thenReturn(EndTurnOutcome.Won(winnerId, roundsPlayed))
+        whenever(gameSyncService.buildSnapshot(gameId)).thenReturn(snapshot)
 
         controller.endTurn(EndTurnRequest(gameId), authedAccessor())
 
@@ -261,7 +267,12 @@ class GameControllerTest {
 
         val message = captor.firstValue
         assertEquals(MessageType.GAME_END, message.type)
-        assertEquals(mapOf("winnerId" to winnerId, "roundsPlayed" to roundsPlayed), message.payload)
+        assertEquals(gameId, message.gameId)
+        @Suppress("UNCHECKED_CAST")
+        val payload = message.payload as Map<String, Any?>
+        assertEquals(winnerId, payload["winnerId"])
+        assertEquals(roundsPlayed, payload["roundsPlayed"])
+        assertEquals(snapshot, payload["state"])
     }
 
     @Test
@@ -283,7 +294,7 @@ class GameControllerTest {
     @Test
     fun `purchase delegates to service with the requested payload`() {
         val gameId = 42
-        val snapshot = gameStateDto(gameId)
+        val snapshot = gameStateDto(gameId, turnPhase = TurnPhase.BUY_OR_BUILD)
         whenever(purchaseService.purchase(gameId, PurchaseType.ESTABLISHMENT, CardType.BAKERY, null))
             .thenReturn(PurchaseResult(turnPhase = TurnPhase.BUY_OR_BUILD, purchaseType = PurchaseType.ESTABLISHMENT, cardType = CardType.BAKERY))
         whenever(gameSyncService.buildSnapshot(gameId)).thenReturn(snapshot)
@@ -297,7 +308,7 @@ class GameControllerTest {
     @Test
     fun `purchase broadcasts resulting purchase payload as GAME_ACTION on game topic`() {
         val gameId = 42
-        val snapshot = gameStateDto(gameId)
+        val snapshot = gameStateDto(gameId, turnPhase = TurnPhase.BUY_OR_BUILD)
         whenever(purchaseService.purchase(gameId, PurchaseType.LANDMARK, null, LandmarkType.TRAIN_STATION))
             .thenReturn(PurchaseResult(turnPhase = TurnPhase.BUY_OR_BUILD, purchaseType = PurchaseType.LANDMARK, landmarkType = LandmarkType.TRAIN_STATION))
         whenever(gameSyncService.buildSnapshot(gameId)).thenReturn(snapshot)
@@ -316,6 +327,7 @@ class GameControllerTest {
         assertEquals("LANDMARK", payload["purchaseType"])
         assertEquals("TRAIN_STATION", payload["landmarkType"])
         assertEquals(snapshot, payload["state"])
+        assertEquals(gameId, message.gameId)
     }
 
     @Test
@@ -340,7 +352,9 @@ class GameControllerTest {
         val playerId = 2
         val request = RollDiceRequest(gameId = gameId, playerId = playerId)
         val response = RollDiceResponse(dice = listOf(3, 4), total = 7)
+        val snapshot = gameStateDto(gameId)
         whenever(diceService.rollDice(request)).thenReturn(response)
+        whenever(gameSyncService.buildSnapshot(gameId)).thenReturn(snapshot)
 
         controller.rollDice(request, authedAccessor())
 
@@ -358,6 +372,8 @@ class GameControllerTest {
         assertEquals(playerId, payload["playerId"])
         assertEquals(listOf(3, 4), payload["result"])
         assert(payload["timestamp"] is Long)
+        assertEquals(snapshot, payload["state"])
+        assertEquals(gameId, message.gameId)
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
@@ -123,6 +123,7 @@ class GameControllerTest {
         assertEquals("ROLL_DICE", payload["turnPhase"])
         assertEquals(1, payload["activePlayerId"])
         assertEquals(snapshot, payload["state"])
+        assertEquals(gameId, phaseMessage.gameId)
     }
 
     @Test
@@ -361,7 +362,7 @@ class GameControllerTest {
 
         verify(gameStateGuard).ensureSenderIsActivePlayer(gameId, alice)
         val captor = argumentCaptor<WebSocketMessage>()
-        verify(messagingTemplate).convertAndSend(eq("/topic/game/$gameId"), captor.capture())
+        verify(messagingTemplate, times(2)).convertAndSend(eq("/topic/game/$gameId"), captor.capture())
 
         val message = captor.firstValue
         assertEquals(MessageType.ROLL_DICE, message.type)
@@ -380,6 +381,21 @@ class GameControllerTest {
         assert(payload["timestamp"] is Long)
         assertEquals(snapshot, payload["state"])
         assertEquals(gameId, message.gameId)
+
+        val actionMessage = captor.secondValue
+        assertEquals(MessageType.GAME_ACTION, actionMessage.type)
+        assertEquals("server", actionMessage.sender)
+        assertEquals(gameId, actionMessage.gameId)
+        @Suppress("UNCHECKED_CAST")
+        val actionPayload = actionMessage.payload as Map<String, Any?>
+        assertEquals("DICE_ROLLED", actionPayload["event"])
+        assertEquals("RESOLVE_EFFECTS", actionPayload["turnPhase"])
+        assertEquals(1, actionPayload["activePlayerId"])
+        assertEquals(activePlayer.id, actionPayload["playerId"])
+        assertEquals(listOf(3, 4), actionPayload["result"])
+        assertEquals(7, actionPayload["total"])
+        assertEquals(true, actionPayload["completed"])
+        assertEquals(snapshot, actionPayload["state"])
         verify(diceService).rollDice(request, activePlayer.id)
         verify(gameStateGuard, never()).ensureSenderOwnsPlayer(any(), any(), any())
     }


### PR DESCRIPTION
## Summary

This PR updates the game WebSocket broadcast flow so clients receive a complete, synchronized game state snapshot after every state-changing game action.

The affected actions now include turn metadata and the full `GameStateDto` in their broadcast payloads, allowing the client to update board state, active player state, phase state, and end-game state from a single authoritative server message.

## Changes

- Adds full game state snapshots to `GAME_ACTION` broadcasts after:
  - game start
  - phase advancement
  - turn end
  - purchase completion
  - effects resolution
  - dice roll completion
- Adds the final game state snapshot to `GAME_END` broadcasts.
- Standardizes game action payloads with:
  - `event`
  - `turnPhase`
  - `activePlayerId`
  - `state`
- Ensures dice roll broadcasts include:
  - server-resolved `playerId`
  - dice result
  - total roll value
  - completion status
  - updated turn phase
  - synchronized game state
- Removes controller-level player lookup logic from phase broadcasts and relies on `GameSyncService` as the authoritative source for client-facing state.
- Extends controller tests to verify the new broadcast payload structure and game state snapshots.

## Verification
- Manual: verified that WebSocket game action broadcasts include the updated `turnPhase`, `activePlayerId`, and full `state` payload needed by the client after state-changing actions.

## Related

Unblocks SE2-Machi-Koro/Client#177