### PR TITLE
docs: enhance WebSocket game protocol documentation and backend resta…

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ For detailed API documentation, the server exposes both standard REST and asynch
 - **WebSocket Endpoint:** `ws://localhost:8080/ws`
 - **WebSocket Game Protocol:** Client subscriptions, send destinations, message envelopes, and reconnect synchronization are documented in [docs/websocket-game-protocol.md](docs/websocket-game-protocol.md).
 - **Backend Restart Recovery:** The manual restart procedure and `/app/game.sync` verification checklist are documented in [docs/backend-restart-recovery.md](docs/backend-restart-recovery.md).
+- **Backend Networking Demo Checklist:** Reviewer/demo validation for two-player sync, reconnect, restart recovery, health, and deployment is documented in [docs/backend-networking-demo-checklist.md](docs/backend-networking-demo-checklist.md).
 
 Run the backend restart recovery smoke test with:
 
@@ -315,9 +316,10 @@ GET http://localhost:8080/actuator/health
 
 ## Deployment
 
-The server is deployed to the AAU shared infrastructure (`se2-demo.aau.at`, group 6) via
-[doco-cd](https://github.com/kimdre/doco-cd), which reconciles the running stack from this
-repository's `compose.yaml` on every push to `main`.
+The server is deployed to the AAU shared infrastructure (`se2-demo.aau.at`, group 6) by the
+`deploy` job in [.github/workflows/docker-publish.yml](.github/workflows/docker-publish.yml).
+The workflow publishes the backend image to GHCR, then SSHes into the group 6 server and refreshes
+the `backend` service from `~/machi-koro-server-deploy`.
 
 ### Pipeline overview
 
@@ -328,8 +330,8 @@ flowchart LR
     Action --> Docker[Build Multi-Arch Docker Image]
     Docker --> GHCR[(GHCR Image Registry)]
     
-    GHCR --> DocoCD(doco-cd on AAU Server)
-    DocoCD -->|Pulls Image| Production[Docker Compose Stack]
+    GHCR --> SSHDeploy[GitHub Actions SSH deploy]
+    SSHDeploy -->|docker compose pull backend| Production[Docker Compose Stack on AAU]
     Production --> Backend[Machi Koro Backend]
     Production --> DB[(PostgreSQL)]
 ```
@@ -348,11 +350,14 @@ flowchart LR
    - `latest` (only on `main`)
    - `sha-<short-commit>` (every build, used for rollback)
    - `v*` (when a Git tag matching `v*` is pushed)
-5. doco-cd on the AAU server detects the change, pulls the new image (`pull_policy: always`),
-   and restarts the `backend` service defined in [compose.yaml](compose.yaml), when the
-   course deployment config contains a stack entry for this repository.
+5. The `deploy` job connects to the AAU server over SSH on port `53200`, enters
+   `~/machi-koro-server-deploy`, pulls the updated backend image, and restarts only the
+   `backend` service with `docker compose up -d --no-deps backend`.
 6. The Postgres service runs alongside the backend on the internal compose network and is
    **not exposed to the host** — only the backend is published on `PUBLIC_PORT` (`53210`).
+7. WebSocket clients connect through the same public backend port (`ws://se2-demo.aau.at:53210/ws`)
+   and subscribe to `/topic/game/{gameId}` for game-state broadcasts. `/topic/public` is reserved
+   for global chat only.
 
 ### Live endpoints
 
@@ -368,14 +373,13 @@ flowchart LR
 ssh grp-6@se2-demo.aau.at -p 53200
 ```
 
-The doco-cd working copy of this repo lives at:
+The active deployment directory used by the GitHub Actions SSH deploy job is:
 
 ```
-/var/lib/docker/volumes/doco-cd-setup_data/_data/github.com/SE2-Machi-Koro/Server/
+~/machi-koro-server-deploy
 ```
 
-This path is owned by Docker and may not be directly readable from the `grp-6` shell.
-If doco-cd has not created a group 6 stack yet, deploy from the group home directory:
+If the directory does not exist yet, initialize it from the group home directory:
 
 ```bash
 mkdir -p /home/grp-6/machi-koro-server-deploy
@@ -407,10 +411,9 @@ docker compose up -d
 docker compose ps
 ```
 
-This manual fallback does not auto-restart on every push to `main`. After a new image is
-published to GHCR, refresh the running stack from `/home/grp-6/machi-koro-server-deploy`
-with the same `docker compose pull && docker compose up -d` commands, or add a group 6
-stack entry to the course doco-cd config so reconciliation is automatic.
+The GitHub Actions deploy job refreshes the backend automatically on pushes to `main` when
+`DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_SSH_KEY`, and the production `.env` are configured.
+For manual recovery, run the same compose commands from `/home/grp-6/machi-koro-server-deploy`.
 
 The deployment is healthy when `docker compose ps` shows both `machikoro-db` and
 `machikoro-server` as healthy and the external health check returns `status: UP`:
@@ -423,7 +426,7 @@ curl http://se2-demo.aau.at:53210/actuator/health
 
 To roll back to a previous image, edit the production `.env` on the server and set
 `IMAGE_TAG=sha-<short-commit>` (or any other tag published to GHCR), then trigger a
-manual `docker compose up -d` or a doco-cd reconcile. The `compose.yaml` resolves the image as
+manual `docker compose up -d --no-deps backend` or rerun the deploy workflow. The `compose.yaml` resolves the image as
 `ghcr.io/se2-machi-koro/server:${IMAGE_TAG:-latest}`.
 
 ## Frontend dependencies (Subresource Integrity)

--- a/docs/backend-networking-demo-checklist.md
+++ b/docs/backend-networking-demo-checklist.md
@@ -1,0 +1,117 @@
+# Backend Networking Demo Checklist
+
+Use this checklist to validate the backend networking, recovery, health, and deployment paths during review or demo. It assumes the server is running locally on port `8080` or on the AAU group 6 deployment port `53210`.
+
+## References
+
+| Area | Reference |
+| --- | --- |
+| STOMP protocol | [websocket-game-protocol.md](websocket-game-protocol.md) |
+| Restart recovery | [backend-restart-recovery.md](backend-restart-recovery.md) |
+| Deployment | [README.md#deployment](../README.md#deployment) |
+| Local health | `http://localhost:8080/actuator/health` |
+| AAU health | `http://se2-demo.aau.at:53210/actuator/health` |
+| Local WebSocket | `ws://localhost:8080/ws` |
+| AAU WebSocket | `ws://se2-demo.aau.at:53210/ws` |
+
+## Pre-Demo Setup
+
+1. Start the backend and database.
+
+   ```bash
+   docker compose -f compose.yaml -f compose-dev.yaml up -d
+   ```
+
+2. Verify health.
+
+   ```bash
+   curl http://localhost:8080/actuator/health
+   ```
+
+   Expected result: JSON response with `status` set to `UP`.
+
+3. Open REST and AsyncAPI documentation.
+
+   ```text
+   http://localhost:8080/swagger-ui.html
+   http://localhost:8080/springwolf/asyncapi-ui.html
+   ```
+
+## Two-Player Sync
+
+1. Log in two users and keep both session tokens.
+2. Connect both clients to `/ws` with `Authorization: Bearer <sessionToken>`.
+3. Subscribe both clients to `/user/queue/errors`.
+4. Player A subscribes to `/queue/lobby-user{sessionId}` and sends `/app/lobby.create`.
+5. Player A records `gameId` and `lobbyCode` from `LOBBY_CREATED`.
+6. Both players subscribe to `/topic/game/{gameId}`.
+7. Player B subscribes to `/queue/lobby-user{sessionId}` and sends `/app/lobby.join` with `payload.lobbyCode`.
+8. Verify Player B receives `LOBBY_ROSTER` privately and both players receive `LOBBY_JOINED` on `/topic/game/{gameId}`.
+9. Player A sends `/app/game.start`.
+10. Verify both players receive `GAME_STARTED` and `GAME_ACTION` on `/topic/game/{gameId}`.
+11. Run one turn: `/app/game.rollDice`, `/app/game.resolveEffects`, `/app/game.advancePhase`, optional `/app/game.purchase`, then `/app/game.endTurn`.
+12. Verify both clients receive the same final `state.activePlayerId`, `state.turnOrder`, `state.players`, `state.playerCards`, `state.playerLandmarks`, and `state.marketplace`.
+
+## Reconnect Recovery
+
+1. Keep the game in `IN_PROGRESS`.
+2. Disconnect one player without ending the game.
+3. Reconnect with the same session token.
+4. Subscribe to `/topic/game/{gameId}`, `/user/queue/game-sync`, and `/user/queue/errors`.
+5. Send `/app/game.sync` with the current `gameId`.
+6. Verify the reconnecting client receives `SYNC` privately on `/user/queue/game-sync`.
+7. Compare the `SYNC.payload.state` with the last broadcast snapshot.
+
+The following fields must match: `game.id`, `game.status`, `game.turnPhase`, `activePlayerId`, `turnOrder`, player coins, owned cards, built landmarks, and marketplace quantities.
+
+## Backend Restart Recovery
+
+1. Keep a two-player game in `IN_PROGRESS` after at least one state mutation.
+2. Capture the latest broadcast snapshot from `/topic/game/{gameId}`.
+3. Restart only the backend container.
+
+   ```bash
+   docker compose restart backend
+   ```
+
+4. Reconnect both clients with their existing session tokens.
+5. Subscribe again to `/topic/game/{gameId}`, `/user/queue/game-sync`, and `/user/queue/errors`.
+6. Send `/app/game.sync`.
+7. Verify the recovered `SYNC.payload.state` matches the pre-restart snapshot for turn, coin, card, landmark, and marketplace state.
+8. Continue the game by sending the next valid turn action and verify `/topic/game/{gameId}` broadcasts resume.
+
+Automated smoke coverage:
+
+```bash
+./scripts/backend-restart-recovery-smoke.sh
+```
+
+## Error Routing
+
+1. Send an invalid lobby join request with a non-existent lobby code.
+2. Verify the error is delivered only to `/queue/lobby-user{sessionId}`.
+3. Send a WebSocket command that fails validation or authorization.
+4. Verify the private error response is delivered on `/user/queue/errors`.
+5. Trigger a purchase rejection, for example a duplicate purple establishment.
+6. Verify a game-topic `ERROR` with `payload.event = "PURCHASE_FAILED"` is broadcast on `/topic/game/{gameId}`.
+
+## Deployment Verification
+
+1. Confirm the GHCR image publication and SSH deployment workflow exists at `.github/workflows/docker-publish.yml`.
+2. Confirm `compose.yaml` uses `ghcr.io/se2-machi-koro/server:${IMAGE_TAG:-latest}` and publishes only the backend via `PUBLIC_PORT`.
+3. On the AAU server, verify `~/machi-koro-server-deploy` contains `compose.yaml` and a production `.env`.
+4. Refresh the stack when needed.
+
+   ```bash
+   docker compose pull backend
+   docker compose up -d --no-deps backend
+   docker compose ps
+   ```
+
+5. Verify both containers are healthy and the public endpoint returns `UP`.
+
+   ```bash
+   curl http://se2-demo.aau.at:53210/actuator/health
+   ```
+
+6. Verify clients use `ws://se2-demo.aau.at:53210/ws` and game-state subscriptions use `/topic/game/{gameId}`, not `/topic/public`.

--- a/docs/backend-restart-recovery.md
+++ b/docs/backend-restart-recovery.md
@@ -32,7 +32,8 @@ This document outlines the procedure to verify that an in-progress Machi Koro ga
 
 6. **Reconnect Clients:**
    - After the backend is back online, refresh both clients (or trigger a WS reconnect).
-   - The reconnect flow invokes `/app/game.sync` and retrieves the `GameStateDto` snapshot.
+   - Subscribe each reconnecting client to `/topic/game/{gameId}`, `/user/queue/game-sync`, and `/user/queue/errors`.
+   - The reconnect flow invokes `/app/game.sync` and retrieves the private `SYNC` response containing the `GameStateDto` snapshot.
 
 7. **Verify Game State:**
    Ensure that the state is identical to pre-restart. The following fields must match exactly:
@@ -50,6 +51,7 @@ Automated coverage:
 - `scripts/backend-restart-recovery-smoke.sh` builds and starts the backend with Docker Compose, creates two authenticated STOMP clients, starts a game, buys an establishment, builds a landmark, restarts the `backend` container, reconnects with the same session token, and re-issues `/app/game.sync`.
 - `SpringContextRestartRecoveryIntegrationTest` creates an in-progress game in a Testcontainers-backed Postgres database, mutates persisted fields, forces a Spring application context restart, and then re-enters the `/app/game.sync` controller path.
 - The recovered `SYNC` payload verifies the same game id, `IN_PROGRESS` status, `BUY_OR_BUILD` phase, dice roll, round number, player coins, owned cards, built landmark, marketplace quantities, active player, and turn order.
+- The broader reviewer flow is documented in [backend-networking-demo-checklist.md](backend-networking-demo-checklist.md).
 
 Last local verification:
 

--- a/docs/websocket-game-protocol.md
+++ b/docs/websocket-game-protocol.md
@@ -1,6 +1,6 @@
 # WebSocket Game Synchronization Protocol
 
-This document defines the client-facing STOMP contract for real-time Machi Koro lobby updates, game action broadcasts, and reconnect synchronization.
+This document defines the client-facing STOMP contract for Machi Koro lobby updates, game-state broadcasts, turn actions, errors, and reconnect synchronization.
 
 ## Connection
 
@@ -11,51 +11,112 @@ Clients connect with STOMP over one of the registered WebSocket endpoints:
 | Native WebSocket | `/ws` | Android and WebSocket-capable clients |
 | SockJS | `/ws-sockjs` | Browser clients that need SockJS fallback transports |
 
-The application destination prefix is `/app`. Broker subscriptions use `/topic` for shared broadcasts and `/queue` for session-scoped replies.
+The application destination prefix is `/app`. Broker subscriptions use `/topic` for shared broadcasts and `/queue` or `/user/queue` for session-scoped replies.
 
-Every STOMP `CONNECT` frame must include an authenticated session token:
+Every STOMP `CONNECT` frame must include the authenticated session token returned by the login API:
 
 ```text
 Authorization: Bearer <sessionToken>
 ```
 
-The server resolves the user identity from this token and ignores client-supplied sender or user fields for authorization-sensitive actions.
+The server resolves the authenticated user from this token. Clients must not send user IDs or sender names as an authorization mechanism; sensitive actions derive identity from the STOMP principal and server-side room membership.
 
 ## Subscriptions
 
-Clients should subscribe before sending lobby or game commands so they do not miss immediate broadcasts.
+Subscribe before sending lobby or game commands so immediate responses are not missed.
 
 | Subscription | Scope | Purpose |
 | --- | --- | --- |
-| `/topic/game/{gameId}` | All players in one lobby or game | Lobby membership changes, game start, dice, phase, purchase, effects, game end, and broadcast errors |
-| `/queue/lobby-user{sessionId}` | Single WebSocket session | Lobby creation result, lobby roster after join, and lobby-specific request errors |
+| `/topic/game/{gameId}` | All players in one lobby or game | Lobby membership changes, game start, dice, phase changes, purchases, resolved effects, game end, and game-topic errors |
+| `/queue/lobby-user{sessionId}` | Single WebSocket session | Lobby creation result, lobby roster after join, invalid lobby-code errors |
 | `/user/queue/game-sync` | Single WebSocket session | Full `SYNC` snapshot for reconnect and explicit state refresh |
-| `/topic/public` | Global chat only | Chat and connection announcements from `/app/chat.*` |
+| `/user/queue/errors` | Single WebSocket session | `CustomWebSocketException` and unexpected WebSocket handler failures |
+| `/topic/public` | Global chat only | Chat messages and chat join announcements from `/app/chat.*` |
 
-`{sessionId}` is the STOMP session id assigned by Spring. Browser clients usually receive it from the STOMP session object after connection. The server sends private lobby replies to `/queue/lobby-user{sessionId}` and sends reconnect sync replies to the resolved broker destination `/queue/game-sync-user{sessionId}`, which clients consume by subscribing to `/user/queue/game-sync`.
+`{sessionId}` is the STOMP session id assigned by Spring. Browser clients usually receive it from the STOMP session object after connection.
 
-Game clients must not use `/topic/public` for game state. All game-state broadcasts are scoped to `/topic/game/{gameId}` or a private queue.
+The server sends private lobby replies to `/queue/lobby-user{sessionId}`. It sends reconnect snapshots to the resolved broker destination `/queue/game-sync-user{sessionId}`; clients consume that reply by subscribing to `/user/queue/game-sync`.
+
+Game clients must not use `/topic/public` for lobby or game state. All game-state broadcasts are scoped to `/topic/game/{gameId}` or to a private queue.
 
 ## Send Destinations
 
 | Client sends to | Payload | Server publishes |
 | --- | --- | --- |
-| `/app/lobby.create` | `WebSocketMessage` | `LOBBY_CREATED` to `/queue/lobby-user{sessionId}` |
+| `/app/chat.addUser` | `WebSocketMessage`, optional `gameId` | Chat join message to `/topic/public`; may also emit `SYNC` to `/user/queue/game-sync` when the user has an active in-progress game |
+| `/app/chat.send` | `WebSocketMessage` | Chat message to `/topic/public` |
+| `/app/lobby.create` | `WebSocketMessage` body; sender ignored | `LOBBY_CREATED` to `/queue/lobby-user{sessionId}` |
 | `/app/lobby.join` | `WebSocketMessage` with `payload.lobbyCode` | `LOBBY_ROSTER` to `/queue/lobby-user{sessionId}` and `LOBBY_JOINED` to `/topic/game/{gameId}` |
 | `/app/lobby.leave` | `WebSocketMessage` with `payload.gameId` | `LOBBY_LEFT` or `HOST_LEFT` to `/topic/game/{gameId}` |
-| `/app/game.start` | `StartGameRequest` | `GAME_STARTED` and a `GAME_ACTION` snapshot to `/topic/game/{gameId}` |
-| `/app/game.rollDice` | `RollDiceRequest` | `ROLL_DICE` and a `GAME_ACTION` snapshot to `/topic/game/{gameId}` |
+| `/app/game.start` | `StartGameRequest` | `GAME_STARTED` and `GAME_ACTION` snapshots to `/topic/game/{gameId}` |
+| `/app/game.enterScreen` | `EnterGameScreenRequest` | Idempotent initialization path; host may trigger `GAME_STARTED` and `GAME_ACTION` to `/topic/game/{gameId}` |
+| `/app/game.rollDice` | `RollDiceRequest` | `ROLL_DICE` and `GAME_ACTION` snapshots to `/topic/game/{gameId}` |
 | `/app/game.resolveEffects` | `ResolveEffectsRequest` | `GAME_ACTION` income/effects result to `/topic/game/{gameId}` |
 | `/app/game.advancePhase` | `AdvancePhaseRequest` | `GAME_ACTION` phase snapshot to `/topic/game/{gameId}` |
 | `/app/game.purchase` | `PurchaseRequest` | `GAME_ACTION` purchase snapshot or `ERROR` purchase failure to `/topic/game/{gameId}` |
 | `/app/game.endTurn` | `EndTurnRequest` | `GAME_ACTION` next-turn snapshot or `GAME_END` to `/topic/game/{gameId}` |
-| `/app/game.sync` | `SyncGameRequest` | `SYNC` to `/queue/game-sync-user{sessionId}` |
-| `/app/chat.send` | `WebSocketMessage` | Chat message to `/topic/public` |
-| `/app/chat.addUser` | `WebSocketMessage` | Join message to `/topic/public`; may also trigger `SYNC` for an active in-progress game |
+| `/app/game.sync` | `SyncGameRequest` | `SYNC` to `/user/queue/game-sync` |
+
+## Request Payloads
+
+Start game:
+
+```json
+{
+  "gameId": 42
+}
+```
+
+Roll dice:
+
+```json
+{
+  "gameId": 42,
+  "rollTwoDice": false
+}
+```
+
+Resolve effects, advance phase, and end turn all use the same minimal game-scoped request shape:
+
+```json
+{
+  "gameId": 42
+}
+```
+
+Purchase an establishment:
+
+```json
+{
+  "gameId": 42,
+  "purchaseType": "ESTABLISHMENT",
+  "cardType": "BAKERY"
+}
+```
+
+Build a landmark:
+
+```json
+{
+  "gameId": 42,
+  "purchaseType": "LANDMARK",
+  "landmarkType": "TRAIN_STATION"
+}
+```
+
+Explicit reconnect sync:
+
+```json
+{
+  "gameId": 42
+}
+```
+
+`SyncGameRequest.gameId` is optional. When omitted, the server attempts to resolve the authenticated user's active `IN_PROGRESS` game.
 
 ## Message Envelope
 
-All WebSocket responses use `WebSocketMessage`:
+Most WebSocket responses use `WebSocketMessage`:
 
 ```json
 {
@@ -64,7 +125,7 @@ All WebSocket responses use `WebSocketMessage`:
   "content": "Optional human-readable text",
   "payload": {},
   "timestamp": 1714000000000,
-  "gameId": 1
+  "gameId": 42
 }
 ```
 
@@ -72,20 +133,148 @@ Core game message types:
 
 | Type | Meaning |
 | --- | --- |
-| `GAME_STARTED` | The host started the lobby. The payload is the full `GameStateDto`. |
+| `GAME_STARTED` | The host started the game. The payload is the full `GameStateDto`. |
 | `GAME_ACTION` | A state-changing game action completed. The payload includes `event`, `turnPhase`, `activePlayerId`, and `state`. |
-| `ROLL_DICE` | Dice were rolled. The payload includes the dice values, total, completion flag, and state snapshot. |
+| `ROLL_DICE` | Dice were rolled. The payload includes dice values, total, completion flag, and a state snapshot. |
 | `SYNC` | Private reconnect snapshot. The payload includes `targetUserId`, `targetSessionId`, and `state`. |
 | `GAME_END` | The game has ended. The payload includes `winnerId`, `roundsPlayed`, and final `state`. |
-| `ERROR` | The command failed. The payload includes an event or error code and a message when available. |
+| `ERROR` | A command failed. Game-topic errors use `WebSocketMessage`; user-queue handler errors use `WebSocketErrorResponse`. |
 
 Lobby-specific message types include `LOBBY_CREATED`, `LOBBY_JOINED`, `LOBBY_ROSTER`, `LOBBY_LEFT`, and `HOST_LEFT`.
 
-## Purchase Rejections
+`GameStateDto` is the authoritative board snapshot. Important fields for client reconciliation are:
 
-When `/app/game.purchase` is rejected after authorization succeeds, the server broadcasts an `ERROR` message on `/topic/game/{gameId}`. Clients with a pending shop action must consume `payload.event = "PURCHASE_FAILED"` as a failed purchase and clear their pending state.
+| Field | Meaning |
+| --- | --- |
+| `game.status` | Current game lifecycle state, for example `WAITING`, `IN_PROGRESS`, or `FINISHED` |
+| `game.turnPhase` | Current turn phase, for example `ROLL_DICE`, `EARN_INCOME`, or `BUY_OR_BUILD` |
+| `players` | Active players in the game |
+| `playerCards` | Player-owned establishments keyed by player id |
+| `playerLandmarks` | Landmark build state keyed by player id |
+| `marketplace` | Remaining card supply keyed by `CardType` |
+| `turnOrder` | Ordered list of user ids |
+| `activePlayerId` | User id of the current active player |
+| `playerUsernames` | Display names keyed by player id |
 
-For example, buying the same purple establishment twice produces:
+Clients should treat the latest server snapshot as authoritative and replace local board state with the included `state`.
+
+## Response Examples
+
+The examples below show the relevant envelope and payload fields. `GameStateDto` snapshots may contain additional card, landmark, player, and marketplace entries depending on the running game.
+
+### Start Game
+
+`/app/game.start` publishes `GAME_STARTED` followed by a `GAME_ACTION` event. Both messages are sent to `/topic/game/{gameId}`.
+
+```json
+{
+  "type": "GAME_STARTED",
+  "sender": "server",
+  "content": "Game 42 has started",
+  "payload": {
+    "game": {
+      "id": 42,
+      "status": "IN_PROGRESS",
+      "turnPhase": "ROLL_DICE"
+    },
+    "players": [],
+    "playerCards": {},
+    "playerLandmarks": {},
+    "marketplace": {},
+    "cardDefinitions": [],
+    "landmarkDefinitions": [],
+    "turnOrder": [10, 11],
+    "activePlayerId": 10,
+    "playerUsernames": {}
+  },
+  "timestamp": 1714000000000,
+  "gameId": 42
+}
+```
+
+The immediate `GAME_ACTION` uses the same state under `payload.state`:
+
+```json
+{
+  "type": "GAME_ACTION",
+  "sender": "server",
+  "payload": {
+    "event": "GAME_STARTED",
+    "turnPhase": "ROLL_DICE",
+    "activePlayerId": 10,
+    "state": {
+      "game": {
+        "id": 42,
+        "status": "IN_PROGRESS",
+        "turnPhase": "ROLL_DICE"
+      }
+    }
+  },
+  "gameId": 42
+}
+```
+
+### Purchase
+
+A successful purchase publishes a `GAME_ACTION` to `/topic/game/{gameId}`:
+
+```json
+{
+  "type": "GAME_ACTION",
+  "sender": "server",
+  "payload": {
+    "event": "PURCHASE_COMPLETED",
+    "turnPhase": "BUY_OR_BUILD",
+    "activePlayerId": 10,
+    "state": {
+      "game": {
+        "id": 42,
+        "status": "IN_PROGRESS",
+        "turnPhase": "BUY_OR_BUILD"
+      }
+    },
+    "purchaseType": "ESTABLISHMENT",
+    "cardType": "BAKERY"
+  },
+  "gameId": 42
+}
+```
+
+For landmark builds, the payload uses `landmarkType` instead of `cardType`.
+
+### Sync
+
+`/app/game.sync` publishes a private `SYNC` response consumed through `/user/queue/game-sync`:
+
+```json
+{
+  "type": "SYNC",
+  "sender": "server",
+  "content": "State sync for reconnecting player",
+  "payload": {
+    "targetUserId": 10,
+    "targetSessionId": "abc123",
+    "state": {
+      "game": {
+        "id": 42,
+        "status": "IN_PROGRESS",
+        "turnPhase": "ROLL_DICE"
+      },
+      "activePlayerId": 10,
+      "turnOrder": [10, 11],
+      "players": [],
+      "playerCards": {},
+      "playerLandmarks": {},
+      "marketplace": {}
+    }
+  },
+  "gameId": 42
+}
+```
+
+### Errors
+
+Purchase rejections are broadcast on `/topic/game/{gameId}` so every subscribed client can clear pending purchase UI consistently:
 
 ```json
 {
@@ -102,21 +291,42 @@ For example, buying the same purple establishment twice produces:
 }
 ```
 
-For rejected landmark purchases the payload uses `landmarkType` instead of `cardType`.
+Handler exceptions are private user-queue errors on `/user/queue/errors`:
+
+```json
+{
+  "code": "UNAUTHENTICATED",
+  "message": "Authenticated principal not found",
+  "timestamp": 1714000000000
+}
+```
+
+For rejected landmark purchases, the game-topic error payload uses `landmarkType` instead of `cardType`.
+
+## Turn Sequence
+
+The server enforces the active-player check for turn actions. Client turn controls should follow this sequence:
+
+1. Send `/app/game.rollDice`.
+2. Send `/app/game.resolveEffects`.
+3. Send `/app/game.advancePhase` when moving from income resolution to buy/build.
+4. Send `/app/game.purchase` at most once during `BUY_OR_BUILD`, unless the player skips buying.
+5. Send `/app/game.endTurn`.
+
+Income resolution applies Machi Koro card effects in server order: red cards, blue cards, green cards, then purple cards. Clients should not locally apply income as the source of truth; they should render the `GAME_ACTION` snapshot returned after `/app/game.resolveEffects`.
 
 ## Two-Player Synchronization Flow
 
 1. Player A and Player B connect to `/ws` or `/ws-sockjs` with `Authorization: Bearer <sessionToken>`.
 2. Player A subscribes to `/queue/lobby-user{sessionId}` and sends `/app/lobby.create`.
 3. Player A receives `LOBBY_CREATED` with `gameId` and `lobbyCode`.
-4. Both players subscribe to `/topic/game/{gameId}`.
+4. Both players subscribe to `/topic/game/{gameId}` and `/user/queue/errors`.
 5. Player B subscribes to `/queue/lobby-user{sessionId}` and sends `/app/lobby.join` with the lobby code.
 6. Player B receives `LOBBY_ROSTER` privately. Both players receive `LOBBY_JOINED` on `/topic/game/{gameId}`.
 7. Player A sends `/app/game.start`.
 8. Both players receive `GAME_STARTED` and the initial `GAME_ACTION` snapshot on `/topic/game/{gameId}`.
-9. During the game, the active player sends dice, effects, phase, purchase, and end-turn commands. Both players consume the resulting `ROLL_DICE`, `GAME_ACTION`, or `GAME_END` messages from `/topic/game/{gameId}` and replace their local state with the included `state` snapshot.
-
-Clients should treat the server snapshot as authoritative. Local UI state may optimistically display pending actions, but it must reconcile to the latest broadcast payload.
+9. During the game, the active player sends dice, effects, phase, purchase, and end-turn commands.
+10. Both players consume the resulting `ROLL_DICE`, `GAME_ACTION`, or `GAME_END` messages from `/topic/game/{gameId}` and replace local state with the included `state` snapshot.
 
 ## Reconnect and Explicit Sync
 
@@ -125,42 +335,21 @@ A reconnecting player must establish a new STOMP connection with the same authen
 ```text
 /topic/game/{gameId}
 /user/queue/game-sync
+/user/queue/errors
 ```
 
 Then the client sends:
 
-```json
+```text
 SEND /app/game.sync
-
-{
-  "gameId": 1
-}
 ```
-
-The server validates that the authenticated user belongs to the requested game and that the game is in progress. On success, it publishes:
 
 ```json
 {
-  "type": "SYNC",
-  "sender": "server",
-  "content": "State sync for reconnecting player",
-  "payload": {
-    "targetUserId": 10,
-    "targetSessionId": "abc123",
-    "state": {
-      "game": {
-        "id": 1,
-        "status": "IN_PROGRESS",
-        "turnPhase": "ROLL_DICE"
-      },
-      "activePlayerId": 10,
-      "turnOrder": [10, 11],
-      "players": [],
-      "marketplace": []
-    }
-  },
-  "gameId": 1
+  "gameId": 42
 }
 ```
 
-If `gameId` is omitted, the server attempts to find the authenticated user's active in-progress game. Unauthorized or inactive sync requests are rejected without broadcasting state to other players.
+The server validates that the authenticated user belongs to the requested game and that the game is in progress. On success, it publishes a private `SYNC` message to the reconnecting session. Unauthorized or inactive sync requests are rejected without broadcasting state to other players.
+
+`/app/chat.addUser` may also trigger a sync when the reconnecting user has an active in-progress game, but clients should still support explicit `/app/game.sync` because it is deterministic and does not depend on chat registration.


### PR DESCRIPTION
## Summary
- Polishes the backend WebSocket/STOMP protocol documentation for issue SE2-Machi-Koro/docs#23.
- Adds a reviewer-facing backend networking demo checklist.
- Clarifies reconnect, restart recovery, error routing, health, and deployment validation steps.
- Corrects stale game-state broadcast wording so `/topic/public` is documented as chat-only and `/topic/game/{gameId}` as the game-state channel.

## Changes
- Expanded `docs/websocket-game-protocol.md` with:
  - WebSocket endpoints and STOMP destinations.
  - Game, lobby, sync, and error subscriptions.
  - Request payload examples for start, purchase, sync, and errors.
  - Turn sequence and reconnect behavior.
- Added `docs/backend-networking-demo-checklist.md` for demo/reviewer validation.
- Updated `docs/backend-restart-recovery.md` with explicit reconnect subscriptions.
- Updated `README.md` links and deployment wording to match the current GHCR + SSH deploy workflow.

## Related Issue
Closes SE2-Machi-Koro/docs#23
Part of SE2-Machi-Koro/docs#22