### PR TITLE
295 docs document websocket game synchronization and broadcast protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,4 +447,4 @@ DevTools console that no *"Failed to find a valid digest in the 'integrity' attr
 error is logged.
 
 ---
-*Last Updated: May 15, 2026*
+*Last Updated: 23.05.2026*

--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ For detailed API documentation, the server exposes both standard REST and asynch
 - **Swagger UI (REST):** Accessible at `http://localhost:8080/swagger-ui.html`. Powered by Springdoc OpenAPI, this interface provides interactive documentation for our standard REST endpoints.
 - **Springwolf UI (AsyncAPI/WebSockets):** Accessible at `http://localhost:8080/springwolf/asyncapi-ui.html`. Powered by Springwolf, this provides interactive documentation and an event publisher for our STOMP over WebSocket channels, which are the backbone of our real-time game communications.
 - **WebSocket Endpoint:** `ws://localhost:8080/ws`
+- **WebSocket Game Protocol:** Client subscriptions, send destinations, message envelopes, and reconnect synchronization are documented in [docs/websocket-game-protocol.md](docs/websocket-game-protocol.md).
 - **Backend Restart Recovery:** The manual restart procedure and `/app/game.sync` verification checklist are documented in [docs/backend-restart-recovery.md](docs/backend-restart-recovery.md).
 
 Run the backend restart recovery smoke test with:

