### PR TITLE
Feat/334 add admin accounts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,4 @@ PGADMIN_PASSWORD=admin
 
 #Debugging
 DEBUG_ENABLED=true
+ADMIN_PASSWORD=adminacc

--- a/src/main/kotlin/org/machikoro/server/controller/DebugController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/DebugController.kt
@@ -5,13 +5,17 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.machikoro.server.dto.DebugSeedResponse
 import org.machikoro.server.dto.FillLobbyRequest
 import org.machikoro.server.dto.LoginResponse
+import org.machikoro.server.exception.InvalidSessionTokenException
+import org.machikoro.server.exception.NotAdminException
 import org.machikoro.server.service.DebugService
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -25,11 +29,16 @@ class DebugController(private val debugService: DebugService) {
 
     @PostMapping("/seed")
     @Operation(summary = "Seed a ready-to-play debug game with four dummy players and return their session tokens")
-    fun seed(): ResponseEntity<DebugSeedResponse> {
+    fun seed(@RequestHeader("Authorization", required = false) authHeader: String?): ResponseEntity<DebugSeedResponse> {
         return try {
+            debugService.validateAdmin(authHeader)
             val result = debugService.seed()
             logger.info("Debug seed completed for game {}", result.gameState.game.id)
             ResponseEntity.ok(result)
+        } catch (e: InvalidSessionTokenException) {
+            ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+        } catch (e: NotAdminException) {
+            ResponseEntity.status(HttpStatus.FORBIDDEN).build()
         } catch (e: Exception) {
             logger.error("Debug seed failed: {}", e.message)
             ResponseEntity.internalServerError().build()
@@ -37,12 +46,17 @@ class DebugController(private val debugService: DebugService) {
     }
 
     @DeleteMapping("/purge")
-    @Operation(summary = "Delete all games and players from the database")
-    fun purge(): ResponseEntity<Map<String, Int>> {
+    @Operation(summary = "Delete all games and players from the database — requires admin session token")
+    fun purge(@RequestHeader("Authorization", required = false) authHeader: String?): ResponseEntity<Map<String, Int>> {
         return try {
+            debugService.validateAdmin(authHeader)
             val deleted = debugService.purgeGames()
             logger.info("Debug purge deleted {} games", deleted)
             ResponseEntity.ok(mapOf("deletedGames" to deleted))
+        } catch (e: InvalidSessionTokenException) {
+            ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+        } catch (e: NotAdminException) {
+            ResponseEntity.status(HttpStatus.FORBIDDEN).build()
         } catch (e: Exception) {
             logger.error("Debug purge failed: {}", e.message)
             ResponseEntity.internalServerError().build()
@@ -51,11 +65,19 @@ class DebugController(private val debugService: DebugService) {
 
     @PostMapping("/fill-lobby")
     @Operation(summary = "Fill an existing lobby with dummy players (up to 3) and broadcast LOBBY_JOINED events")
-    fun fillLobby(@RequestBody request: FillLobbyRequest): ResponseEntity<List<LoginResponse>> {
+    fun fillLobby(
+        @RequestHeader("Authorization", required = false) authHeader: String?,
+        @RequestBody request: FillLobbyRequest,
+    ): ResponseEntity<List<LoginResponse>> {
         return try {
+            debugService.validateAdmin(authHeader)
             val added = debugService.fillLobby(request.lobbyCode)
             logger.info("Filled lobby '{}' with {} dummy players", request.lobbyCode, added.size)
             ResponseEntity.ok(added)
+        } catch (e: InvalidSessionTokenException) {
+            ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+        } catch (e: NotAdminException) {
+            ResponseEntity.status(HttpStatus.FORBIDDEN).build()
         } catch (e: Exception) {
             logger.error("Fill lobby failed for '{}': {}", request.lobbyCode, e.message)
             ResponseEntity.internalServerError().build()
@@ -64,11 +86,19 @@ class DebugController(private val debugService: DebugService) {
 
     @PostMapping("/reset-lobby")
     @Operation(summary = "Remove all dummy players from a lobby and broadcast LOBBY_LEFT events")
-    fun resetLobby(@RequestBody request: FillLobbyRequest): ResponseEntity<Map<String, Int>> {
+    fun resetLobby(
+        @RequestHeader("Authorization", required = false) authHeader: String?,
+        @RequestBody request: FillLobbyRequest,
+    ): ResponseEntity<Map<String, Int>> {
         return try {
+            debugService.validateAdmin(authHeader)
             val removed = debugService.resetLobby(request.lobbyCode)
             logger.info("Reset lobby '{}': removed {} dummy players", request.lobbyCode, removed)
             ResponseEntity.ok(mapOf("removedPlayers" to removed))
+        } catch (e: InvalidSessionTokenException) {
+            ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+        } catch (e: NotAdminException) {
+            ResponseEntity.status(HttpStatus.FORBIDDEN).build()
         } catch (e: Exception) {
             logger.error("Reset lobby failed for '{}': {}", request.lobbyCode, e.message)
             ResponseEntity.internalServerError().build()

--- a/src/main/kotlin/org/machikoro/server/dao/UserDao.kt
+++ b/src/main/kotlin/org/machikoro/server/dao/UserDao.kt
@@ -23,7 +23,8 @@ class UserDao {
         passwordHash = this[Users.passwordHash],
         sessionToken = this[Users.sessionToken],
         totalWins = this[Users.totalWins],
-        totalGamesPlayed = this[Users.totalGamesPlayed]
+        totalGamesPlayed = this[Users.totalGamesPlayed],
+        isAdmin = this[Users.isAdmin],
     )
 
     /**
@@ -64,13 +65,14 @@ class UserDao {
      * passwordHash is optional so existing fixtures keep working;
      * once registration is in place every real user will have one.
      */
-    fun create(username: String, passwordHash: String? = null): Int = transaction {
+    fun create(username: String, passwordHash: String? = null, isAdmin: Boolean = false): Int = transaction {
         Users.insertAndGetId {
             it[Users.username] = username
             it[Users.passwordHash] = passwordHash
             it[Users.sessionToken] = null
             it[Users.totalWins] = 0
             it[Users.totalGamesPlayed] = 0
+            it[Users.isAdmin] = isAdmin
         }.value
     }
 

--- a/src/main/kotlin/org/machikoro/server/database/AdminSeeder.kt
+++ b/src/main/kotlin/org/machikoro/server/database/AdminSeeder.kt
@@ -33,19 +33,12 @@ class AdminSeeder(
         }
 
         ADMIN_USERNAMES.forEach { username ->
-            val existing = userDao.findByUsername(username)
-            when {
-                existing == null -> {
-                    val hash = passwordEncoder.encode(adminPassword)
-                    userDao.create(username, hash, isAdmin = true)
-                    logger.info("Created admin user '{}'", username)
-                }
-                !existing.isAdmin -> {
-                    // Upgrade if somehow the account exists without the flag
-                    userDao.setAdmin(existing.id, true)
-                    logger.info("Upgraded '{}' to admin", username)
-                }
-                else -> logger.debug("Admin user '{}' already exists", username)
+            if (userDao.findByUsername(username) == null) {
+                val hash = passwordEncoder.encode(adminPassword)
+                userDao.create(username, hash, isAdmin = true)
+                logger.info("Created admin user '{}'", username)
+            } else {
+                logger.debug("Admin user '{}' already exists", username)
             }
         }
     }

--- a/src/main/kotlin/org/machikoro/server/database/AdminSeeder.kt
+++ b/src/main/kotlin/org/machikoro/server/database/AdminSeeder.kt
@@ -1,0 +1,52 @@
+package org.machikoro.server.database
+
+import org.machikoro.server.dao.UserDao
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.CommandLineRunner
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.core.annotation.Order
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Component
+
+// Seeds 4 admin accounts at startup — only runs when debug.enabled=true
+@Component
+@Order(3)
+@ConditionalOnProperty(name = ["debug.enabled"], havingValue = "true")
+class AdminSeeder(
+    private val userDao: UserDao,
+    private val passwordEncoder: PasswordEncoder,
+    // Falls back to blank so missing env var logs a warning instead of crashing
+    @Value("\${admin.password:}") private val adminPassword: String,
+) : CommandLineRunner {
+
+    private val logger = LoggerFactory.getLogger(AdminSeeder::class.java)
+
+    companion object {
+        val ADMIN_USERNAMES = listOf("admin_1", "admin_2", "admin_3", "admin_4")
+    }
+
+    override fun run(vararg args: String) {
+        if (adminPassword.isBlank()) {
+            logger.warn("ADMIN_PASSWORD not set — skipping admin account seeding")
+            return
+        }
+
+        ADMIN_USERNAMES.forEach { username ->
+            val existing = userDao.findByUsername(username)
+            when {
+                existing == null -> {
+                    val hash = passwordEncoder.encode(adminPassword)
+                    userDao.create(username, hash, isAdmin = true)
+                    logger.info("Created admin user '{}'", username)
+                }
+                !existing.isAdmin -> {
+                    // Upgrade if somehow the account exists without the flag
+                    userDao.setAdmin(existing.id, true)
+                    logger.info("Upgraded '{}' to admin", username)
+                }
+                else -> logger.debug("Admin user '{}' already exists", username)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/machikoro/server/database/Tables.kt
+++ b/src/main/kotlin/org/machikoro/server/database/Tables.kt
@@ -78,6 +78,8 @@ object Users : IntIdTable("users") {
     val sessionToken = varchar("session_token", 255).nullable().uniqueIndex()
     val totalWins = integer("total_wins").default(0)
     val totalGamesPlayed = integer("total_games_played").default(0)
+    // Admin flag gates access to debug endpoints
+    val isAdmin = bool("is_admin").default(false)
 }
 
 /**

--- a/src/main/kotlin/org/machikoro/server/domain/models/UserModel.kt
+++ b/src/main/kotlin/org/machikoro/server/domain/models/UserModel.kt
@@ -10,5 +10,7 @@ data class UserModel(
     @field:JsonIgnore
     val sessionToken: String?,
     val totalWins: Int,
-    val totalGamesPlayed: Int
+    val totalGamesPlayed: Int,
+    @field:JsonIgnore
+    val isAdmin: Boolean,
 )

--- a/src/main/kotlin/org/machikoro/server/exception/NotAdminException.kt
+++ b/src/main/kotlin/org/machikoro/server/exception/NotAdminException.kt
@@ -1,0 +1,3 @@
+package org.machikoro.server.exception
+
+class NotAdminException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/org/machikoro/server/service/DebugService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/DebugService.kt
@@ -5,7 +5,9 @@ import org.machikoro.server.dto.DebugSeedResponse
 import org.machikoro.server.dto.LoginResponse
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.WebSocketMessage
+import org.machikoro.server.exception.InvalidSessionTokenException
 import org.machikoro.server.exception.LobbyFullException
+import org.machikoro.server.exception.NotAdminException
 import org.slf4j.LoggerFactory
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -115,6 +117,15 @@ class DebugService(
         // Delete debug users so they get fresh IDs (and names reset to debug_player1 etc.) next fill
         userDao.deleteByUsernamePrefix(LobbyService.DEBUG_USER_PREFIX)
         return deleted
+    }
+
+    // Throws 401 if token is missing/invalid, 403 if user is not an admin
+    fun validateAdmin(authHeader: String?) {
+        val token = authHeader?.removePrefix("Bearer ")?.trim()
+            ?: throw InvalidSessionTokenException("Missing Authorization header")
+        val user = userDao.findBySessionToken(token)
+            ?: throw InvalidSessionTokenException("Invalid session token")
+        if (!user.isAdmin) throw NotAdminException("Admin access required")
     }
 
     // Creates the user if absent, then issues a fresh session token

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,6 +13,8 @@ websocket.allowed-origins=${WEBSOCKET_ALLOWED_ORIGINS:http://localhost:8080,http
 machikoro.db.init.enabled=true
 # Enable debug endpoints via env var — off by default for safety
 debug.enabled=${DEBUG_ENABLED:false}
+# Password for the 4 seeded admin accounts — required when debug.enabled=true
+admin.password=${ADMIN_PASSWORD:}
 
 spring.datasource.url=jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:machikoro}
 spring.datasource.username=${DB_USERNAME:}

--- a/src/main/resources/db/migration/V2__add_is_admin_to_users.sql
+++ b/src/main/resources/db/migration/V2__add_is_admin_to_users.sql
@@ -1,0 +1,2 @@
+-- Add is_admin column to gate debug endpoint access to admin accounts only
+ALTER TABLE users ADD COLUMN is_admin BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/test/kotlin/org/machikoro/server/auth/StompAuthChannelInterceptorTest.kt
+++ b/src/test/kotlin/org/machikoro/server/auth/StompAuthChannelInterceptorTest.kt
@@ -196,5 +196,6 @@ class StompAuthChannelInterceptorTest {
         sessionToken = sessionToken,
         totalWins = 0,
         totalGamesPlayed = 0,
+        isAdmin = false,
     )
 }

--- a/src/test/kotlin/org/machikoro/server/controller/DebugControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/DebugControllerTest.kt
@@ -11,7 +11,10 @@ import org.machikoro.server.dto.FillLobbyRequest
 import org.machikoro.server.dto.GameStateDto
 import org.machikoro.server.dto.LoginResponse
 import org.machikoro.server.exception.GameNotFoundException
+import org.machikoro.server.exception.InvalidSessionTokenException
+import org.machikoro.server.exception.NotAdminException
 import org.machikoro.server.service.DebugService
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
@@ -172,5 +175,63 @@ class DebugControllerTest {
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.statusCode)
         assertNull(response.body)
+    }
+
+    // === Admin auth — 401 / 403 across all endpoints ===
+
+    @Test
+    fun `seed returns 401 when session token is invalid`() {
+        whenever(debugService.validateAdmin(any())).thenThrow(InvalidSessionTokenException("bad token"))
+
+        assertEquals(HttpStatus.UNAUTHORIZED, controller.seed("Bearer bad").statusCode)
+    }
+
+    @Test
+    fun `seed returns 403 when user is not admin`() {
+        whenever(debugService.validateAdmin(any())).thenThrow(NotAdminException("not admin"))
+
+        assertEquals(HttpStatus.FORBIDDEN, controller.seed("Bearer token").statusCode)
+    }
+
+    @Test
+    fun `purge returns 401 when session token is invalid`() {
+        whenever(debugService.validateAdmin(any())).thenThrow(InvalidSessionTokenException("bad token"))
+
+        assertEquals(HttpStatus.UNAUTHORIZED, controller.purge("Bearer bad").statusCode)
+    }
+
+    @Test
+    fun `purge returns 403 when user is not admin`() {
+        whenever(debugService.validateAdmin(any())).thenThrow(NotAdminException("not admin"))
+
+        assertEquals(HttpStatus.FORBIDDEN, controller.purge("Bearer token").statusCode)
+    }
+
+    @Test
+    fun `fillLobby returns 401 when session token is invalid`() {
+        whenever(debugService.validateAdmin(any())).thenThrow(InvalidSessionTokenException("bad token"))
+
+        assertEquals(HttpStatus.UNAUTHORIZED, controller.fillLobby("Bearer bad", FillLobbyRequest("X")).statusCode)
+    }
+
+    @Test
+    fun `fillLobby returns 403 when user is not admin`() {
+        whenever(debugService.validateAdmin(any())).thenThrow(NotAdminException("not admin"))
+
+        assertEquals(HttpStatus.FORBIDDEN, controller.fillLobby("Bearer token", FillLobbyRequest("X")).statusCode)
+    }
+
+    @Test
+    fun `resetLobby returns 401 when session token is invalid`() {
+        whenever(debugService.validateAdmin(any())).thenThrow(InvalidSessionTokenException("bad token"))
+
+        assertEquals(HttpStatus.UNAUTHORIZED, controller.resetLobby("Bearer bad", FillLobbyRequest("X")).statusCode)
+    }
+
+    @Test
+    fun `resetLobby returns 403 when user is not admin`() {
+        whenever(debugService.validateAdmin(any())).thenThrow(NotAdminException("not admin"))
+
+        assertEquals(HttpStatus.FORBIDDEN, controller.resetLobby("Bearer token", FillLobbyRequest("X")).statusCode)
     }
 }

--- a/src/test/kotlin/org/machikoro/server/controller/DebugControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/DebugControllerTest.kt
@@ -62,7 +62,7 @@ class DebugControllerTest {
         val seedResponse = DebugSeedResponse(gameState = gameStateDto(), players = players)
         whenever(debugService.seed()).thenReturn(seedResponse)
 
-        val response = controller.seed()
+        val response = controller.seed("Bearer admin-token")
 
         assertEquals(HttpStatus.OK, response.statusCode)
         assertEquals(seedResponse, response.body)
@@ -73,7 +73,7 @@ class DebugControllerTest {
     fun `seed returns 500 when service throws`() {
         whenever(debugService.seed()).thenThrow(RuntimeException("DB unavailable"))
 
-        val response = controller.seed()
+        val response = controller.seed("Bearer admin-token")
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.statusCode)
         assertNull(response.body)
@@ -87,7 +87,7 @@ class DebugControllerTest {
         val added = listOf(loginResponse("debug_player2", 2), loginResponse("debug_player3", 3))
         whenever(debugService.fillLobby("ABC123")).thenReturn(added)
 
-        val response = controller.fillLobby(request)
+        val response = controller.fillLobby("Bearer admin-token", request)
 
         assertEquals(HttpStatus.OK, response.statusCode)
         assertEquals(added, response.body)
@@ -100,7 +100,7 @@ class DebugControllerTest {
         val request = FillLobbyRequest(lobbyCode = "FULL99")
         whenever(debugService.fillLobby("FULL99")).thenReturn(emptyList())
 
-        val response = controller.fillLobby(request)
+        val response = controller.fillLobby("Bearer admin-token", request)
 
         assertEquals(HttpStatus.OK, response.statusCode)
         assertEquals(emptyList<LoginResponse>(), response.body)
@@ -111,7 +111,7 @@ class DebugControllerTest {
         val request = FillLobbyRequest(lobbyCode = "NOPE")
         whenever(debugService.fillLobby("NOPE")).thenThrow(GameNotFoundException("Lobby not found"))
 
-        val response = controller.fillLobby(request)
+        val response = controller.fillLobby("Bearer admin-token", request)
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.statusCode)
         assertNull(response.body)
@@ -122,7 +122,7 @@ class DebugControllerTest {
         val request = FillLobbyRequest(lobbyCode = "ABC123")
         whenever(debugService.fillLobby("ABC123")).thenThrow(RuntimeException("Unexpected"))
 
-        val response = controller.fillLobby(request)
+        val response = controller.fillLobby("Bearer admin-token", request)
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.statusCode)
         assertNull(response.body)
@@ -134,7 +134,7 @@ class DebugControllerTest {
     fun `purge returns 200 OK with deleted game count`() {
         whenever(debugService.purgeGames()).thenReturn(5)
 
-        val response = controller.purge()
+        val response = controller.purge("Bearer admin-token")
 
         assertEquals(HttpStatus.OK, response.statusCode)
         assertEquals(mapOf("deletedGames" to 5), response.body)
@@ -144,7 +144,7 @@ class DebugControllerTest {
     fun `purge returns 500 when service throws`() {
         whenever(debugService.purgeGames()).thenThrow(RuntimeException("DB error"))
 
-        val response = controller.purge()
+        val response = controller.purge("Bearer admin-token")
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.statusCode)
         assertNull(response.body)
@@ -157,7 +157,7 @@ class DebugControllerTest {
         val request = FillLobbyRequest(lobbyCode = "ABC123")
         whenever(debugService.resetLobby("ABC123")).thenReturn(2)
 
-        val response = controller.resetLobby(request)
+        val response = controller.resetLobby("Bearer admin-token", request)
 
         assertEquals(HttpStatus.OK, response.statusCode)
         assertEquals(mapOf("removedPlayers" to 2), response.body)
@@ -168,7 +168,7 @@ class DebugControllerTest {
         val request = FillLobbyRequest(lobbyCode = "NOPE")
         whenever(debugService.resetLobby("NOPE")).thenThrow(GameNotFoundException("not found"))
 
-        val response = controller.resetLobby(request)
+        val response = controller.resetLobby("Bearer admin-token", request)
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.statusCode)
         assertNull(response.body)

--- a/src/test/kotlin/org/machikoro/server/controller/GameWebSocketBroadcastIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/GameWebSocketBroadcastIntegrationTest.kt
@@ -459,6 +459,7 @@ class GameWebSocketBroadcastIntegrationTest {
             sessionToken = login.sessionToken,
             totalWins = 0,
             totalGamesPlayed = 0,
+            isAdmin = false,
         )
 
     private fun game(

--- a/src/test/kotlin/org/machikoro/server/controller/LeaderboardControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/LeaderboardControllerTest.kt
@@ -22,6 +22,7 @@ class LeaderboardControllerTest {
         sessionToken = null,
         totalWins = wins,
         totalGamesPlayed = played,
+        isAdmin = false,
     )
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/dao/UserDaoTest.kt
+++ b/src/test/kotlin/org/machikoro/server/dao/UserDaoTest.kt
@@ -41,6 +41,18 @@ class UserDaoTest : AbstractDBSetup() {
     }
 
     @Test
+    fun `create defaults isAdmin to false`() {
+        val id = dao.create("robin")
+        assertFalse(dao.findById(id)!!.isAdmin)
+    }
+
+    @Test
+    fun `create with isAdmin true persists admin flag`() {
+        val id = dao.create("admin_1", isAdmin = true)
+        assertTrue(dao.findById(id)!!.isAdmin)
+    }
+
+    @Test
     fun `findById returns null for unknown id`() {
         assertNull(dao.findById(999))
     }

--- a/src/test/kotlin/org/machikoro/server/database/AdminSeederTest.kt
+++ b/src/test/kotlin/org/machikoro/server/database/AdminSeederTest.kt
@@ -1,0 +1,87 @@
+package org.machikoro.server.database
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+import org.machikoro.server.dao.UserDao
+import org.machikoro.server.domain.models.UserModel
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.security.crypto.password.PasswordEncoder
+
+class AdminSeederTest {
+
+    private val userDao = mock<UserDao>()
+    private val passwordEncoder = mock<PasswordEncoder>()
+
+    private fun adminUser(id: Int, username: String) = UserModel(
+        id = id,
+        username = username,
+        passwordHash = "hash",
+        sessionToken = null,
+        totalWins = 0,
+        totalGamesPlayed = 0,
+        isAdmin = true,
+    )
+
+    @Test
+    fun `run skips seeding when adminPassword is blank`() {
+        val seeder = AdminSeeder(userDao, passwordEncoder, "")
+
+        seeder.run()
+
+        verify(userDao, never()).findByUsername(any())
+        verify(userDao, never()).create(any(), any(), any())
+    }
+
+    @Test
+    fun `run creates all 4 admin accounts when they do not exist`() {
+        whenever(userDao.findByUsername(any())).thenReturn(null)
+        whenever(passwordEncoder.encode("secret")).thenReturn("hashed")
+        whenever(userDao.create(any(), any(), any())).thenReturn(1)
+
+        val seeder = AdminSeeder(userDao, passwordEncoder, "secret")
+        seeder.run()
+
+        // All 4 accounts created with isAdmin=true
+        verify(userDao, times(4)).create(any(), eq("hashed"), eq(true))
+    }
+
+    @Test
+    fun `run skips create when admin accounts already exist`() {
+        AdminSeeder.ADMIN_USERNAMES.forEachIndexed { i, name ->
+            whenever(userDao.findByUsername(name)).thenReturn(adminUser(i + 1, name))
+        }
+
+        val seeder = AdminSeeder(userDao, passwordEncoder, "secret")
+        seeder.run()
+
+        verify(userDao, never()).create(any(), any(), any())
+    }
+
+    @Test
+    fun `run creates only missing admin accounts when some already exist`() {
+        whenever(userDao.findByUsername("admin_1")).thenReturn(adminUser(1, "admin_1"))
+        whenever(userDao.findByUsername("admin_2")).thenReturn(null)
+        whenever(userDao.findByUsername("admin_3")).thenReturn(null)
+        whenever(userDao.findByUsername("admin_4")).thenReturn(adminUser(4, "admin_4"))
+        whenever(passwordEncoder.encode("secret")).thenReturn("hashed")
+        whenever(userDao.create(any(), any(), any())).thenReturn(1)
+
+        val seeder = AdminSeeder(userDao, passwordEncoder, "secret")
+        seeder.run()
+
+        // Only the 2 missing ones get created
+        verify(userDao, times(2)).create(any(), eq("hashed"), eq(true))
+    }
+
+    @Test
+    fun `ADMIN_USERNAMES contains exactly 4 entries`() {
+        assertFalse(AdminSeeder.ADMIN_USERNAMES.isEmpty())
+        assert(AdminSeeder.ADMIN_USERNAMES.size == 4)
+    }
+}

--- a/src/test/kotlin/org/machikoro/server/service/AuthServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/AuthServiceTest.kt
@@ -53,7 +53,7 @@ class AuthServiceTest {
         }
 
         verify(passwordEncoder, never()).encode(any())
-        verify(userDao, never()).create(any(), any())
+        verify(userDao, never()).create(any(), any(), any())
     }
 
     @Test
@@ -194,6 +194,7 @@ class AuthServiceTest {
         sessionToken = sessionToken,
         totalWins = 0,
         totalGamesPlayed = 0,
+        isAdmin = false,
     )
 
     companion object {

--- a/src/test/kotlin/org/machikoro/server/service/DebugServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/DebugServiceTest.kt
@@ -60,6 +60,7 @@ class DebugServiceTest {
         sessionToken = null,
         totalWins = 0,
         totalGamesPlayed = 0,
+        isAdmin = false,
     )
 
     private fun gameStateDto() = GameStateDto(
@@ -75,7 +76,7 @@ class DebugServiceTest {
     // Stubs userDao so ensureUser will create a new user
     private fun stubNewUser(username: String, userId: Int) {
         whenever(userDao.findByUsername(username)).thenReturn(null)
-        whenever(userDao.create(eq(username), any())).thenReturn(userId)
+        whenever(userDao.create(eq(username), any(), any())).thenReturn(userId)
     }
 
     // Stubs userDao so ensureUser will reuse an existing user
@@ -104,7 +105,7 @@ class DebugServiceTest {
         assertEquals("debug_player1", result.players[0].username)
         assertEquals("debug_player4", result.players[3].username)
         assertEquals(expectedState, result.gameState)
-        verify(userDao, times(4)).create(any(), any())
+        verify(userDao, times(4)).create(any(), any(), any())
         verify(lobbyService).createLobby(1)
         verify(lobbyService, times(4)).addUserToLobby(eq(10), any())
         verify(lobbyService).startGame(eq(10), isNull())
@@ -122,7 +123,7 @@ class DebugServiceTest {
 
         service.seed()
 
-        verify(userDao, never()).create(any(), any())
+        verify(userDao, never()).create(any(), any(), any())
         verify(passwordEncoder, never()).encode(any())
     }
 

--- a/src/test/kotlin/org/machikoro/server/service/DebugServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/DebugServiceTest.kt
@@ -2,6 +2,7 @@ package org.machikoro.server.service
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.machikoro.server.dao.UserDao
 import org.machikoro.server.domain.enums.GameStatus
@@ -13,7 +14,9 @@ import org.machikoro.server.dto.GameStateDto
 import org.machikoro.server.dto.LobbyRosterPlayerDto
 import org.machikoro.server.exception.GameNotFoundException
 import org.machikoro.server.exception.GameStartedException
+import org.machikoro.server.exception.InvalidSessionTokenException
 import org.machikoro.server.exception.LobbyFullException
+import org.machikoro.server.exception.NotAdminException
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
@@ -280,5 +283,41 @@ class DebugServiceTest {
         assertEquals(3, count)
         verify(lobbyService).purgeAllGames()
         verify(userDao).deleteByUsernamePrefix(LobbyService.DEBUG_USER_PREFIX)
+    }
+
+    // === validateAdmin() ===
+
+    @Test
+    fun `validateAdmin throws InvalidSessionTokenException when header is null`() {
+        assertThrows<InvalidSessionTokenException> {
+            service.validateAdmin(null)
+        }
+    }
+
+    @Test
+    fun `validateAdmin throws InvalidSessionTokenException when token not found in db`() {
+        whenever(userDao.findBySessionToken("bad")).thenReturn(null)
+
+        assertThrows<InvalidSessionTokenException> {
+            service.validateAdmin("Bearer bad")
+        }
+    }
+
+    @Test
+    fun `validateAdmin throws NotAdminException when user is not admin`() {
+        // userModel helper defaults isAdmin to false
+        whenever(userDao.findBySessionToken("token")).thenReturn(userModel(1, "alice"))
+
+        assertThrows<NotAdminException> {
+            service.validateAdmin("Bearer token")
+        }
+    }
+
+    @Test
+    fun `validateAdmin passes without throwing when user is admin`() {
+        val admin = userModel(1, "admin_1").copy(isAdmin = true)
+        whenever(userDao.findBySessionToken("token")).thenReturn(admin)
+
+        assertDoesNotThrow { service.validateAdmin("Bearer token") }
     }
 }


### PR DESCRIPTION
Added an isAdmin column to the UsersTable
Database gets seeded with 4 admin accounts now

Now only admin accounts can use the debug endpoints, since we currently get a 403 when using a debug endpoint on the uni server