### PR TITLE
306 lobby leave host leaves lobby

### DIFF
--- a/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
@@ -3,6 +3,7 @@ package org.machikoro.server.controller
 import io.github.springwolf.core.asyncapi.annotations.AsyncListener
 import io.github.springwolf.core.asyncapi.annotations.AsyncOperation
 import org.machikoro.server.auth.userPrincipal
+import org.machikoro.server.dto.LobbyLeavingOutcome
 import org.machikoro.server.dto.LobbyRosterDto
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.WebSocketMessage
@@ -182,10 +183,22 @@ class LobbyWebSocketController(
     /**
      * Handles a player leaving a lobby via WebSocket.
      *
-     * Client sends a message to /app/lobby.leave with the gameId in the payload.
-     * The player is removed from the lobby roster. If the lobby becomes empty, the
-     * game record is deleted. Otherwise LOBBY_LEFT is broadcast to the remaining
-     * members so they can update the player list.
+     * Client sends a message to `/app/lobby.leave` with the `gameId`
+     * in the payload.
+     *
+     * The authenticated player is removed from the lobby. If the lobby
+     * still contains real players, a `LOBBY_LEFT` event is broadcast to
+     * `/topic/game/{gameId}` so remaining members can update screen.
+     *
+     * If no real players remain (debug/dummy players do not count), the
+     * lobby is deleted and a `HOST_LEFT` event is broadcast so clients
+     * can close the lobby UI.
+     *
+     * Authentication is derived from the WebSocket principal; the sender
+     * field in [WebSocketMessage] is ignored to prevent spoofing.
+     *
+     * @throws CustomWebSocketException when authentication is missing,
+     * the payload is invalid, or `gameId` is absent.
      */
     @MessageMapping("/lobby.leave")
     @Suppress("UNUSED_PARAMETER")
@@ -214,32 +227,42 @@ class LobbyWebSocketController(
         logger.info("User '{}' leaving lobby {}", principal.username, gameId)
 
         val result = lobbyService.leaveLobby(gameId, principal.userId)
-        if (result == null) {
-            logger.warn("leaveLobby: user '{}' is not in game {}", principal.username, gameId)
-            return
-        }
 
-        if (!result.gameDeleted) {
-            // Notify remaining players so they can remove the leaver from the UI
-            messagingTemplate.convertAndSend(
-                "/topic/game/$gameId",
-                WebSocketMessage(
-                    type = MessageType.LOBBY_LEFT,
-                    sender = "SERVER",
-                    content = "Player left lobby",
-                    gameId = gameId,
-                    payload = mapOf(
-                        "playerId" to result.playerId,
-                        "userId" to principal.userId,
-                        "username" to principal.username,
+        when(result) {
+            is LobbyLeavingOutcome.LobbyRemains -> {
+                logger.info(
+                    "Player ${principal.userId} left game"
+                )
+                messagingTemplate.convertAndSend(
+                    "/topic/game/$gameId",
+                    WebSocketMessage(
+                        type = MessageType.LOBBY_LEFT,
+                        sender = "SERVER",
+                        content = "Player left lobby",
+                        gameId = gameId,
+                        payload = mapOf(
+                            "userId" to principal.userId,
+                        )
                     )
                 )
-            )
+            }
+            is LobbyLeavingOutcome.LobbyDeleted -> {
+                logger.info(
+                    "Host ${principal.userId} left game, gameDeleted= $gameId"
+                )
+                messagingTemplate.convertAndSend(
+                    "/topic/game/$gameId",
+                    WebSocketMessage(
+                        type = MessageType.HOST_LEFT,
+                        sender = "SERVER",
+                        content = "Host left lobby",
+                        gameId = gameId,
+                        payload = mapOf(
+                            "userId" to principal.userId
+                        )
+                    )
+                )
+            }
         }
-        // If game was deleted there are no remaining subscribers to notify
-        logger.info(
-            "User '{}' left lobby {} — gameDeleted={}",
-            principal.username, gameId, result.gameDeleted
-        )
     }
 }

--- a/src/main/kotlin/org/machikoro/server/dto/ChatMessage.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/ChatMessage.kt
@@ -17,7 +17,6 @@ enum class MessageType {
     GAME_ACTION,
     GAME_END,
     LOBBY_LEFT,
-    PLAYER_LEFT_FINISHED_GAME,
     ERROR,
     ROLL_DICE,
 }

--- a/src/main/kotlin/org/machikoro/server/dto/ChatMessage.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/ChatMessage.kt
@@ -9,6 +9,7 @@ enum class MessageType {
     LEAVE,
     LOBBY_CREATED,
     LOBBY_JOINED,
+    HOST_LEFT,
     LOBBY_ROSTER,
     GAME_START,
     GAME_STARTED,

--- a/src/main/kotlin/org/machikoro/server/dto/LobbyLeavingOutcome.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/LobbyLeavingOutcome.kt
@@ -1,0 +1,24 @@
+package org.machikoro.server.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    description = "Result of leaving lobby",
+    oneOf = [LobbyLeavingOutcome.LobbyRemains::class, LobbyLeavingOutcome.LobbyDeleted::class]
+)
+sealed interface LobbyLeavingOutcome {
+
+    @Schema(description = "Normal player left the game, lobby remains for other players")
+    data class LobbyRemains(
+        @field:Schema(description = "ID of the game to notify player leaving", example = "2")
+        val gameId: Int,
+        @field:Schema(description = "ID of the user leaving", example = "12")
+        val userId: Int
+    ) : LobbyLeavingOutcome
+
+    @Schema(description = "Host left the game, lobby was deleted")
+    data class LobbyDeleted(
+        @field:Schema(description = "ID of the game to close lobby for", example = "1")
+        val gameId: Int
+    ) : LobbyLeavingOutcome
+}

--- a/src/main/kotlin/org/machikoro/server/dto/LobbyLeavingOutcome.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/LobbyLeavingOutcome.kt
@@ -10,8 +10,6 @@ sealed interface LobbyLeavingOutcome {
 
     @Schema(description = "Normal player left the game, lobby remains for other players")
     data class LobbyRemains(
-        @field:Schema(description = "ID of the game to notify player leaving", example = "2")
-        val gameId: Int,
         @field:Schema(description = "ID of the user leaving", example = "12")
         val userId: Int
     ) : LobbyLeavingOutcome

--- a/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
@@ -206,7 +206,7 @@ open class LobbyService(
             return@runInTransaction LobbyLeavingOutcome.LobbyDeleted(gameId)
         }
 
-        LobbyLeavingOutcome.LobbyRemains(gameId, userId)
+        LobbyLeavingOutcome.LobbyRemains(userId)
     }
 
 

--- a/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
@@ -12,6 +12,7 @@ import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.models.GameModel
 import org.machikoro.server.domain.models.PlayerModel
 import org.machikoro.server.dto.GameStateDto
+import org.machikoro.server.dto.LobbyLeavingOutcome
 import org.machikoro.server.dto.LobbyRosterPlayerDto
 import org.machikoro.server.dto.toDefinitionDto
 import org.machikoro.server.exception.GameFinishedException
@@ -20,6 +21,7 @@ import org.machikoro.server.exception.GameStartedException
 import org.machikoro.server.exception.LobbyFullException
 import org.machikoro.server.exception.NotEnoughPlayersException
 import org.machikoro.server.exception.NotHostException
+import org.machikoro.server.exception.PlayerNotFoundException
 import org.springframework.stereotype.Service
 import java.util.concurrent.ConcurrentHashMap
 
@@ -165,29 +167,47 @@ open class LobbyService(
     }
 
     /**
-     * Represents the result of a player leaving a lobby.
+     * Removes the given [userId] from the lobby of [gameId].
      *
-     * @property playerId The DB player ID of the player who left.
-     * @property gameDeleted True if the lobby was deleted because it is now empty.
+     * If the leaving player is the host, the lobby is deleted immediately.
+     *
+     * After a non-host player leaves, the lobby is automatically deleted when
+     * no real players remain. A real player is any player whose username does
+     * not start with [DEBUG_USER_PREFIX]. Debug users are treated as dummy
+     * fill-players and do not keep a lobby alive.
+     *
+     * @param gameId the game/lobby identifier
+     * @param userId the user leaving the lobby
+     *
+     * @return [LobbyLeavingOutcome.LobbyDeleted] if the lobby was deleted,
+     * [LobbyLeavingOutcome.HostPresent] if the host is still present and the
+     * lobby remains active.
+     *
+     * @throws PlayerNotFoundException if the user is not part of the lobby
+     * @throws GameNotFoundException if the game does not exist
      */
-    data class LeaveLobbyResult(val playerId: Int, val gameDeleted: Boolean)
-
-    /**
-     * Removes [userId] from the lobby [gameId] and deletes the game if no real players remain.
-     *
-     * "Real" means non-debug: any player whose username starts with [DEBUG_USER_PREFIX] is
-     * treated as a dummy and does not count toward keeping the lobby alive. This lets a real
-     * player leave a lobby that still has dummy fill-players and still have the game cleaned up.
-     *
-     * Returns null if the user was not a player in the given game.
-     * Returns [LeaveLobbyResult] with [LeaveLobbyResult.gameDeleted] = true when no real
-     * players remain and the game row (plus any leftover dummies) has been deleted.
-     */
-    fun leaveLobby(gameId: Int, userId: Int): LeaveLobbyResult? = runInTransaction {
+    fun leaveLobby(gameId: Int, userId: Int): LobbyLeavingOutcome = runInTransaction {
         val player = playerDao.findByGameIdAndUserId(gameId, userId)
-            ?: return@runInTransaction null
+            ?: throw PlayerNotFoundException("Player $userId not found in game $gameId")
 
-        playerDao.deleteByPlayerId(player.id)
+        val game = gameDao.findById(gameId)
+            ?: throw GameNotFoundException("Game $gameId not found")
+
+        val shouldDeleteLobby =
+            player.userId == game.hostUserId
+
+        if (!shouldDeleteLobby) {
+            playerDao.deleteByPlayerId(player.id)
+        }
+
+        if (shouldDeleteLobby || noRealPlayersRemain(gameId)) {
+            cleanUpLobby(gameId)
+
+            return@runInTransaction LobbyLeavingOutcome.LobbyDeleted(gameId)
+        }
+
+        LobbyLeavingOutcome.LobbyRemains(gameId, userId)
+    }
 
         val realPlayersRemain = playerDao.getLobbyRoster(gameId)
             .any { !it.username.startsWith(DEBUG_USER_PREFIX) }

--- a/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
@@ -209,18 +209,28 @@ open class LobbyService(
         LobbyLeavingOutcome.LobbyRemains(gameId, userId)
     }
 
-        val realPlayersRemain = playerDao.getLobbyRoster(gameId)
-            .any { !it.username.startsWith(DEBUG_USER_PREFIX) }
 
-        if (!realPlayersRemain) {
-            // Clean up leftover dummy players before dropping the game row (FK constraint)
-            playerDao.deleteByGameId(gameId)
-            gameDao.delete(gameId)
-            lobbyLocks.remove(gameId)
-            LeaveLobbyResult(playerId = player.id, gameDeleted = true)
-        } else {
-            LeaveLobbyResult(playerId = player.id, gameDeleted = false)
-        }
+    /**
+     * Returns `true` if no real players remain in the lobby.
+     *
+     * A real player is any player whose username does not start with
+     * [DEBUG_USER_PREFIX]. Debug users are treated as dummy players.
+     */
+    private fun noRealPlayersRemain(gameId: Int): Boolean {
+        return playerDao.getLobbyRoster(gameId)
+            .none { !it.username.startsWith(DEBUG_USER_PREFIX) }
+    }
+
+    /**
+     * Deletes the lobby and all associated players for the given [gameId].
+     *
+     * This removes all players, deletes the game row, and clears any
+     * in-memory synchronization state for the lobby.
+     */
+    private fun cleanUpLobby(gameId: Int) {
+        playerDao.deleteByGameId(gameId)
+        gameDao.delete(gameId)
+        lobbyLocks.remove(gameId)
     }
 
     /**

--- a/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
@@ -180,7 +180,7 @@ open class LobbyService(
      * @param userId the user leaving the lobby
      *
      * @return [LobbyLeavingOutcome.LobbyDeleted] if the lobby was deleted,
-     * [LobbyLeavingOutcome.HostPresent] if the host is still present and the
+     * [LobbyLeavingOutcome.LobbyRemains] if the host is still present and the
      * lobby remains active.
      *
      * @throws PlayerNotFoundException if the user is not part of the lobby

--- a/src/test/kotlin/org/machikoro/server/controller/LobbyWebSocketControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/LobbyWebSocketControllerTest.kt
@@ -390,7 +390,7 @@ class LobbyWebSocketControllerTest {
     fun `leaveLobby broadcasts LOBBY_LEFT to game topic when lobby persists`() {
         whenever(lobbyService.leaveLobby(1, 10))
             .thenReturn(
-                LobbyLeavingOutcome.LobbyRemains(1, 10)
+                LobbyLeavingOutcome.LobbyRemains( 10)
             )
 
         val accessor = authenticatedAccessor(

--- a/src/test/kotlin/org/machikoro/server/controller/LobbyWebSocketControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/LobbyWebSocketControllerTest.kt
@@ -13,9 +13,11 @@ import org.machikoro.server.service.LobbyService
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.machikoro.server.domain.models.PlayerModel
+import org.machikoro.server.dto.LobbyLeavingOutcome
 import org.machikoro.server.dto.LobbyRosterDto
 import org.machikoro.server.dto.LobbyRosterPlayerDto
 import org.machikoro.server.exception.GameNotFoundException
+import org.machikoro.server.exception.PlayerNotFoundException
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
@@ -280,104 +282,202 @@ class LobbyWebSocketControllerTest {
 
     @Test
     fun `leaveLobby throws when no authenticated principal is present`() {
-        val accessor = SimpMessageHeaderAccessor.create().apply { sessionId = "sess-1" }
+        val accessor = SimpMessageHeaderAccessor.create().apply {
+            sessionId = "sess-1"
+        }
 
         val ex = assertThrows<CustomWebSocketException> {
             controller.leaveLobby(
-                WebSocketMessage(type = MessageType.JOIN, sender = "ghost", payload = mapOf("gameId" to 1)),
+                WebSocketMessage(
+                    type = MessageType.JOIN,
+                    sender = "ghost",
+                    payload = mapOf("gameId" to 1)
+                ),
                 accessor,
             )
         }
 
         assertEquals("UNAUTHENTICATED", ex.errorCode)
-        verify(lobbyService, never()).leaveLobby(any(), any())
-        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
+
+        verify(lobbyService, never())
+            .leaveLobby(any(), any())
+
+        verify(messagingTemplate, never())
+            .convertAndSend(any<String>(), any<WebSocketMessage>())
     }
 
     @Test
     fun `leaveLobby throws when payload is not a Map`() {
-        val accessor = authenticatedAccessor(userId = 10, username = "Player1")
+        val accessor = authenticatedAccessor(
+            userId = 10,
+            username = "Player1"
+        )
 
         val ex = assertThrows<CustomWebSocketException> {
             controller.leaveLobby(
-                WebSocketMessage(type = MessageType.JOIN, sender = "Player1", payload = "not-a-map"),
+                WebSocketMessage(
+                    type = MessageType.JOIN,
+                    sender = "Player1",
+                    payload = "not-a-map"
+                ),
                 accessor,
             )
         }
 
         assertEquals("INVALID_PAYLOAD", ex.errorCode)
-        verify(lobbyService, never()).leaveLobby(any(), any())
+
+        verify(lobbyService, never())
+            .leaveLobby(any(), any())
     }
 
     @Test
     fun `leaveLobby throws when gameId is missing from payload`() {
-        val accessor = authenticatedAccessor(userId = 10, username = "Player1")
+        val accessor = authenticatedAccessor(
+            userId = 10,
+            username = "Player1"
+        )
 
         val ex = assertThrows<CustomWebSocketException> {
             controller.leaveLobby(
-                WebSocketMessage(type = MessageType.JOIN, sender = "Player1", payload = emptyMap<String, Any>()),
+                WebSocketMessage(
+                    type = MessageType.JOIN,
+                    sender = "Player1",
+                    payload = emptyMap<String, Any>()
+                ),
                 accessor,
             )
         }
 
         assertEquals("MISSING_GAME_ID", ex.errorCode)
-        verify(lobbyService, never()).leaveLobby(any(), any())
+
+        verify(lobbyService, never())
+            .leaveLobby(any(), any())
     }
 
     @Test
-    fun `leaveLobby does nothing when player is not in game`() {
-        whenever(lobbyService.leaveLobby(1, 10)).thenReturn(null)
-        val accessor = authenticatedAccessor(userId = 10, username = "Player1")
+    fun `leaveLobby throws when player is not in lobby`() {
+        whenever(lobbyService.leaveLobby(1, 10))
+            .thenThrow(
+                PlayerNotFoundException(
+                    "Player 10 not found in game 1"
+                )
+            )
 
-        controller.leaveLobby(
-            WebSocketMessage(type = MessageType.JOIN, sender = "Player1", payload = mapOf("gameId" to 1)),
-            accessor,
+        val accessor = authenticatedAccessor(
+            userId = 10,
+            username = "Player1"
         )
 
-        verify(lobbyService).leaveLobby(1, 10)
-        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
+        assertThrows<PlayerNotFoundException> {
+            controller.leaveLobby(
+                WebSocketMessage(
+                    type = MessageType.JOIN,
+                    sender = "Player1",
+                    payload = mapOf("gameId" to 1)
+                ),
+                accessor,
+            )
+        }
+
+        verify(lobbyService)
+            .leaveLobby(1, 10)
+
+        verify(messagingTemplate, never())
+            .convertAndSend(any<String>(), any<WebSocketMessage>())
     }
 
     @Test
     fun `leaveLobby broadcasts LOBBY_LEFT to game topic when lobby persists`() {
-        val result = LobbyService.LeaveLobbyResult(playerId = 5, gameDeleted = false)
-        whenever(lobbyService.leaveLobby(1, 10)).thenReturn(result)
-        val accessor = authenticatedAccessor(userId = 10, username = "Player1", sessionId = "sess-leave")
+        whenever(lobbyService.leaveLobby(1, 10))
+            .thenReturn(
+                LobbyLeavingOutcome.LobbyRemains(1, 10)
+            )
+
+        val accessor = authenticatedAccessor(
+            userId = 10,
+            username = "Player1",
+            sessionId = "sess-leave"
+        )
 
         controller.leaveLobby(
-            WebSocketMessage(type = MessageType.JOIN, sender = "Player1", payload = mapOf("gameId" to 1)),
+            WebSocketMessage(
+                type = MessageType.JOIN,
+                sender = "Player1",
+                payload = mapOf("gameId" to 1)
+            ),
             accessor,
         )
 
         val destCaptor = argumentCaptor<String>()
         val msgCaptor = argumentCaptor<WebSocketMessage>()
-        verify(messagingTemplate).convertAndSend(destCaptor.capture(), msgCaptor.capture())
 
-        assertEquals("/topic/game/1", destCaptor.firstValue)
+        verify(messagingTemplate)
+            .convertAndSend(
+                destCaptor.capture(),
+                msgCaptor.capture()
+            )
+
+        assertEquals(
+            "/topic/game/1",
+            destCaptor.firstValue
+        )
+
         val msg = msgCaptor.firstValue
         assertEquals(MessageType.LOBBY_LEFT, msg.type)
         assertEquals("SERVER", msg.sender)
         assertEquals(1, msg.gameId)
-        val payload = msg.payload as? Map<*, *> ?: throw AssertionError("Payload is not a Map")
-        assertEquals(5, payload["playerId"])
+
+        val payload = msg.payload as? Map<*, *>
+            ?: throw AssertionError("Payload is not a Map")
+
         assertEquals(10, payload["userId"])
-        assertEquals("Player1", payload["username"])
     }
 
     @Test
-    fun `leaveLobby does not broadcast when game was deleted`() {
-        val result = LobbyService.LeaveLobbyResult(playerId = 5, gameDeleted = true)
-        whenever(lobbyService.leaveLobby(1, 10)).thenReturn(result)
-        val accessor = authenticatedAccessor(userId = 10, username = "Player1")
+    fun `leaveLobby broadcasts HOST_LEFT when lobby is deleted`() {
+        whenever(lobbyService.leaveLobby(1, 10))
+            .thenReturn(
+                LobbyLeavingOutcome.LobbyDeleted(1)
+            )
+
+        val accessor = authenticatedAccessor(
+            userId = 10,
+            username = "Player1"
+        )
 
         controller.leaveLobby(
-            WebSocketMessage(type = MessageType.JOIN, sender = "Player1", payload = mapOf("gameId" to 1)),
+            WebSocketMessage(
+                type = MessageType.JOIN,
+                sender = "Player1",
+                payload = mapOf("gameId" to 1)
+            ),
             accessor,
         )
 
-        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
-    }
+        val destCaptor = argumentCaptor<String>()
+        val msgCaptor = argumentCaptor<WebSocketMessage>()
 
+        verify(messagingTemplate)
+            .convertAndSend(
+                destCaptor.capture(),
+                msgCaptor.capture()
+            )
+
+        assertEquals(
+            "/topic/game/1",
+            destCaptor.firstValue
+        )
+
+        val msg = msgCaptor.firstValue
+        assertEquals(MessageType.HOST_LEFT, msg.type)
+        assertEquals("SERVER", msg.sender)
+        assertEquals(1, msg.gameId)
+
+        val payload = msg.payload as? Map<*, *>
+            ?: throw AssertionError("Payload is not a Map")
+
+        assertEquals(10, payload["userId"])
+    }
     @Test
     fun `joinLobby skips LOBBY_ROSTER when sessionId is null`() {
         whenever(lobbyService.joinLobby("ABC1234", 20)).thenReturn(player())

--- a/src/test/kotlin/org/machikoro/server/dto/ChatMessageTests.kt
+++ b/src/test/kotlin/org/machikoro/server/dto/ChatMessageTests.kt
@@ -15,6 +15,7 @@ class ChatMessageTests {
             "LEAVE",
             "LOBBY_CREATED",
             "LOBBY_JOINED",
+            "HOST_LEFT",
             "LOBBY_ROSTER",
             "GAME_START",
             "GAME_STARTED",
@@ -22,7 +23,6 @@ class ChatMessageTests {
             "GAME_ACTION",
             "GAME_END",
             "LOBBY_LEFT",
-            "PLAYER_LEFT_FINISHED_GAME",
             "ERROR",
             "ROLL_DICE"
         )

--- a/src/test/kotlin/org/machikoro/server/dto/LobbyLeavingOutcomeTest.kt
+++ b/src/test/kotlin/org/machikoro/server/dto/LobbyLeavingOutcomeTest.kt
@@ -1,0 +1,47 @@
+package org.machikoro.server.dto
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class LobbyLeavingOutcomeTest {
+
+    @Test
+    fun `LobbyRemains should have correct userId`() {
+        val outcome = LobbyLeavingOutcome.LobbyRemains(userId = 42)
+        assertEquals(42, outcome.userId)
+    }
+
+    @Test
+    fun `LobbyRemains toString should be correct`() {
+        val outcome = LobbyLeavingOutcome.LobbyRemains(userId = 42)
+        val str = outcome.toString()
+        assert(str.contains("42"))
+    }
+
+    @Test
+    fun `LobbyRemains equality should work`() {
+        val outcome1 = LobbyLeavingOutcome.LobbyRemains(userId = 42)
+        val outcome2 = LobbyLeavingOutcome.LobbyRemains(userId = 42)
+        assertEquals(outcome1, outcome2)
+    }
+
+    @Test
+    fun `LobbyDeleted should have correct gameId`() {
+        val outcome = LobbyLeavingOutcome.LobbyDeleted(gameId = 1)
+        assertEquals(1, outcome.gameId)
+    }
+
+    @Test
+    fun `LobbyDeleted toString should be correct`() {
+        val outcome = LobbyLeavingOutcome.LobbyDeleted(gameId = 1)
+        val str = outcome.toString()
+        assert(str.contains("1"))
+    }
+
+    @Test
+    fun `LobbyDeleted equality should work`() {
+        val outcome1 = LobbyLeavingOutcome.LobbyDeleted(gameId = 1)
+        val outcome2 = LobbyLeavingOutcome.LobbyDeleted(gameId = 1)
+        assertEquals(outcome1, outcome2)
+    }
+}

--- a/src/test/kotlin/org/machikoro/server/service/LobbyServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/LobbyServiceTest.kt
@@ -20,6 +20,7 @@ import org.machikoro.server.domain.models.PlayerCardModel
 import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.models.GameModel
 import org.machikoro.server.domain.models.PlayerModel
+import org.machikoro.server.dto.LobbyLeavingOutcome
 import org.machikoro.server.dto.LobbyRosterPlayerDto
 import org.machikoro.server.exception.GameFinishedException
 import org.machikoro.server.exception.GameNotFoundException
@@ -27,6 +28,7 @@ import org.machikoro.server.exception.GameStartedException
 import org.machikoro.server.exception.LobbyFullException
 import org.machikoro.server.exception.NotEnoughPlayersException
 import org.machikoro.server.exception.NotHostException
+import org.machikoro.server.exception.PlayerNotFoundException
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -359,62 +361,195 @@ class LobbyServiceTest {
     // === leaveLobby() ===
 
     @Test
-    fun `leaveLobby returns null when player is not in the game`() {
-        whenever(playerDao.findByGameIdAndUserId(1, 99)).thenReturn(null)
+    fun `leaveLobby throws PlayerNotFoundException when player is not in the game`() {
+        whenever(playerDao.findByGameIdAndUserId(1, 99))
+            .thenReturn(null)
 
-        val result = lobbyService.leaveLobby(1, 99)
+        assertThrows<PlayerNotFoundException> {
+            lobbyService.leaveLobby(1, 99)
+        }
 
-        assertNull(result)
-        verify(playerDao, never()).deleteByPlayerId(any())
+        verify(playerDao, never())
+            .deleteByPlayerId(any())
     }
 
     @Test
-    fun `leaveLobby returns gameDeleted=false when real players still remain`() {
-        val p = player(5).copy(gameId = 1, userId = 10)
-        whenever(playerDao.findByGameIdAndUserId(1, 10)).thenReturn(p)
-        whenever(playerDao.getLobbyRoster(1)).thenReturn(
-            listOf(rosterEntry(6, "alice", 1))
+    fun `leaveLobby returns LobbyRemains when real players still remain`() {
+        val gameId = 1
+        val userId = 10
+
+        val p = player(5).copy(
+            gameId = gameId,
+            userId = userId
         )
 
-        val result = lobbyService.leaveLobby(1, 10)
+        whenever(playerDao.findByGameIdAndUserId(gameId, userId))
+            .thenReturn(p)
 
-        assertNotNull(result)
-        assertEquals(5, result!!.playerId)
-        assertFalse(result.gameDeleted)
-        verify(playerDao).deleteByPlayerId(5)
-        verify(gameDao, never()).delete(any())
-    }
+        whenever(gameDao.findById(gameId))
+            .thenReturn(
+                game(gameId, GameStatus.WAITING)
+                    .copy(hostUserId = 999)
+            )
 
-    @Test
-    fun `leaveLobby returns gameDeleted=true and purges game when only dummy players remain`() {
-        val p = player(5).copy(gameId = 1, userId = 10)
-        whenever(playerDao.findByGameIdAndUserId(1, 10)).thenReturn(p)
-        whenever(playerDao.getLobbyRoster(1)).thenReturn(
-            listOf(rosterEntry(2, "debug_player2", 1))
+        whenever(playerDao.getLobbyRoster(gameId))
+            .thenReturn(
+                listOf(
+                    rosterEntry(6, "alice", gameId)
+                )
+            )
+
+        val result =
+            lobbyService.leaveLobby(gameId, userId)
+
+        assertEquals(
+            LobbyLeavingOutcome.LobbyRemains(
+                gameId,
+                userId
+            ),
+            result
         )
 
-        val result = lobbyService.leaveLobby(1, 10)
+        verify(playerDao)
+            .deleteByPlayerId(5)
 
-        assertNotNull(result)
-        assertEquals(5, result!!.playerId)
-        assertTrue(result.gameDeleted)
-        verify(playerDao).deleteByPlayerId(5)
-        verify(playerDao).deleteByGameId(1)
-        verify(gameDao).delete(1)
+        verify(playerDao, never())
+            .deleteByGameId(any())
+
+        verify(gameDao, never())
+            .delete(any())
     }
 
     @Test
-    fun `leaveLobby returns gameDeleted=true when roster is empty after player leaves`() {
-        val p = player(5).copy(gameId = 1, userId = 10)
-        whenever(playerDao.findByGameIdAndUserId(1, 10)).thenReturn(p)
-        whenever(playerDao.getLobbyRoster(1)).thenReturn(emptyList())
+    fun `leaveLobby returns LobbyDeleted when only dummy players remain`() {
+        val gameId = 1
+        val userId = 10
 
-        val result = lobbyService.leaveLobby(1, 10)
+        val p = player(5).copy(
+            gameId = gameId,
+            userId = userId
+        )
 
-        assertNotNull(result)
-        assertTrue(result!!.gameDeleted)
-        verify(playerDao).deleteByGameId(1)
-        verify(gameDao).delete(1)
+        whenever(playerDao.findByGameIdAndUserId(gameId, userId))
+            .thenReturn(p)
+
+        whenever(gameDao.findById(gameId))
+            .thenReturn(
+                game(gameId, GameStatus.WAITING)
+                    .copy(hostUserId = 999)
+            )
+
+        whenever(playerDao.getLobbyRoster(gameId))
+            .thenReturn(
+                listOf(
+                    rosterEntry(
+                        2,
+                        "debug_player2",
+                        gameId
+                    )
+                )
+            )
+
+        val result =
+            lobbyService.leaveLobby(gameId, userId)
+
+        assertEquals(
+            LobbyLeavingOutcome.LobbyDeleted(gameId),
+            result
+        )
+
+        verify(playerDao)
+            .deleteByPlayerId(5)
+
+        verify(playerDao)
+            .deleteByGameId(gameId)
+
+        verify(gameDao)
+            .delete(gameId)
+    }
+
+    @Test
+    fun `leaveLobby returns LobbyDeleted when roster is empty after player leaves`() {
+        val gameId = 1
+        val userId = 10
+
+        val p = player(5).copy(
+            gameId = gameId,
+            userId = userId
+        )
+
+        whenever(playerDao.findByGameIdAndUserId(gameId, userId))
+            .thenReturn(p)
+
+        whenever(gameDao.findById(gameId))
+            .thenReturn(
+                game(gameId, GameStatus.WAITING)
+                    .copy(hostUserId = 999)
+            )
+
+        whenever(playerDao.getLobbyRoster(gameId))
+            .thenReturn(emptyList())
+
+        val result =
+            lobbyService.leaveLobby(gameId, userId)
+
+        assertEquals(
+            LobbyLeavingOutcome.LobbyDeleted(gameId),
+            result
+        )
+
+        verify(playerDao)
+            .deleteByPlayerId(5)
+
+        verify(playerDao)
+            .deleteByGameId(gameId)
+
+        verify(gameDao)
+            .delete(gameId)
+    }
+
+    @Test
+    fun `leaveLobby deletes lobby immediately when host leaves`() {
+        val gameId = 1
+        val hostUserId = 10
+
+        val host = player(5).copy(
+            gameId = gameId,
+            userId = hostUserId
+        )
+
+        whenever(
+            playerDao.findByGameIdAndUserId(
+                gameId,
+                hostUserId
+            )
+        ).thenReturn(host)
+
+        whenever(gameDao.findById(gameId))
+            .thenReturn(
+                game(gameId, GameStatus.WAITING)
+                    .copy(hostUserId = hostUserId)
+            )
+
+        val result =
+            lobbyService.leaveLobby(
+                gameId,
+                hostUserId
+            )
+
+        assertEquals(
+            LobbyLeavingOutcome.LobbyDeleted(gameId),
+            result
+        )
+
+        verify(playerDao, never())
+            .deleteByPlayerId(any())
+
+        verify(playerDao)
+            .deleteByGameId(gameId)
+
+        verify(gameDao)
+            .delete(gameId)
     }
 
     // === resetLobby() ===

--- a/src/test/kotlin/org/machikoro/server/service/LobbyServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/LobbyServiceTest.kt
@@ -1,9 +1,7 @@
 package org.machikoro.server.service
 
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/org/machikoro/server/service/LobbyServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/LobbyServiceTest.kt
@@ -404,7 +404,6 @@ class LobbyServiceTest {
 
         assertEquals(
             LobbyLeavingOutcome.LobbyRemains(
-                gameId,
                 userId
             ),
             result


### PR DESCRIPTION
##  Summary

Refactors lobby leaving behavior to better reflect actual lobby lifecycle semantics and improve cleanup logic.

This PR replaces the old nullable LeaveLobbyResult flow with a sealed LobbyLeavingOutcome, clarifies lobby deletion behavior, and updates controller/service tests accordingly.

## Changes

- Lobby leave flow
- Replaced LeaveLobbyResult with sealed LobbyLeavingOutcome
   LobbyRemains and LobbyDeleted
- Removed nullable return behavior from leaveLobby() previously returned null when a player was not in the game, now throws PlayerNotFoundException
- Lobby cleanup behavior

Refactored lobby deletion logic:
- host leaving immediately deletes the lobby
- non-host leaving deletes the lobby when no real players remain
- debug players (DEBUG_USER_PREFIX) no longer keep lobbies alive
- Helper: noRealPlayersRemain()
- leaveLobby() already executes inside a transaction
- WebSocket controller

## Updated /lobby.leave handling to work with LobbyLeavingOutcome:

LobbyRemains broadcasts LOBBY_LEFT (normal player)
LobbyDeleted broadcasts HOST_LEFT

Also updated logging and leave handling semantics.