--- a/docs/websocket-game-protocol.md
+++ b/docs/websocket-game-protocol.md
@@ -1,0 +1,143 @@
+# WebSocket Game Synchronization Protocol
+
+This document defines the client-facing STOMP contract for real-time Machi Koro lobby updates, game action broadcasts, and reconnect synchronization.
+
+## Connection
+
+Clients connect with STOMP over one of the registered WebSocket endpoints:
+
+| Transport | Endpoint | Typical client |
+| --- | --- | --- |
+| Native WebSocket | `/ws` | Android and WebSocket-capable clients |
+| SockJS | `/ws-sockjs` | Browser clients that need SockJS fallback transports |
+
+The application destination prefix is `/app`. Broker subscriptions use `/topic` for shared broadcasts and `/queue` for session-scoped replies.
+
+Every STOMP `CONNECT` frame must include an authenticated session token:
+
+```text
+Authorization: Bearer <sessionToken>
+```
+
+The server resolves the user identity from this token and ignores client-supplied sender or user fields for authorization-sensitive actions.
+
+## Subscriptions
+
+Clients should subscribe before sending lobby or game commands so they do not miss immediate broadcasts.
+
+| Subscription | Scope | Purpose |
+| --- | --- | --- |
+| `/topic/game/{gameId}` | All players in one lobby or game | Lobby membership changes, game start, dice, phase, purchase, effects, game end, and broadcast errors |
+| `/queue/lobby-user{sessionId}` | Single WebSocket session | Lobby creation result, lobby roster after join, and lobby-specific request errors |
+| `/queue/game-sync-user{sessionId}` | Single WebSocket session | Full `SYNC` snapshot for reconnect and explicit state refresh |
+| `/topic/public` | Global chat only | Chat and connection announcements from `/app/chat.*` |
+
+`{sessionId}` is the STOMP session id assigned by Spring. Browser clients usually receive it from the STOMP session object after connection. The server currently sends private lobby and sync replies to the resolved broker destinations `/queue/lobby-user{sessionId}` and `/queue/game-sync-user{sessionId}`.
+
+Game clients must not use `/topic/public` for game state. All game-state broadcasts are scoped to `/topic/game/{gameId}` or a private queue.
+
+## Send Destinations
+
+| Client sends to | Payload | Server publishes |
+| --- | --- | --- |
+| `/app/lobby.create` | `WebSocketMessage` | `LOBBY_CREATED` to `/queue/lobby-user{sessionId}` |
+| `/app/lobby.join` | `WebSocketMessage` with `payload.lobbyCode` | `LOBBY_ROSTER` to `/queue/lobby-user{sessionId}` and `LOBBY_JOINED` to `/topic/game/{gameId}` |
+| `/app/lobby.leave` | `WebSocketMessage` with `payload.gameId` | `LOBBY_LEFT` or `HOST_LEFT` to `/topic/game/{gameId}` |
+| `/app/game.start` | `StartGameRequest` | `GAME_STARTED` and a `GAME_ACTION` snapshot to `/topic/game/{gameId}` |
+| `/app/game.rollDice` | `RollDiceRequest` | `ROLL_DICE` and a `GAME_ACTION` snapshot to `/topic/game/{gameId}` |
+| `/app/game.resolveEffects` | `ResolveEffectsRequest` | `GAME_ACTION` income/effects result to `/topic/game/{gameId}` |
+| `/app/game.advancePhase` | `AdvancePhaseRequest` | `GAME_ACTION` phase snapshot to `/topic/game/{gameId}` |
+| `/app/game.purchase` | `PurchaseRequest` | `GAME_ACTION` purchase snapshot to `/topic/game/{gameId}` |
+| `/app/game.endTurn` | `EndTurnRequest` | `GAME_ACTION` next-turn snapshot or `GAME_END` to `/topic/game/{gameId}` |
+| `/app/game.sync` | `SyncGameRequest` | `SYNC` to `/queue/game-sync-user{sessionId}` |
+| `/app/chat.send` | `WebSocketMessage` | Chat message to `/topic/public` |
+| `/app/chat.addUser` | `WebSocketMessage` | Join message to `/topic/public`; may also trigger `SYNC` for an active in-progress game |
+
+## Message Envelope
+
+All WebSocket responses use `WebSocketMessage`:
+
+```json
+{
+  "type": "GAME_ACTION",
+  "sender": "server",
+  "content": "Optional human-readable text",
+  "payload": {},
+  "timestamp": 1714000000000,
+  "gameId": 1
+}
+```
+
+Core game message types:
+
+| Type | Meaning |
+| --- | --- |
+| `GAME_STARTED` | The host started the lobby. The payload is the full `GameStateDto`. |
+| `GAME_ACTION` | A state-changing game action completed. The payload includes `event`, `turnPhase`, `activePlayerId`, and `state`. |
+| `ROLL_DICE` | Dice were rolled. The payload includes the dice values, total, completion flag, and state snapshot. |
+| `SYNC` | Private reconnect snapshot. The payload includes `targetUserId`, `targetSessionId`, and `state`. |
+| `GAME_END` | The game has ended. The payload includes `winnerId`, `roundsPlayed`, and final `state`. |
+| `ERROR` | The command failed. The payload includes an event or error code and a message when available. |
+
+Lobby-specific message types include `LOBBY_CREATED`, `LOBBY_JOINED`, `LOBBY_ROSTER`, `LOBBY_LEFT`, and `HOST_LEFT`.
+
+## Two-Player Synchronization Flow
+
+1. Player A and Player B connect to `/ws` or `/ws-sockjs` with `Authorization: Bearer <sessionToken>`.
+2. Player A subscribes to `/queue/lobby-user{sessionId}` and sends `/app/lobby.create`.
+3. Player A receives `LOBBY_CREATED` with `gameId` and `lobbyCode`.
+4. Both players subscribe to `/topic/game/{gameId}`.
+5. Player B subscribes to `/queue/lobby-user{sessionId}` and sends `/app/lobby.join` with the lobby code.
+6. Player B receives `LOBBY_ROSTER` privately. Both players receive `LOBBY_JOINED` on `/topic/game/{gameId}`.
+7. Player A sends `/app/game.start`.
+8. Both players receive `GAME_STARTED` and the initial `GAME_ACTION` snapshot on `/topic/game/{gameId}`.
+9. During the game, the active player sends dice, effects, phase, purchase, and end-turn commands. Both players consume the resulting `ROLL_DICE`, `GAME_ACTION`, or `GAME_END` messages from `/topic/game/{gameId}` and replace their local state with the included `state` snapshot.
+
+Clients should treat the server snapshot as authoritative. Local UI state may optimistically display pending actions, but it must reconcile to the latest broadcast payload.
+
+## Reconnect and Explicit Sync
+
+A reconnecting player must establish a new STOMP connection with the same authenticated session token and resubscribe to:
+
+```text
+/topic/game/{gameId}
+/queue/game-sync-user{newSessionId}
+```
+
+Then the client sends:
+
+```json
+SEND /app/game.sync
+
+{
+  "gameId": 1
+}
+```
+
+The server validates that the authenticated user belongs to the requested game and that the game is in progress. On success, it publishes:
+
+```json
+{
+  "type": "SYNC",
+  "sender": "server",
+  "content": "State sync for reconnecting player",
+  "payload": {
+    "targetUserId": 10,
+    "targetSessionId": "abc123",
+    "state": {
+      "game": {
+        "id": 1,
+        "status": "IN_PROGRESS",
+        "turnPhase": "ROLL_DICE"
+      },
+      "activePlayerId": 10,
+      "turnOrder": [10, 11],
+      "players": [],
+      "marketplace": []
+    }
+  },
+  "gameId": 1
+}
+```
+
+If `gameId` is omitted, the server attempts to find the authenticated user's active in-progress game. Unauthorized or inactive sync requests are rejected without broadcasting state to other players.

