### PR TITLE
331 fix broadcast lobby roster after filllobby so host sees dummy players

### DIFF
--- a/src/main/kotlin/org/machikoro/server/service/DebugService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/DebugService.kt
@@ -2,6 +2,7 @@ package org.machikoro.server.service
 
 import org.machikoro.server.dao.UserDao
 import org.machikoro.server.dto.DebugSeedResponse
+import org.machikoro.server.dto.LobbyRosterDto
 import org.machikoro.server.dto.LoginResponse
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.WebSocketMessage
@@ -51,6 +52,8 @@ class DebugService(
      * Adds up to 3 dummy players to an existing lobby identified by [lobbyCode].
      * Broadcasts a LOBBY_JOINED WebSocket message for each added player so the
      * real client's lobby screen updates in real time.
+     * After all dummies are added, broadcasts a full LOBBY_ROSTER so all clients
+     * (including the host) see the updated player list.
      */
     fun fillLobby(lobbyCode: String): List<LoginResponse> {
         val game = lobbyService.validateLobbyCode(lobbyCode)
@@ -87,6 +90,22 @@ class DebugService(
                 logger.debug("Skipped dummy '{}': {}", username, e.message)
             }
         }
+
+        // Broadcast full roster so all clients (including host) see the updated player list
+        if (added.isNotEmpty()) {
+            val roster = lobbyService.getLobbyRoster(game.id)
+            messagingTemplate.convertAndSend(
+                "/topic/game/${game.id}",
+                WebSocketMessage(
+                    type = MessageType.LOBBY_ROSTER,
+                    sender = "SERVER",
+                    content = "Lobby roster",
+                    gameId = game.id,
+                    payload = LobbyRosterDto(players = roster)
+                )
+            )
+        }
+
         return added
     }
 

--- a/src/test/kotlin/org/machikoro/server/service/DebugServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/DebugServiceTest.kt
@@ -72,6 +72,9 @@ class DebugServiceTest {
         activePlayerId = 1,
     )
 
+    private fun rosterPlayer(playerId: Int, userId: Int, username: String, gameId: Int) =
+        LobbyRosterPlayerDto(playerId = playerId, userId = userId, username = username, gameId = gameId, turnOrder = 0, coins = 3)
+
     // Stubs userDao so ensureUser will create a new user
     private fun stubNewUser(username: String, userId: Int) {
         whenever(userDao.findByUsername(username)).thenReturn(null)
@@ -155,6 +158,14 @@ class DebugServiceTest {
         stubNewUser("debug_player4", 4)
         whenever(passwordEncoder.encode(any())).thenReturn("hash")
         whenever(lobbyService.addUserToLobby(eq(5), any())).thenReturn(player(1, gameId = 5))
+        whenever(lobbyService.getLobbyRoster(5)).thenReturn(
+            listOf(
+                rosterPlayer(1, 1, "lea2", 5),
+                rosterPlayer(2, 2, "debug_player2", 5),
+                rosterPlayer(3, 3, "debug_player3", 5),
+                rosterPlayer(4, 4, "debug_player4", 5),
+            )
+        )
 
         val result = service.fillLobby("ABC123")
 
@@ -162,7 +173,8 @@ class DebugServiceTest {
         assertEquals("debug_player2", result[0].username)
         assertEquals("debug_player4", result[2].username)
         verify(lobbyService, times(3)).addUserToLobby(eq(5), any())
-        verify(messagingTemplate, times(3)).convertAndSend(eq("/topic/game/5"), any<Any>())
+        // 3x LOBBY_JOINED + 1x LOBBY_ROSTER = 4 total
+        verify(messagingTemplate, times(4)).convertAndSend(eq("/topic/game/5"), any<Any>())
     }
 
     @Test
@@ -175,12 +187,19 @@ class DebugServiceTest {
         // First dummy joins successfully, second fills the lobby
         whenever(lobbyService.addUserToLobby(eq(5), eq(2))).thenReturn(player(2, gameId = 5, userId = 2))
         whenever(lobbyService.addUserToLobby(eq(5), eq(3))).thenThrow(LobbyFullException("Lobby full"))
+        whenever(lobbyService.getLobbyRoster(5)).thenReturn(
+            listOf(
+                rosterPlayer(1, 1, "lea2", 5),
+                rosterPlayer(2, 2, "debug_player2", 5),
+            )
+        )
 
         val result = service.fillLobby("ABC123")
 
         assertEquals(1, result.size)
         assertEquals("debug_player2", result[0].username)
-        verify(messagingTemplate, times(1)).convertAndSend(eq("/topic/game/5"), any<Any>())
+        // 1x LOBBY_JOINED + 1x LOBBY_ROSTER = 2 total
+        verify(messagingTemplate, times(2)).convertAndSend(eq("/topic/game/5"), any<Any>())
     }
 
     @Test
@@ -209,14 +228,21 @@ class DebugServiceTest {
         whenever(lobbyService.addUserToLobby(eq(5), eq(2))).thenThrow(GameStartedException("Race condition"))
         whenever(lobbyService.addUserToLobby(eq(5), eq(3))).thenReturn(player(3, gameId = 5, userId = 3))
         whenever(lobbyService.addUserToLobby(eq(5), eq(4))).thenReturn(player(4, gameId = 5, userId = 4))
+        whenever(lobbyService.getLobbyRoster(5)).thenReturn(
+            listOf(
+                rosterPlayer(1, 1, "lea2", 5),
+                rosterPlayer(3, 3, "debug_player3", 5),
+                rosterPlayer(4, 4, "debug_player4", 5),
+            )
+        )
 
         val result = service.fillLobby("ABC123")
 
         assertEquals(2, result.size)
         assertEquals("debug_player3", result[0].username)
         assertEquals("debug_player4", result[1].username)
-        // Only 2 broadcasts — skipped dummy must not get one
-        verify(messagingTemplate, times(2)).convertAndSend(eq("/topic/game/5"), any<Any>())
+        // 2x LOBBY_JOINED + 1x LOBBY_ROSTER = 3 total
+        verify(messagingTemplate, times(3)).convertAndSend(eq("/topic/game/5"), any<Any>())
     }
 
     @Test


### PR DESCRIPTION
## Problem
When the host pressed [Debug] Fill with dummies, the dummy players were 
added successfully but the host's lobby screen stayed empty because no 
LOBBY_ROSTER update was sent after the fill.

## Root Cause
DebugService.fillLobby() only broadcast LOBBY_JOINED per dummy player. 
The host never receives these as a roster update.

## Fix
After all dummies are added, broadcast a full LOBBY_ROSTER message to 
/topic/game/{gameId} so all connected clients (including the host) 
receive the complete updated player list.

## Changes
- `src/main/kotlin/org/machikoro/server/service/DebugService.kt`
- `src/test/kotlin/org/machikoro/server/service/DebugServiceTest.kt`

## Testing
All tests pass ✅

## Note
⚠️ After merging, a new Docker image needs to be built and deployed.
Please merge as soon as possible so the CI/CD pipeline can build the 
new image and the fix can be tested on the server.

After merge, run on the server:
docker compose pull
docker compose up -d