--- a/docs/websocket-game-protocol.md
+++ b/docs/websocket-game-protocol.md
@@ -29,10 +29,10 @@ Clients should subscribe before sending lobby or game commands so they do not mi
 | --- | --- | --- |
 | `/topic/game/{gameId}` | All players in one lobby or game | Lobby membership changes, game start, dice, phase, purchase, effects, game end, and broadcast errors |
 | `/queue/lobby-user{sessionId}` | Single WebSocket session | Lobby creation result, lobby roster after join, and lobby-specific request errors |
-| `/queue/game-sync-user{sessionId}` | Single WebSocket session | Full `SYNC` snapshot for reconnect and explicit state refresh |
+| `/user/queue/game-sync` | Single WebSocket session | Full `SYNC` snapshot for reconnect and explicit state refresh |
 | `/topic/public` | Global chat only | Chat and connection announcements from `/app/chat.*` |
 
-`{sessionId}` is the STOMP session id assigned by Spring. Browser clients usually receive it from the STOMP session object after connection. The server currently sends private lobby and sync replies to the resolved broker destinations `/queue/lobby-user{sessionId}` and `/queue/game-sync-user{sessionId}`.
+`{sessionId}` is the STOMP session id assigned by Spring. Browser clients usually receive it from the STOMP session object after connection. The server sends private lobby replies to `/queue/lobby-user{sessionId}` and sends reconnect sync replies to the resolved broker destination `/queue/game-sync-user{sessionId}`, which clients consume by subscribing to `/user/queue/game-sync`.
 
 Game clients must not use `/topic/public` for game state. All game-state broadcasts are scoped to `/topic/game/{gameId}` or a private queue.
 
@@ -101,7 +101,7 @@ A reconnecting player must establish a new STOMP connection with the same authen
 
 ```text
 /topic/game/{gameId}
-/queue/game-sync-user{newSessionId}
+/user/queue/game-sync
 ```
 
 Then the client sends:

--- a/src/main/kotlin/org/machikoro/server/config/OpenApiConfig.kt
+++ b/src/main/kotlin/org/machikoro/server/config/OpenApiConfig.kt
@@ -23,15 +23,27 @@ class OpenApiConfig {
     REST and WebSocket API for the Machi Koro board game.
     
     ## WebSocket Connection
-    Connect via STOMP at ws://localhost:8080/ws.
+    Connect via STOMP at `ws://localhost:8080/ws` or use SockJS at `/ws-sockjs`.
+    Authenticated clients must send `Authorization: Bearer <sessionToken>` on the STOMP `CONNECT` frame.
     
-    ### Endpoints
-    | Destination | Payload | Broadcasts to |
+    ### Game Synchronization
+    Subscribe to `/topic/game/{gameId}` for lobby and game-state broadcasts.
+    Subscribe to `/queue/lobby-user{sessionId}` for private lobby replies and `/queue/game-sync-user{sessionId}` for reconnect snapshots.
+    `/topic/public` is reserved for global chat only.
+    
+    | Client destination | Payload | Server publishes |
     |---|---|---|
-    | /app/game.resolveEffects | ResolveEffectsRequest | /topic/public |
-    | /app/game.endTurn | EndTurnRequest | /topic/public |
-    | /app/chat.send | WebSocketMessage | /topic/public |
-    | /app/chat.addUser | WebSocketMessage | /topic/public |
+    | `/app/lobby.create` | `WebSocketMessage` | `LOBBY_CREATED` to `/queue/lobby-user{sessionId}` |
+    | `/app/lobby.join` | `WebSocketMessage` with `payload.lobbyCode` | `LOBBY_ROSTER` to `/queue/lobby-user{sessionId}`, `LOBBY_JOINED` to `/topic/game/{gameId}` |
+    | `/app/game.start` | `StartGameRequest` | `GAME_STARTED`, `GAME_ACTION` to `/topic/game/{gameId}` |
+    | `/app/game.rollDice` | `RollDiceRequest` | `ROLL_DICE`, `GAME_ACTION` to `/topic/game/{gameId}` |
+    | `/app/game.resolveEffects` | `ResolveEffectsRequest` | `GAME_ACTION` to `/topic/game/{gameId}` |
+    | `/app/game.advancePhase` | `AdvancePhaseRequest` | `GAME_ACTION` to `/topic/game/{gameId}` |
+    | `/app/game.purchase` | `PurchaseRequest` | `GAME_ACTION` to `/topic/game/{gameId}` |
+    | `/app/game.endTurn` | `EndTurnRequest` | `GAME_ACTION` or `GAME_END` to `/topic/game/{gameId}` |
+    | `/app/game.sync` | `SyncGameRequest` | `SYNC` to `/queue/game-sync-user{sessionId}` |
+    
+    See `docs/websocket-game-protocol.md` for payload examples and reconnect flow.
     """
                         .trimIndent()
                 )

--- a/src/main/kotlin/org/machikoro/server/config/OpenApiConfig.kt
+++ b/src/main/kotlin/org/machikoro/server/config/OpenApiConfig.kt
@@ -28,7 +28,7 @@ class OpenApiConfig {
     
     ### Game Synchronization
     Subscribe to `/topic/game/{gameId}` for lobby and game-state broadcasts.
-    Subscribe to `/queue/lobby-user{sessionId}` for private lobby replies and `/queue/game-sync-user{sessionId}` for reconnect snapshots.
+    Subscribe to `/queue/lobby-user{sessionId}` for private lobby replies and `/user/queue/game-sync` for reconnect snapshots.
     `/topic/public` is reserved for global chat only.
     
     | Client destination | Payload | Server publishes |
@@ -41,7 +41,7 @@ class OpenApiConfig {
     | `/app/game.advancePhase` | `AdvancePhaseRequest` | `GAME_ACTION` to `/topic/game/{gameId}` |
     | `/app/game.purchase` | `PurchaseRequest` | `GAME_ACTION` to `/topic/game/{gameId}` |
     | `/app/game.endTurn` | `EndTurnRequest` | `GAME_ACTION` or `GAME_END` to `/topic/game/{gameId}` |
-    | `/app/game.sync` | `SyncGameRequest` | `SYNC` to `/queue/game-sync-user{sessionId}` |
+    | `/app/game.sync` | `SyncGameRequest` | `SYNC` to resolved `/queue/game-sync-user{sessionId}` |
     
     See `docs/websocket-game-protocol.md` for payload examples and reconnect flow.
     """


### PR DESCRIPTION
## Summary

- Documented the STOMP WebSocket game synchronization and broadcast protocol.
- Clarified supported connection endpoints: `/ws` and `/ws-sockjs`.
- Documented game subscriptions, lobby queues, game sync queues, send destinations, message types, and reconnect flow.
- Fixed stale OpenAPI documentation that incorrectly referenced `/topic/public` for game broadcasts.
- Updated README links and last updated date.