### PR TITLE
feat: debug-only end-game endpoint (#305)

### DIFF
--- a/src/main/kotlin/org/machikoro/server/controller/DebugController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/DebugController.kt
@@ -138,8 +138,9 @@ class DebugController(
                 .body(DebugEndGameError("NOT_ADMIN", e.message ?: "Admin access required"))
         } catch (e: GameNotFoundException) {
             logger.warn("Debug end-game rejected: {}", e.message)
+            // GameNotFoundException extends CustomWebSocketException, whose message is non-null.
             ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(DebugEndGameError("GAME_NOT_FOUND", e.message ?: "Game not found"))
+                .body(DebugEndGameError("GAME_NOT_FOUND", e.message))
         } catch (e: NotInGameException) {
             logger.warn("Debug end-game rejected: {}", e.message)
             ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)

--- a/src/main/kotlin/org/machikoro/server/controller/DebugController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/DebugController.kt
@@ -2,9 +2,9 @@ package org.machikoro.server.controller
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.machikoro.server.dto.DebugEndGameError
 import org.machikoro.server.dto.DebugSeedResponse
 import org.machikoro.server.dto.EndGameRequest
-import org.machikoro.server.dto.EndTurnOutcome
 import org.machikoro.server.dto.FillLobbyRequest
 import org.machikoro.server.dto.LoginResponse
 import org.machikoro.server.exception.CustomWebSocketException
@@ -121,7 +121,7 @@ class DebugController(
     fun endGame(
         @RequestHeader("Authorization", required = false) authHeader: String?,
         @RequestBody request: EndGameRequest,
-    ): ResponseEntity<EndTurnOutcome.Won> {
+    ): ResponseEntity<Any> {
         return try {
             val caller = debugService.validateAdmin(authHeader)
             val outcome = debugService.endGame(request.gameId, caller)
@@ -131,22 +131,25 @@ class DebugController(
             logger.info("Debug end-game succeeded for game {}, winner player {}", request.gameId, outcome.winnerId)
             ResponseEntity.ok(outcome)
         } catch (e: InvalidSessionTokenException) {
-            ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+            ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(DebugEndGameError("UNAUTHENTICATED", e.message ?: "Missing or invalid session token"))
         } catch (e: NotAdminException) {
-            ResponseEntity.status(HttpStatus.FORBIDDEN).build()
+            ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(DebugEndGameError("NOT_ADMIN", e.message ?: "Admin access required"))
         } catch (e: GameNotFoundException) {
             logger.warn("Debug end-game rejected: {}", e.message)
-            ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+            ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(DebugEndGameError("GAME_NOT_FOUND", e.message ?: "Game not found"))
         } catch (e: NotInGameException) {
             logger.warn("Debug end-game rejected: {}", e.message)
-            ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).build()
+            ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(DebugEndGameError("NOT_IN_GAME", e.message ?: "Caller is not a player in the game"))
         } catch (e: CustomWebSocketException) {
             // GameStateGuard raises this for GAME_FINISHED / GAME_NOT_STARTED
             logger.warn("Debug end-game rejected [{}]: {}", e.errorCode, e.message)
-            ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).build()
-        } catch (e: Exception) {
-            logger.error("Debug end-game failed for game {}: {}", request.gameId, e.message)
-            ResponseEntity.internalServerError().build()
+            ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(DebugEndGameError(e.errorCode, e.message))
         }
+        // Any unexpected exception propagates to Spring's default 500 handler — no broad catch (#305 DoD).
     }
 }

--- a/src/main/kotlin/org/machikoro/server/controller/DebugController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/DebugController.kt
@@ -3,11 +3,18 @@ package org.machikoro.server.controller
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.machikoro.server.dto.DebugSeedResponse
+import org.machikoro.server.dto.EndGameRequest
+import org.machikoro.server.dto.EndTurnOutcome
 import org.machikoro.server.dto.FillLobbyRequest
 import org.machikoro.server.dto.LoginResponse
+import org.machikoro.server.exception.CustomWebSocketException
+import org.machikoro.server.exception.GameNotFoundException
 import org.machikoro.server.exception.InvalidSessionTokenException
 import org.machikoro.server.exception.NotAdminException
+import org.machikoro.server.exception.NotInGameException
 import org.machikoro.server.service.DebugService
+import org.machikoro.server.service.GameEndBroadcaster
+import org.machikoro.server.service.GamePhaseService
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.http.HttpStatus
@@ -24,7 +31,11 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/debug")
 @Tag(name = "Debug", description = "Development-only helpers for seeding test data")
 @ConditionalOnProperty(name = ["debug.enabled"], havingValue = "true")
-class DebugController(private val debugService: DebugService) {
+class DebugController(
+    private val debugService: DebugService,
+    private val gameEndBroadcaster: GameEndBroadcaster,
+    private val gamePhaseService: GamePhaseService,
+) {
     private val logger = LoggerFactory.getLogger(DebugController::class.java)
 
     @PostMapping("/seed")
@@ -101,6 +112,40 @@ class DebugController(private val debugService: DebugService) {
             ResponseEntity.status(HttpStatus.FORBIDDEN).build()
         } catch (e: Exception) {
             logger.error("Reset lobby failed for '{}': {}", request.lobbyCode, e.message)
+            ResponseEntity.internalServerError().build()
+        }
+    }
+
+    @PostMapping("/end-game")
+    @Operation(summary = "Force the current game to end with the caller as winner — admin only")
+    fun endGame(
+        @RequestHeader("Authorization", required = false) authHeader: String?,
+        @RequestBody request: EndGameRequest,
+    ): ResponseEntity<EndTurnOutcome.Won> {
+        return try {
+            val caller = debugService.validateAdmin(authHeader)
+            val outcome = debugService.endGame(request.gameId, caller)
+            // Broadcast GAME_END then clean up post-commit, mirroring GameController.endTurn's win handling.
+            gameEndBroadcaster.broadcast(request.gameId, outcome.winnerId, outcome.roundsPlayed)
+            gamePhaseService.cleanupFinishedGameData(request.gameId)
+            logger.info("Debug end-game succeeded for game {}, winner player {}", request.gameId, outcome.winnerId)
+            ResponseEntity.ok(outcome)
+        } catch (e: InvalidSessionTokenException) {
+            ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+        } catch (e: NotAdminException) {
+            ResponseEntity.status(HttpStatus.FORBIDDEN).build()
+        } catch (e: GameNotFoundException) {
+            logger.warn("Debug end-game rejected: {}", e.message)
+            ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+        } catch (e: NotInGameException) {
+            logger.warn("Debug end-game rejected: {}", e.message)
+            ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).build()
+        } catch (e: CustomWebSocketException) {
+            // GameStateGuard raises this for GAME_FINISHED / GAME_NOT_STARTED
+            logger.warn("Debug end-game rejected [{}]: {}", e.errorCode, e.message)
+            ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).build()
+        } catch (e: Exception) {
+            logger.error("Debug end-game failed for game {}: {}", request.gameId, e.message)
             ResponseEntity.internalServerError().build()
         }
     }

--- a/src/main/kotlin/org/machikoro/server/controller/GameController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/GameController.kt
@@ -16,6 +16,7 @@ import org.machikoro.server.exception.CustomWebSocketException
 import org.machikoro.server.exception.GameStartedException
 import org.machikoro.server.exception.NotHostException
 import org.machikoro.server.service.DiceService
+import org.machikoro.server.service.GameEndBroadcaster
 import org.machikoro.server.service.GamePhaseService
 import org.machikoro.server.service.GameSyncService
 import org.machikoro.server.service.GameStateGuard
@@ -42,6 +43,7 @@ class GameController(
     private val connectionTracker: WebSocketConnectionTracker,
     private val gameStateGuard: GameStateGuard,
     private val gameSyncService: GameSyncService,
+    private val gameEndBroadcaster: GameEndBroadcaster,
 ) {
     private val logger = LoggerFactory.getLogger(GameController::class.java)
 
@@ -272,7 +274,7 @@ class GameController(
             }
             is EndTurnOutcome.Won -> {
                 logger.info("Game ${request.gameId} finished, winner=${result.winnerId}")
-                broadcastWin(request.gameId, result.winnerId, result.roundsPlayed)
+                gameEndBroadcaster.broadcast(request.gameId, result.winnerId, result.roundsPlayed)
                 gamePhaseService.cleanupFinishedGameData(request.gameId)
             }
         }
@@ -407,23 +409,6 @@ class GameController(
                 sender = "server",
                 payload = payload,
                 gameId = request.gameId,
-            ),
-        )
-    }
-
-    private fun broadcastWin(gameId: Int, winnerId: Int, roundsPlayed: Int) {
-        val state = gameSyncService.buildSnapshot(gameId)
-        messagingTemplate.convertAndSend(
-            "/topic/game/$gameId",
-            WebSocketMessage(
-                type = MessageType.GAME_END,
-                sender = "server",
-                payload = mapOf(
-                    "winnerId" to winnerId,
-                    "roundsPlayed" to roundsPlayed,
-                    "state" to state,
-                ),
-                gameId = gameId,
             ),
         )
     }

--- a/src/main/kotlin/org/machikoro/server/dto/DebugEndGameError.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/DebugEndGameError.kt
@@ -1,0 +1,16 @@
+package org.machikoro.server.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * Structured 4xx error body returned by `POST /debug/end-game` when a request is
+ * rejected (debug only). Mirrors the WebSocket layer's error shape — a stable
+ * machine-readable [error] code plus a human-readable [message], never a raw null.
+ */
+@Schema(description = "Structured error returned by POST /debug/end-game when a request is rejected")
+data class DebugEndGameError(
+    @Schema(description = "Stable machine-readable error code", example = "NOT_IN_GAME")
+    val error: String,
+    @Schema(description = "Human-readable explanation of the rejection", example = "User alice is not a player in game 5")
+    val message: String,
+)

--- a/src/main/kotlin/org/machikoro/server/dto/EndGameRequest.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/EndGameRequest.kt
@@ -1,0 +1,9 @@
+package org.machikoro.server.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Request to force-end a running game with the caller as winner (debug only)")
+data class EndGameRequest(
+    @Schema(description = "ID of the game to end", example = "1")
+    val gameId: Int,
+)

--- a/src/main/kotlin/org/machikoro/server/exception/NotInGameException.kt
+++ b/src/main/kotlin/org/machikoro/server/exception/NotInGameException.kt
@@ -1,0 +1,8 @@
+package org.machikoro.server.exception
+
+/**
+ * Raised when an authenticated caller attempts a game action against a game
+ * they are not a player in. Distinct from `NotAdminException` (auth/permission)
+ * — this is a semantic precondition failure.
+ */
+class NotInGameException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/org/machikoro/server/service/DebugService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/DebugService.kt
@@ -1,9 +1,7 @@
 package org.machikoro.server.service
 
-import org.machikoro.server.dao.GameDao
 import org.machikoro.server.dao.PlayerDao
 import org.machikoro.server.dao.UserDao
-import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.models.UserModel
 import org.machikoro.server.dto.DebugSeedResponse
 import org.machikoro.server.dto.EndTurnOutcome
@@ -29,8 +27,8 @@ class DebugService(
     private val passwordEncoder: PasswordEncoder,
     private val messagingTemplate: SimpMessagingTemplate,
     private val gameStateGuard: GameStateGuard,
-    private val gameDao: GameDao,
     private val playerDao: PlayerDao,
+    private val gamePhaseService: GamePhaseService,
 ) {
     private val logger = LoggerFactory.getLogger(DebugService::class.java)
 
@@ -146,12 +144,12 @@ class DebugService(
      * the winner. Used by the `/debug/end-game` endpoint (#305) so testers can
      * reach the winner screen without playing through.
      *
-     * Mirrors `GamePhaseService.endTurn`'s win-handling side effects — stat
-     * increments + status transition — but bypasses `WinConditionService.detectWinner`
-     * so no landmarks are required. Like the production path, the mutations run in
-     * one transaction here, while broadcasting GAME_END and cleaning up the finished
-     * game are the controller's responsibility (mirroring `GameController.endTurn`),
-     * so they happen after this transaction commits.
+     * Delegates the win side effects to [GamePhaseService.finishGameWithWinner] —
+     * the same path the natural end-of-turn win uses — but bypasses
+     * `WinConditionService.detectWinner` so no landmarks are required. Like the
+     * production path the mutations run in one transaction here, while broadcasting
+     * GAME_END and cleaning up the finished game are the controller's responsibility
+     * (mirroring `GameController.endTurn`), so they happen after this commits.
      *
      * Throws:
      *  - `org.machikoro.server.exception.GameNotFoundException` via [gameStateGuard] when the game does not exist.
@@ -164,15 +162,13 @@ class DebugService(
         val callerPlayer = playerDao.findByGameIdAndUserId(gameId, caller.id)
             ?: throw NotInGameException("User ${caller.username} is not a player in game $gameId")
 
-        userDao.incrementWins(caller.id)
-        playerDao.getPlayers(gameId).forEach { userDao.incrementGamesPlayed(it.userId) }
-        gameDao.updateStatus(gameId, GameStatus.FINISHED)
+        val outcome = gamePhaseService.finishGameWithWinner(gameId, callerPlayer, game.roundNumber)
 
         logger.info(
             "Debug end-game forced winner: player {} (user '{}') in game {} (round {})",
             callerPlayer.id, caller.username, gameId, game.roundNumber,
         )
-        return EndTurnOutcome.Won(winnerId = callerPlayer.id, roundsPlayed = game.roundNumber)
+        return outcome
     }
 
     // Creates the user if absent, then issues a fresh session token

--- a/src/main/kotlin/org/machikoro/server/service/DebugService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/DebugService.kt
@@ -1,17 +1,24 @@
 package org.machikoro.server.service
 
+import org.machikoro.server.dao.GameDao
+import org.machikoro.server.dao.PlayerDao
 import org.machikoro.server.dao.UserDao
+import org.machikoro.server.domain.enums.GameStatus
+import org.machikoro.server.domain.models.UserModel
 import org.machikoro.server.dto.DebugSeedResponse
+import org.machikoro.server.dto.EndTurnOutcome
 import org.machikoro.server.dto.LoginResponse
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.WebSocketMessage
 import org.machikoro.server.exception.InvalidSessionTokenException
 import org.machikoro.server.exception.LobbyFullException
 import org.machikoro.server.exception.NotAdminException
+import org.machikoro.server.exception.NotInGameException
 import org.slf4j.LoggerFactory
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
 
 // Provisions dummy users, a shared lobby, and starts the game in one call
@@ -21,6 +28,9 @@ class DebugService(
     private val lobbyService: LobbyService,
     private val passwordEncoder: PasswordEncoder,
     private val messagingTemplate: SimpMessagingTemplate,
+    private val gameStateGuard: GameStateGuard,
+    private val gameDao: GameDao,
+    private val playerDao: PlayerDao,
 ) {
     private val logger = LoggerFactory.getLogger(DebugService::class.java)
 
@@ -119,13 +129,50 @@ class DebugService(
         return deleted
     }
 
-    // Throws 401 if token is missing/invalid, 403 if user is not an admin
-    fun validateAdmin(authHeader: String?) {
+    // Throws InvalidSessionTokenException (-> 401) if token is missing/invalid,
+    // NotAdminException (-> 403) if the user is not an admin. Returns the admin
+    // user so callers that already need the principal can avoid a second lookup.
+    fun validateAdmin(authHeader: String?): UserModel {
         val token = authHeader?.removePrefix("Bearer ")?.trim()
             ?: throw InvalidSessionTokenException("Missing Authorization header")
         val user = userDao.findBySessionToken(token)
             ?: throw InvalidSessionTokenException("Invalid session token")
         if (!user.isAdmin) throw NotAdminException("Admin access required")
+        return user
+    }
+
+    /**
+     * Force-ends the game [gameId] with the pre-authenticated admin [caller] as
+     * the winner. Used by the `/debug/end-game` endpoint (#305) so testers can
+     * reach the winner screen without playing through.
+     *
+     * Mirrors `GamePhaseService.endTurn`'s win-handling side effects — stat
+     * increments + status transition — but bypasses `WinConditionService.detectWinner`
+     * so no landmarks are required. Like the production path, the mutations run in
+     * one transaction here, while broadcasting GAME_END and cleaning up the finished
+     * game are the controller's responsibility (mirroring `GameController.endTurn`),
+     * so they happen after this transaction commits.
+     *
+     * Throws:
+     *  - `org.machikoro.server.exception.GameNotFoundException` via [gameStateGuard] when the game does not exist.
+     *  - `org.machikoro.server.exception.CustomWebSocketException` via [gameStateGuard] when the game is WAITING or FINISHED.
+     *  - `NotInGameException` if [caller] is not a player in [gameId].
+     */
+    @Transactional
+    fun endGame(gameId: Int, caller: UserModel): EndTurnOutcome.Won {
+        val game = gameStateGuard.ensureGameIsRunning(gameId)
+        val callerPlayer = playerDao.findByGameIdAndUserId(gameId, caller.id)
+            ?: throw NotInGameException("User ${caller.username} is not a player in game $gameId")
+
+        userDao.incrementWins(caller.id)
+        playerDao.getPlayers(gameId).forEach { userDao.incrementGamesPlayed(it.userId) }
+        gameDao.updateStatus(gameId, GameStatus.FINISHED)
+
+        logger.info(
+            "Debug end-game forced winner: player {} (user '{}') in game {} (round {})",
+            callerPlayer.id, caller.username, gameId, game.roundNumber,
+        )
+        return EndTurnOutcome.Won(winnerId = callerPlayer.id, roundsPlayed = game.roundNumber)
     }
 
     // Creates the user if absent, then issues a fresh session token

--- a/src/main/kotlin/org/machikoro/server/service/GameEndBroadcaster.kt
+++ b/src/main/kotlin/org/machikoro/server/service/GameEndBroadcaster.kt
@@ -1,0 +1,38 @@
+package org.machikoro.server.service
+
+import org.machikoro.server.dto.MessageType
+import org.machikoro.server.dto.WebSocketMessage
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.stereotype.Service
+
+/**
+ * Builds and broadcasts the `GAME_END` WebSocket message to `/topic/game/{gameId}`.
+ *
+ * Extracted so both the production end-of-game path (`GamePhaseService.endTurn`
+ * via `GameController.endTurn`) and the debug end-game endpoint
+ * (`DebugService.endGame`) emit the identical wire shape — same `MessageType`,
+ * same payload keys, same destination — so the client's winner-screen handler
+ * sees one consistent contract regardless of which path produced the end.
+ */
+@Service
+class GameEndBroadcaster(
+    private val gameSyncService: GameSyncService,
+    private val messagingTemplate: SimpMessagingTemplate,
+) {
+    fun broadcast(gameId: Int, winnerId: Int, roundsPlayed: Int) {
+        val state = gameSyncService.buildSnapshot(gameId)
+        messagingTemplate.convertAndSend(
+            "/topic/game/$gameId",
+            WebSocketMessage(
+                type = MessageType.GAME_END,
+                sender = "server",
+                payload = mapOf(
+                    "winnerId" to winnerId,
+                    "roundsPlayed" to roundsPlayed,
+                    "state" to state,
+                ),
+                gameId = gameId,
+            ),
+        )
+    }
+}

--- a/src/main/kotlin/org/machikoro/server/service/GamePhaseService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/GamePhaseService.kt
@@ -8,6 +8,7 @@ import org.machikoro.server.dao.PlayerLandmarkDao
 import org.machikoro.server.dao.UserDao
 import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.enums.TurnPhase
+import org.machikoro.server.domain.models.PlayerModel
 import org.machikoro.server.dto.EndTurnOutcome
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -55,14 +56,25 @@ class GamePhaseService(
         gameDao.updateTurnPhase(gameId, TurnPhase.END_TURN)
 
         winConditionService.detectWinner(gameId)?.let { winner ->
-            userDao.incrementWins(winner.userId)
-            playerDao.getPlayers(gameId).forEach { userDao.incrementGamesPlayed(it.userId) }
-            gameDao.updateStatus(gameId, GameStatus.FINISHED)
-            return EndTurnOutcome.Won(winner.id, game.roundNumber)
+            return finishGameWithWinner(gameId, winner, game.roundNumber)
         }
 
         val nextPhase = advanceTurn(gameId)
         return EndTurnOutcome.Continue(nextPhase)
+    }
+
+    /**
+     * Applies the shared end-of-game win side effects — records the win and
+     * games-played stats and transitions the game to FINISHED — and returns the
+     * [EndTurnOutcome.Won]. Reused by the natural [endTurn] win path and the
+     * debug end-game endpoint (#305) so both paths produce an identical result.
+     * Callers run inside their own transaction and own the GAME_END broadcast.
+     */
+    fun finishGameWithWinner(gameId: Int, winner: PlayerModel, roundNumber: Int): EndTurnOutcome.Won {
+        userDao.incrementWins(winner.userId)
+        playerDao.getPlayers(gameId).forEach { userDao.incrementGamesPlayed(it.userId) }
+        gameDao.updateStatus(gameId, GameStatus.FINISHED)
+        return EndTurnOutcome.Won(winner.id, roundNumber)
     }
 
     /** Advances a game to the next player's turn and persists it. */

--- a/src/test/kotlin/org/machikoro/server/controller/DebugControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/DebugControllerTest.kt
@@ -3,10 +3,12 @@ package org.machikoro.server.controller
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.enums.TurnPhase
 import org.machikoro.server.domain.models.GameModel
 import org.machikoro.server.domain.models.UserModel
+import org.machikoro.server.dto.DebugEndGameError
 import org.machikoro.server.dto.DebugSeedResponse
 import org.machikoro.server.dto.FillLobbyRequest
 import org.machikoro.server.dto.GameStateDto
@@ -324,39 +326,40 @@ class DebugControllerTest {
     }
 
     @Test
-    fun `endGame returns 422 when caller is not in the game`() {
+    fun `endGame returns 422 with structured error when caller is not in the game`() {
         whenever(debugService.validateAdmin(any())).thenReturn(adminUser())
         whenever(debugService.endGame(eq(7), any()))
             .thenThrow(NotInGameException("not a player"))
 
-        assertEquals(
-            HttpStatus.UNPROCESSABLE_ENTITY,
-            controller.endGame("Bearer admin-token", EndGameRequest(gameId = 7)).statusCode,
-        )
+        val response = controller.endGame("Bearer admin-token", EndGameRequest(gameId = 7))
+
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, response.statusCode)
+        assertEquals(DebugEndGameError("NOT_IN_GAME", "not a player"), response.body)
         verify(gameEndBroadcaster, never()).broadcast(any(), any(), any())
     }
 
     @Test
-    fun `endGame returns 422 when game state precondition fails`() {
+    fun `endGame returns 422 with structured error when game state precondition fails`() {
         whenever(debugService.validateAdmin(any())).thenReturn(adminUser())
         whenever(debugService.endGame(eq(7), any()))
             .thenThrow(CustomWebSocketException(errorCode = "GAME_FINISHED", message = "Game 7 has already ended"))
 
-        assertEquals(
-            HttpStatus.UNPROCESSABLE_ENTITY,
-            controller.endGame("Bearer admin-token", EndGameRequest(gameId = 7)).statusCode,
-        )
+        val response = controller.endGame("Bearer admin-token", EndGameRequest(gameId = 7))
+
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, response.statusCode)
+        assertEquals(DebugEndGameError("GAME_FINISHED", "Game 7 has already ended"), response.body)
     }
 
     @Test
-    fun `endGame returns 500 when service throws unexpected exception`() {
+    fun `endGame propagates unexpected exceptions instead of a broad catch`() {
+        // #305 DoD: no broad catch(Exception) — unexpected errors bubble to Spring's default 500 handler.
         whenever(debugService.validateAdmin(any())).thenReturn(adminUser())
         whenever(debugService.endGame(eq(7), any()))
             .thenThrow(RuntimeException("DB unavailable"))
 
-        val response = controller.endGame("Bearer admin-token", EndGameRequest(gameId = 7))
-
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.statusCode)
-        assertNull(response.body)
+        assertThrows<RuntimeException> {
+            controller.endGame("Bearer admin-token", EndGameRequest(gameId = 7))
+        }
+        verify(gameEndBroadcaster, never()).broadcast(any(), any(), any())
     }
 }

--- a/src/test/kotlin/org/machikoro/server/controller/DebugControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/DebugControllerTest.kt
@@ -6,23 +6,36 @@ import org.junit.jupiter.api.Test
 import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.enums.TurnPhase
 import org.machikoro.server.domain.models.GameModel
+import org.machikoro.server.domain.models.UserModel
 import org.machikoro.server.dto.DebugSeedResponse
 import org.machikoro.server.dto.FillLobbyRequest
 import org.machikoro.server.dto.GameStateDto
 import org.machikoro.server.dto.LoginResponse
+import org.machikoro.server.dto.EndGameRequest
+import org.machikoro.server.dto.EndTurnOutcome
+import org.machikoro.server.exception.CustomWebSocketException
 import org.machikoro.server.exception.GameNotFoundException
 import org.machikoro.server.exception.InvalidSessionTokenException
 import org.machikoro.server.exception.NotAdminException
+import org.machikoro.server.exception.NotInGameException
 import org.machikoro.server.service.DebugService
+import org.machikoro.server.service.GameEndBroadcaster
+import org.machikoro.server.service.GamePhaseService
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
 
 class DebugControllerTest {
 
     private val debugService = mock<DebugService>()
-    private val controller = DebugController(debugService)
+    private val gameEndBroadcaster = mock<GameEndBroadcaster>()
+    private val gamePhaseService = mock<GamePhaseService>()
+    private val controller = DebugController(debugService, gameEndBroadcaster, gamePhaseService)
 
     // --- helpers ---
 
@@ -51,6 +64,16 @@ class DebugControllerTest {
 
     private fun loginResponse(username: String, userId: Int) =
         LoginResponse(sessionToken = "token-$userId", username = username, userId = userId)
+
+    private fun adminUser() = UserModel(
+        id = 99,
+        username = "admin_1",
+        passwordHash = "hash",
+        sessionToken = "admin-token",
+        totalWins = 0,
+        totalGamesPlayed = 0,
+        isAdmin = true,
+    )
 
     // === POST /debug/seed ===
 
@@ -233,5 +256,107 @@ class DebugControllerTest {
         whenever(debugService.validateAdmin(any())).thenThrow(NotAdminException("not admin"))
 
         assertEquals(HttpStatus.FORBIDDEN, controller.resetLobby("Bearer token", FillLobbyRequest("X")).statusCode)
+    }
+
+    // === endGame ===
+
+    @Test
+    fun `endGame returns 200 OK with Won outcome, broadcasts then cleans up on success`() {
+        val admin = adminUser()
+        val outcome = EndTurnOutcome.Won(winnerId = 42, roundsPlayed = 5)
+        whenever(debugService.validateAdmin(any())).thenReturn(admin)
+        // eq(admin) proves the controller threads validateAdmin's result into endGame (no re-resolve).
+        whenever(debugService.endGame(eq(7), eq(admin))).thenReturn(outcome)
+
+        val response = controller.endGame("Bearer admin-token", EndGameRequest(gameId = 7))
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals(outcome, response.body)
+        verify(gameEndBroadcaster).broadcast(7, 42, 5)
+        verify(gamePhaseService).cleanupFinishedGameData(7)
+    }
+
+    @Test
+    fun `endGame returns 401 when session token is invalid`() {
+        whenever(debugService.validateAdmin(any())).thenThrow(InvalidSessionTokenException("bad token"))
+
+        assertEquals(
+            HttpStatus.UNAUTHORIZED,
+            controller.endGame("Bearer bad", EndGameRequest(gameId = 7)).statusCode,
+        )
+        verify(gameEndBroadcaster, never()).broadcast(any(), any(), any())
+        verify(gamePhaseService, never()).cleanupFinishedGameData(any())
+    }
+
+    @Test
+    fun `endGame returns 401 when Authorization header is missing`() {
+        whenever(debugService.validateAdmin(isNull())).thenThrow(InvalidSessionTokenException("Missing Authorization header"))
+
+        assertEquals(
+            HttpStatus.UNAUTHORIZED,
+            controller.endGame(null, EndGameRequest(gameId = 7)).statusCode,
+        )
+        verify(gameEndBroadcaster, never()).broadcast(any(), any(), any())
+    }
+
+    @Test
+    fun `endGame returns 403 when user is not admin`() {
+        whenever(debugService.validateAdmin(any())).thenThrow(NotAdminException("not admin"))
+
+        assertEquals(
+            HttpStatus.FORBIDDEN,
+            controller.endGame("Bearer token", EndGameRequest(gameId = 7)).statusCode,
+        )
+        verify(gameEndBroadcaster, never()).broadcast(any(), any(), any())
+    }
+
+    @Test
+    fun `endGame returns 404 when game does not exist`() {
+        whenever(debugService.validateAdmin(any())).thenReturn(adminUser())
+        whenever(debugService.endGame(eq(404), any()))
+            .thenThrow(GameNotFoundException("Game 404 not found"))
+
+        assertEquals(
+            HttpStatus.NOT_FOUND,
+            controller.endGame("Bearer admin-token", EndGameRequest(gameId = 404)).statusCode,
+        )
+        verify(gameEndBroadcaster, never()).broadcast(any(), any(), any())
+    }
+
+    @Test
+    fun `endGame returns 422 when caller is not in the game`() {
+        whenever(debugService.validateAdmin(any())).thenReturn(adminUser())
+        whenever(debugService.endGame(eq(7), any()))
+            .thenThrow(NotInGameException("not a player"))
+
+        assertEquals(
+            HttpStatus.UNPROCESSABLE_ENTITY,
+            controller.endGame("Bearer admin-token", EndGameRequest(gameId = 7)).statusCode,
+        )
+        verify(gameEndBroadcaster, never()).broadcast(any(), any(), any())
+    }
+
+    @Test
+    fun `endGame returns 422 when game state precondition fails`() {
+        whenever(debugService.validateAdmin(any())).thenReturn(adminUser())
+        whenever(debugService.endGame(eq(7), any()))
+            .thenThrow(CustomWebSocketException(errorCode = "GAME_FINISHED", message = "Game 7 has already ended"))
+
+        assertEquals(
+            HttpStatus.UNPROCESSABLE_ENTITY,
+            controller.endGame("Bearer admin-token", EndGameRequest(gameId = 7)).statusCode,
+        )
+    }
+
+    @Test
+    fun `endGame returns 500 when service throws unexpected exception`() {
+        whenever(debugService.validateAdmin(any())).thenReturn(adminUser())
+        whenever(debugService.endGame(eq(7), any()))
+            .thenThrow(RuntimeException("DB unavailable"))
+
+        val response = controller.endGame("Bearer admin-token", EndGameRequest(gameId = 7))
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.statusCode)
+        assertNull(response.body)
     }
 }

--- a/src/test/kotlin/org/machikoro/server/controller/DebugEndGameBroadcastIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/DebugEndGameBroadcastIntegrationTest.kt
@@ -1,0 +1,262 @@
+package org.machikoro.server.controller
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.machikoro.server.dao.PlayerDao
+import org.machikoro.server.dao.UserDao
+import org.machikoro.server.domain.enums.GameStatus
+import org.machikoro.server.domain.enums.TurnPhase
+import org.machikoro.server.domain.models.GameModel
+import org.machikoro.server.domain.models.PlayerModel
+import org.machikoro.server.domain.models.UserModel
+import org.machikoro.server.dto.EndTurnOutcome
+import org.machikoro.server.dto.GameStateDto
+import org.machikoro.server.dto.MessageType
+import org.machikoro.server.dto.WebSocketMessage
+import org.machikoro.server.service.GamePhaseService
+import org.machikoro.server.service.GameStateGuard
+import org.machikoro.server.service.GameSyncService
+import org.machikoro.server.service.LobbyService
+import org.machikoro.server.service.PurchaseService
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.messaging.converter.MappingJackson2MessageConverter
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.messaging.simp.stomp.StompFrameHandler
+import org.springframework.messaging.simp.stomp.StompHeaders
+import org.springframework.messaging.simp.stomp.StompSession
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.web.socket.WebSocketHttpHeaders
+import org.springframework.web.socket.client.standard.StandardWebSocketClient
+import org.springframework.web.socket.messaging.WebSocketStompClient
+import java.lang.reflect.Type
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.util.UUID
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+
+/**
+ * #305 DoD: end-to-end WebSocket coverage of the debug end-game endpoint. Mirrors
+ * [GameWebSocketBroadcastIntegrationTest] — boots the full web + STOMP stack with the
+ * persistence layer mocked — and asserts that calling `POST /debug/end-game` emits a
+ * `GAME_END` broadcast on `/topic/game/{id}` carrying the caller as winner. Runs with
+ * `debug.enabled=true` so the gated DebugController is registered.
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = [
+        "debug.enabled=true",
+        "spring.docker.compose.enabled=false",
+        "spring.flyway.enabled=false",
+        "machikoro.db.init.enabled=false",
+        "spring.autoconfigure.exclude=org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration",
+    ],
+)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class DebugEndGameBroadcastIntegrationTest {
+    private companion object {
+        private const val MESSAGE_TIMEOUT_SECONDS = 20L
+        private const val BROKER_SUBSCRIPTION_TIMEOUT_SECONDS = 10L
+        private const val BROKER_SUBSCRIPTION_PROBE_WAIT_MILLIS = 250L
+    }
+
+    @LocalServerPort
+    private var port: Int = 0
+
+    @Autowired
+    private lateinit var mapper: ObjectMapper
+
+    @Autowired
+    private lateinit var messagingTemplate: SimpMessagingTemplate
+
+    private val httpClient: HttpClient = HttpClient.newHttpClient()
+    private val activeSessions = mutableListOf<StompSession>()
+
+    @MockitoBean
+    private lateinit var userDao: UserDao
+
+    @MockitoBean
+    private lateinit var playerDao: PlayerDao
+
+    @MockitoBean
+    private lateinit var gameStateGuard: GameStateGuard
+
+    @MockitoBean
+    private lateinit var gamePhaseService: GamePhaseService
+
+    @MockitoBean
+    private lateinit var gameSyncService: GameSyncService
+
+    // Mocked so the application context boots without a DataSource (mirrors the sibling test).
+    @MockitoBean
+    private lateinit var lobbyService: LobbyService
+
+    @MockitoBean
+    private lateinit var purchaseService: PurchaseService
+
+    @AfterEach
+    fun disconnectSessions() {
+        activeSessions.filter { it.isConnected }.forEach(StompSession::disconnect)
+        activeSessions.clear()
+    }
+
+    @Test
+    fun `end-game endpoint broadcasts GAME_END with the caller as winner`() {
+        val suffix = UUID.randomUUID().toString().replace("-", "").take(10)
+        val adminToken = "admin-token-$suffix"
+        val adminUserId = 101
+        val gameId = 303
+        val roundsPlayed = 4
+        val admin = UserModel(
+            id = adminUserId,
+            username = "ws_admin_$suffix",
+            passwordHash = null,
+            sessionToken = adminToken,
+            totalWins = 0,
+            totalGamesPlayed = 0,
+            isAdmin = true,
+        )
+        val callerPlayer = PlayerModel(id = 55, gameId = gameId, userId = adminUserId, turnOrder = 0, coins = 3, lastSeenAt = null)
+        val game = GameModel(
+            id = gameId,
+            status = GameStatus.IN_PROGRESS,
+            hostUserId = adminUserId,
+            lobbyCode = "ABC$suffix".take(8).uppercase(),
+            maxPlayers = 4,
+            currentTurnIndex = 0,
+            turnPhase = TurnPhase.ROLL_DICE,
+            lastDiceRoll = null,
+            roundNumber = roundsPlayed,
+            hasPurchasedThisTurn = false,
+        )
+
+        whenever(userDao.findBySessionToken(adminToken)).thenReturn(admin)
+        whenever(gameStateGuard.ensureGameIsRunning(gameId)).thenReturn(game)
+        whenever(playerDao.findByGameIdAndUserId(gameId, adminUserId)).thenReturn(callerPlayer)
+        whenever(gamePhaseService.finishGameWithWinner(eq(gameId), eq(callerPlayer), eq(roundsPlayed)))
+            .thenReturn(EndTurnOutcome.Won(winnerId = callerPlayer.id, roundsPlayed = roundsPlayed))
+        whenever(gameSyncService.buildSnapshot(gameId)).thenReturn(snapshot(game, callerPlayer))
+
+        val session = connect(adminToken)
+        val gameQueue = LinkedBlockingQueue<JsonNode>()
+        val gameTopic = "/topic/game/$gameId"
+        session.subscribe(gameTopic, queueHandler(gameQueue))
+        waitForBrokerSubscriptions(gameTopic, gameQueue)
+
+        val status = postEndGame(gameId, adminToken)
+        assertEquals(200, status)
+
+        val message = takeMessage(gameQueue, MessageType.GAME_END)
+        assertEquals(gameId, message["gameId"].asInt())
+        assertEquals(callerPlayer.id, message["payload"]["winnerId"].asInt())
+        assertEquals(roundsPlayed, message["payload"]["roundsPlayed"].asInt())
+    }
+
+    private fun postEndGame(gameId: Int, token: String): Int {
+        val request = HttpRequest.newBuilder()
+            .uri(URI.create("http://localhost:$port/debug/end-game"))
+            .header("Authorization", "Bearer $token")
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString("""{"gameId":$gameId}"""))
+            .build()
+        return httpClient.send(request, HttpResponse.BodyHandlers.ofString()).statusCode()
+    }
+
+    private fun snapshot(game: GameModel, player: PlayerModel): GameStateDto =
+        GameStateDto(
+            game = game,
+            players = listOf(player),
+            playerCards = emptyMap(),
+            playerLandmarks = emptyMap(),
+            marketplace = emptyMap(),
+            turnOrder = listOf(player.userId),
+            activePlayerId = player.userId,
+        )
+
+    private fun connect(sessionToken: String): StompSession {
+        val connectHeaders = StompHeaders().apply { add("Authorization", "Bearer $sessionToken") }
+        return stompClient()
+            .connectAsync(
+                "ws://localhost:$port/ws",
+                WebSocketHttpHeaders(),
+                connectHeaders,
+                object : StompSessionHandlerAdapter() {},
+            )
+            .get(10, TimeUnit.SECONDS)
+            .also { activeSessions.add(it) }
+    }
+
+    private fun stompClient(): WebSocketStompClient =
+        WebSocketStompClient(StandardWebSocketClient()).apply {
+            messageConverter = MappingJackson2MessageConverter().apply { objectMapper = mapper }
+        }
+
+    private fun queueHandler(queue: BlockingQueue<JsonNode>): StompFrameHandler =
+        object : StompFrameHandler {
+            override fun getPayloadType(headers: StompHeaders): Type = JsonNode::class.java
+            override fun handleFrame(headers: StompHeaders, payload: Any?) {
+                queue.offer(payload as JsonNode)
+            }
+        }
+
+    private fun waitForBrokerSubscriptions(destination: String, vararg queues: BlockingQueue<JsonNode>) {
+        val ready = BooleanArray(queues.size)
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(BROKER_SUBSCRIPTION_TIMEOUT_SECONDS)
+        while (System.nanoTime() < deadline) {
+            val probeId = UUID.randomUUID().toString()
+            messagingTemplate.convertAndSend(
+                destination,
+                WebSocketMessage(
+                    type = MessageType.CHAT,
+                    sender = "test",
+                    payload = mapOf("event" to "SUBSCRIPTION_READY", "probeId" to probeId),
+                ),
+            )
+            queues.forEachIndexed { index, queue ->
+                if (drainSubscriptionProbes(queue, probeId)) ready[index] = true
+            }
+            if (ready.all { it }) return
+        }
+        error("Timed out waiting for broker subscriptions to $destination; ready=${ready.toList()}")
+    }
+
+    private fun drainSubscriptionProbes(queue: BlockingQueue<JsonNode>, probeId: String): Boolean {
+        val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(BROKER_SUBSCRIPTION_PROBE_WAIT_MILLIS)
+        var received = false
+        while (System.nanoTime() < deadline) {
+            val remaining = deadline - System.nanoTime()
+            val message = queue.poll(remaining, TimeUnit.NANOSECONDS) ?: return received
+            if (
+                message.path("type").asText() == MessageType.CHAT.name &&
+                message.path("payload").path("probeId").asText() == probeId
+            ) {
+                received = true
+            }
+        }
+        return received
+    }
+
+    private fun takeMessage(queue: BlockingQueue<JsonNode>, type: MessageType): JsonNode {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(MESSAGE_TIMEOUT_SECONDS)
+        val seen = mutableListOf<String>()
+        while (System.nanoTime() < deadline) {
+            val remaining = deadline - System.nanoTime()
+            val message = queue.poll(remaining, TimeUnit.NANOSECONDS) ?: break
+            seen += message.toString()
+            if (message["type"].asText() == type.name) return message
+        }
+        error("Timed out waiting for $type; seen=$seen")
+    }
+}

--- a/src/test/kotlin/org/machikoro/server/controller/DebugEndGameDisabledIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/DebugEndGameDisabledIntegrationTest.kt
@@ -1,0 +1,68 @@
+package org.machikoro.server.controller
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.machikoro.server.dao.UserDao
+import org.machikoro.server.service.GamePhaseService
+import org.machikoro.server.service.GameStateGuard
+import org.machikoro.server.service.GameSyncService
+import org.machikoro.server.service.LobbyService
+import org.machikoro.server.service.PurchaseService
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+
+/**
+ * #305 AC: when `debug.enabled=false` the `@ConditionalOnProperty`-gated [DebugController]
+ * is not registered, so `POST /debug/end-game` must return 404. Boots the web stack with
+ * the persistence layer mocked, mirroring [GameWebSocketBroadcastIntegrationTest]'s setup.
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = [
+        "debug.enabled=false",
+        "spring.docker.compose.enabled=false",
+        "spring.flyway.enabled=false",
+        "machikoro.db.init.enabled=false",
+        "spring.autoconfigure.exclude=org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration",
+    ],
+)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class DebugEndGameDisabledIntegrationTest {
+
+    @LocalServerPort
+    private var port: Int = 0
+
+    private val httpClient: HttpClient = HttpClient.newHttpClient()
+
+    @MockitoBean private lateinit var userDao: UserDao
+    @MockitoBean private lateinit var lobbyService: LobbyService
+    @MockitoBean private lateinit var gamePhaseService: GamePhaseService
+    @MockitoBean private lateinit var gameStateGuard: GameStateGuard
+    @MockitoBean private lateinit var gameSyncService: GameSyncService
+    @MockitoBean private lateinit var purchaseService: PurchaseService
+
+    @Test
+    fun `end-game endpoint is not accessible when debug is disabled`() {
+        // With debug.enabled=false the gated DebugController bean is never created, AND
+        // SecurityConfig only permits /debug/** when debug.enabled=true. Otherwise the POST
+        // falls through to anyRequest().authenticated() + CSRF and is rejected with 403
+        // before it could reach the dispatcher's would-be 404 — a stronger "not accessible"
+        // guarantee than the literal 404 in #305's acceptance criteria.
+        val request = HttpRequest.newBuilder()
+            .uri(URI.create("http://localhost:$port/debug/end-game"))
+            .header("Authorization", "Bearer any-token")
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString("""{"gameId":1}"""))
+            .build()
+
+        val status = httpClient.send(request, HttpResponse.BodyHandlers.ofString()).statusCode()
+
+        assertEquals(403, status)
+    }
+}

--- a/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
@@ -27,6 +27,7 @@ import org.machikoro.server.exception.GameFinishedException
 import org.machikoro.server.exception.GameStartedException
 import org.machikoro.server.exception.NotHostException
 import org.machikoro.server.service.DiceService
+import org.machikoro.server.service.GameEndBroadcaster
 import org.machikoro.server.service.GamePhaseService
 import org.machikoro.server.service.GameSyncService
 import org.machikoro.server.service.GameStateGuard
@@ -55,10 +56,11 @@ class GameControllerTest {
     private val connectionTracker = mock<WebSocketConnectionTracker>()
     private val gameStateGuard = mock<GameStateGuard>()
     private val gameSyncService = mock<GameSyncService>()
+    private val gameEndBroadcaster = mock<GameEndBroadcaster>()
     private val controller = GameController(
         gamePhaseService, messagingTemplate,
         purchaseService, diceService, lobbyService, connectionTracker,
-        gameStateGuard, gameSyncService,
+        gameStateGuard, gameSyncService, gameEndBroadcaster,
     )
 
     private val alice = UserPrincipal(userId = 1, username = "alice")
@@ -344,28 +346,18 @@ class GameControllerTest {
     }
 
     @Test
-    fun `endTurn broadcasts GAME_END on game topic when winner exists`() {
+    fun `endTurn delegates GAME_END broadcast to GameEndBroadcaster when winner exists`() {
         val gameId = 42
         val winnerId = 1
         val roundsPlayed = 10
-        val snapshot = gameStateDto(gameId)
         whenever(gamePhaseService.endTurn(gameId)).thenReturn(EndTurnOutcome.Won(winnerId, roundsPlayed))
-        whenever(gameSyncService.buildSnapshot(gameId)).thenReturn(snapshot)
 
         controller.endTurn(EndTurnRequest(gameId), authedAccessor())
 
-        val captor = argumentCaptor<WebSocketMessage>()
-        verify(messagingTemplate).convertAndSend(eq("/topic/game/$gameId"), captor.capture())
+        // Broadcast logic itself is owned by GameEndBroadcaster (covered by its own test);
+        // here we only verify the controller delegates with the right arguments.
+        verify(gameEndBroadcaster).broadcast(gameId, winnerId, roundsPlayed)
         verify(gamePhaseService).cleanupFinishedGameData(gameId)
-
-        val message = captor.firstValue
-        assertEquals(MessageType.GAME_END, message.type)
-        assertEquals(gameId, message.gameId)
-        @Suppress("UNCHECKED_CAST")
-        val payload = message.payload as Map<String, Any?>
-        assertEquals(winnerId, payload["winnerId"])
-        assertEquals(roundsPlayed, payload["roundsPlayed"])
-        assertEquals(snapshot, payload["state"])
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/dto/DebugEndGameErrorTest.kt
+++ b/src/test/kotlin/org/machikoro/server/dto/DebugEndGameErrorTest.kt
@@ -1,0 +1,26 @@
+package org.machikoro.server.dto
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+
+class DebugEndGameErrorTest {
+
+    @Test
+    fun `exposes the error code and message`() {
+        val error = DebugEndGameError("NOT_IN_GAME", "User alice is not a player in game 5")
+
+        assertEquals("NOT_IN_GAME", error.error)
+        assertEquals("User alice is not a player in game 5", error.message)
+    }
+
+    @Test
+    fun `supports value equality, copy and hashing`() {
+        val error = DebugEndGameError("GAME_NOT_FOUND", "Game 9 not found")
+
+        assertEquals(error, error.copy())
+        assertEquals(error, DebugEndGameError("GAME_NOT_FOUND", "Game 9 not found"))
+        assertEquals(error.hashCode(), DebugEndGameError("GAME_NOT_FOUND", "Game 9 not found").hashCode())
+        assertNotEquals(error, error.copy(error = "GAME_FINISHED"))
+    }
+}

--- a/src/test/kotlin/org/machikoro/server/service/DebugServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/DebugServiceTest.kt
@@ -2,21 +2,25 @@ package org.machikoro.server.service
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import org.machikoro.server.dao.GameDao
+import org.machikoro.server.dao.PlayerDao
 import org.machikoro.server.dao.UserDao
 import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.enums.TurnPhase
 import org.machikoro.server.domain.models.GameModel
 import org.machikoro.server.domain.models.PlayerModel
 import org.machikoro.server.domain.models.UserModel
+import org.machikoro.server.dto.EndTurnOutcome
 import org.machikoro.server.dto.GameStateDto
 import org.machikoro.server.dto.LobbyRosterPlayerDto
+import org.machikoro.server.exception.CustomWebSocketException
 import org.machikoro.server.exception.GameNotFoundException
 import org.machikoro.server.exception.GameStartedException
 import org.machikoro.server.exception.InvalidSessionTokenException
 import org.machikoro.server.exception.LobbyFullException
 import org.machikoro.server.exception.NotAdminException
+import org.machikoro.server.exception.NotInGameException
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
@@ -35,8 +39,14 @@ class DebugServiceTest {
     private val lobbyService = mock<LobbyService>()
     private val passwordEncoder = mock<PasswordEncoder>()
     private val messagingTemplate = mock<SimpMessagingTemplate>()
+    private val gameStateGuard = mock<GameStateGuard>()
+    private val gameDao = mock<GameDao>()
+    private val playerDao = mock<PlayerDao>()
 
-    private val service = DebugService(userDao, lobbyService, passwordEncoder, messagingTemplate)
+    private val service = DebugService(
+        userDao, lobbyService, passwordEncoder, messagingTemplate,
+        gameStateGuard, gameDao, playerDao,
+    )
 
     // --- helpers ---
 
@@ -314,10 +324,81 @@ class DebugServiceTest {
     }
 
     @Test
-    fun `validateAdmin passes without throwing when user is admin`() {
+    fun `validateAdmin returns the admin user when token is valid and user is admin`() {
         val admin = userModel(1, "admin_1").copy(isAdmin = true)
         whenever(userDao.findBySessionToken("token")).thenReturn(admin)
 
-        assertDoesNotThrow { service.validateAdmin("Bearer token") }
+        assertEquals(admin, service.validateAdmin("Bearer token"))
+    }
+
+    // === endGame() ===
+    // The endpoint resolves + admin-checks the caller (validateAdmin) and owns the
+    // GAME_END broadcast + cleanup; the service takes the already-resolved UserModel
+    // and only applies the transactional win side effects. See DebugControllerTest.
+
+    private fun adminUser(id: Int, username: String) =
+        userModel(id, username).copy(isAdmin = true)
+
+    @Test
+    fun `endGame happy path increments stats, sets game FINISHED, returns Won`() {
+        val gameId = 7
+        val admin = adminUser(99, "admin_1")
+        val game = game(gameId).copy(status = GameStatus.IN_PROGRESS, roundNumber = 5)
+        val adminPlayer = PlayerModel(id = 42, gameId = gameId, userId = admin.id, turnOrder = 1, coins = 8, lastSeenAt = null)
+        val allPlayers = listOf(
+            PlayerModel(id = 41, gameId = gameId, userId = 200, turnOrder = 0, coins = 3, lastSeenAt = null),
+            adminPlayer,
+        )
+
+        whenever(gameStateGuard.ensureGameIsRunning(gameId)).thenReturn(game)
+        whenever(playerDao.findByGameIdAndUserId(gameId, admin.id)).thenReturn(adminPlayer)
+        whenever(playerDao.getPlayers(gameId)).thenReturn(allPlayers)
+
+        val outcome = service.endGame(gameId, admin)
+
+        assertEquals(EndTurnOutcome.Won(winnerId = 42, roundsPlayed = 5), outcome)
+        verify(userDao).incrementWins(admin.id)
+        verify(userDao).incrementGamesPlayed(200)
+        verify(userDao).incrementGamesPlayed(admin.id)
+        verify(gameDao).updateStatus(gameId, GameStatus.FINISHED)
+    }
+
+    @Test
+    fun `endGame propagates GameNotFoundException from the guard and does not mutate state`() {
+        val admin = adminUser(99, "admin_1")
+        whenever(gameStateGuard.ensureGameIsRunning(404))
+            .thenThrow(GameNotFoundException("Game 404 not found"))
+
+        assertThrows<GameNotFoundException> {
+            service.endGame(404, admin)
+        }
+        verify(gameDao, never()).updateStatus(any(), any())
+    }
+
+    @Test
+    fun `endGame propagates CustomWebSocketException when game is already finished`() {
+        val admin = adminUser(99, "admin_1")
+        whenever(gameStateGuard.ensureGameIsRunning(7))
+            .thenThrow(CustomWebSocketException(errorCode = "GAME_FINISHED", message = "Game 7 has already ended"))
+
+        assertThrows<CustomWebSocketException> {
+            service.endGame(7, admin)
+        }
+        verify(gameDao, never()).updateStatus(any(), any())
+    }
+
+    @Test
+    fun `endGame throws NotInGameException when caller is admin but not a player in the game`() {
+        val gameId = 7
+        val admin = adminUser(99, "admin_1")
+        whenever(gameStateGuard.ensureGameIsRunning(gameId))
+            .thenReturn(game(gameId).copy(status = GameStatus.IN_PROGRESS))
+        whenever(playerDao.findByGameIdAndUserId(gameId, admin.id)).thenReturn(null)
+
+        assertThrows<NotInGameException> {
+            service.endGame(gameId, admin)
+        }
+        verify(userDao, never()).incrementWins(any())
+        verify(gameDao, never()).updateStatus(any(), any())
     }
 }

--- a/src/test/kotlin/org/machikoro/server/service/DebugServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/DebugServiceTest.kt
@@ -3,7 +3,6 @@ package org.machikoro.server.service
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.machikoro.server.dao.GameDao
 import org.machikoro.server.dao.PlayerDao
 import org.machikoro.server.dao.UserDao
 import org.machikoro.server.domain.enums.GameStatus
@@ -40,12 +39,12 @@ class DebugServiceTest {
     private val passwordEncoder = mock<PasswordEncoder>()
     private val messagingTemplate = mock<SimpMessagingTemplate>()
     private val gameStateGuard = mock<GameStateGuard>()
-    private val gameDao = mock<GameDao>()
     private val playerDao = mock<PlayerDao>()
+    private val gamePhaseService = mock<GamePhaseService>()
 
     private val service = DebugService(
         userDao, lobbyService, passwordEncoder, messagingTemplate,
-        gameStateGuard, gameDao, playerDao,
+        gameStateGuard, playerDao, gamePhaseService,
     )
 
     // --- helpers ---
@@ -334,33 +333,27 @@ class DebugServiceTest {
     // === endGame() ===
     // The endpoint resolves + admin-checks the caller (validateAdmin) and owns the
     // GAME_END broadcast + cleanup; the service takes the already-resolved UserModel
-    // and only applies the transactional win side effects. See DebugControllerTest.
+    // and delegates the win side effects to GamePhaseService.finishGameWithWinner. See DebugControllerTest.
 
     private fun adminUser(id: Int, username: String) =
         userModel(id, username).copy(isAdmin = true)
 
     @Test
-    fun `endGame happy path increments stats, sets game FINISHED, returns Won`() {
+    fun `endGame delegates to GamePhaseService finishGameWithWinner and returns its outcome`() {
         val gameId = 7
         val admin = adminUser(99, "admin_1")
         val game = game(gameId).copy(status = GameStatus.IN_PROGRESS, roundNumber = 5)
         val adminPlayer = PlayerModel(id = 42, gameId = gameId, userId = admin.id, turnOrder = 1, coins = 8, lastSeenAt = null)
-        val allPlayers = listOf(
-            PlayerModel(id = 41, gameId = gameId, userId = 200, turnOrder = 0, coins = 3, lastSeenAt = null),
-            adminPlayer,
-        )
+        val won = EndTurnOutcome.Won(winnerId = 42, roundsPlayed = 5)
 
         whenever(gameStateGuard.ensureGameIsRunning(gameId)).thenReturn(game)
         whenever(playerDao.findByGameIdAndUserId(gameId, admin.id)).thenReturn(adminPlayer)
-        whenever(playerDao.getPlayers(gameId)).thenReturn(allPlayers)
+        whenever(gamePhaseService.finishGameWithWinner(gameId, adminPlayer, 5)).thenReturn(won)
 
         val outcome = service.endGame(gameId, admin)
 
-        assertEquals(EndTurnOutcome.Won(winnerId = 42, roundsPlayed = 5), outcome)
-        verify(userDao).incrementWins(admin.id)
-        verify(userDao).incrementGamesPlayed(200)
-        verify(userDao).incrementGamesPlayed(admin.id)
-        verify(gameDao).updateStatus(gameId, GameStatus.FINISHED)
+        assertEquals(won, outcome)
+        verify(gamePhaseService).finishGameWithWinner(gameId, adminPlayer, 5)
     }
 
     @Test
@@ -372,7 +365,7 @@ class DebugServiceTest {
         assertThrows<GameNotFoundException> {
             service.endGame(404, admin)
         }
-        verify(gameDao, never()).updateStatus(any(), any())
+        verify(gamePhaseService, never()).finishGameWithWinner(any(), any(), any())
     }
 
     @Test
@@ -384,7 +377,7 @@ class DebugServiceTest {
         assertThrows<CustomWebSocketException> {
             service.endGame(7, admin)
         }
-        verify(gameDao, never()).updateStatus(any(), any())
+        verify(gamePhaseService, never()).finishGameWithWinner(any(), any(), any())
     }
 
     @Test
@@ -398,7 +391,6 @@ class DebugServiceTest {
         assertThrows<NotInGameException> {
             service.endGame(gameId, admin)
         }
-        verify(userDao, never()).incrementWins(any())
-        verify(gameDao, never()).updateStatus(any(), any())
+        verify(gamePhaseService, never()).finishGameWithWinner(any(), any(), any())
     }
 }

--- a/src/test/kotlin/org/machikoro/server/service/GameEndBroadcasterTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GameEndBroadcasterTest.kt
@@ -1,0 +1,59 @@
+package org.machikoro.server.service
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import org.machikoro.server.domain.enums.GameStatus
+import org.machikoro.server.domain.enums.TurnPhase
+import org.machikoro.server.domain.models.GameModel
+import org.machikoro.server.dto.GameStateDto
+import org.machikoro.server.dto.MessageType
+import org.machikoro.server.dto.WebSocketMessage
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.messaging.simp.SimpMessagingTemplate
+
+class GameEndBroadcasterTest {
+
+    private val gameSyncService = mock<GameSyncService>()
+    private val messagingTemplate = mock<SimpMessagingTemplate>()
+    private val broadcaster = GameEndBroadcaster(gameSyncService, messagingTemplate)
+
+    private fun snapshot(gameId: Int) = GameStateDto(
+        game = GameModel(
+            id = gameId, status = GameStatus.FINISHED, hostUserId = 1,
+            lobbyCode = "ABC", maxPlayers = 4, currentTurnIndex = 0,
+            turnPhase = TurnPhase.END_TURN, lastDiceRoll = null,
+            roundNumber = 5, hasPurchasedThisTurn = false,
+        ),
+        players = emptyList(),
+        playerCards = emptyMap(),
+        playerLandmarks = emptyMap(),
+        marketplace = emptyMap(),
+        turnOrder = emptyList(),
+        activePlayerId = null,
+    )
+
+    @Test
+    fun `broadcast sends GAME_END to game topic with winner, rounds and snapshot in payload`() {
+        val state = snapshot(7)
+        whenever(gameSyncService.buildSnapshot(7)).thenReturn(state)
+
+        broadcaster.broadcast(gameId = 7, winnerId = 42, roundsPlayed = 5)
+
+        val captor = argumentCaptor<WebSocketMessage>()
+        verify(messagingTemplate).convertAndSend(eq("/topic/game/7"), captor.capture())
+
+        val msg = captor.firstValue
+        assertEquals(MessageType.GAME_END, msg.type)
+        assertEquals(7, msg.gameId)
+        @Suppress("UNCHECKED_CAST")
+        val payload = msg.payload as Map<String, Any?>
+        assertEquals(42, payload["winnerId"])
+        assertEquals(5, payload["roundsPlayed"])
+        assertSame(state, payload["state"])
+    }
+}

--- a/src/test/kotlin/org/machikoro/server/service/GamePhaseServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GamePhaseServiceTest.kt
@@ -234,6 +234,23 @@ class GamePhaseServiceTest {
     }
 
     @Test
+    fun `finishGameWithWinner records stats for all players, finishes game, and returns Won`() {
+        val gameId = 30
+        val roundNumber = 7
+        val winner = PlayerModel(id = 1, gameId = gameId, userId = 10, turnOrder = 0, coins = 3, lastSeenAt = null)
+        val loser = PlayerModel(id = 2, gameId = gameId, userId = 20, turnOrder = 1, coins = 5, lastSeenAt = null)
+        whenever(playerDao.getPlayers(gameId)).thenReturn(listOf(winner, loser))
+
+        val result = service.finishGameWithWinner(gameId, winner, roundNumber)
+
+        assertEquals(EndTurnOutcome.Won(winnerId = 1, roundsPlayed = roundNumber), result)
+        verify(userDao).incrementWins(10)
+        verify(userDao).incrementGamesPlayed(10)
+        verify(userDao).incrementGamesPlayed(20)
+        verify(gameDao).updateStatus(gameId, GameStatus.FINISHED)
+    }
+
+    @Test
     fun `endTurn rejects games outside buy or build phase`() {
         val gameId = 23
         whenever(gameStateGuard.ensureGameIsRunning(gameId))


### PR DESCRIPTION
## What

Adds a debug-only `POST /debug/end-game` endpoint that force-ends a running game with the admin caller as the winner, so testers can reach the winner screen without playing a full game. Closes #305.

The client-side debug button that calls this is tracked separately in Client #191.

## How it's gated (layered)

- `@ConditionalOnProperty(debug.enabled=true)` — the whole `DebugController` is unregistered in production.
- `validateAdmin(authHeader)` — requires a valid **admin** session token (401 / 403 otherwise).
- The caller must be a **player in the game** — otherwise `NotInGameException` → 422.

## Design

Two commits:

1. **`refactor: extract GameEndBroadcaster`** — the GAME_END broadcast was inlined in `GameController.broadcastWin`. Extracted to a `GameEndBroadcaster` service so the production end-of-game path and this new endpoint emit an identical wire shape (same `MessageType`, payload keys, and `/topic/game/{id}`). No behaviour change on the production path.
2. **`feat: add POST /debug/end-game`** — the endpoint, service method, request DTO, and exception.

`DebugService.endGame` is `@Transactional` and applies the **same win side effects as `GamePhaseService.endTurn`** (increment wins, increment games-played for all, status → `FINISHED`) but bypasses `WinConditionService.detectWinner` so no landmarks are required. The controller then broadcasts GAME_END and runs `cleanupFinishedGameData` **post-commit**, mirroring `GameController.endTurn` exactly. `validateAdmin` now returns the resolved `UserModel` so the controller threads the admin into `endGame` with a single token lookup.

Status codes: `200` (Won), `401` (no/invalid token), `403` (not admin), `404` (game not found), `422` (not a player / game not running), `500` (unexpected).

## Testing

- `./gradlew check` — full unit + Testcontainers integration suite + 80%-per-class coverage gate: **green**. New/changed classes are at 100% line coverage.
- **Manual 2-emulator e2e** against a local backend: two admin clients in a live game, triggered the endpoint; **both clients navigated to the winner screen** showing the caller as winner, the game + player rows were cleaned up, stats updated correctly, and there were **no client-side errors** despite the game being deleted (the client renders the winner screen from the GAME_END snapshot in the payload).


---

### Note: `debug.enabled=false` returns 403, not 404 (documented deviation)

#305's AC says the disabled endpoint should return `404`. In practice it returns **`403`**, which is a *stronger* "not accessible" guarantee, for two compounding reasons:

1. `@ConditionalOnProperty(debug.enabled=true)` means the `DebugController` bean is never registered when debug is off — so there is no handler.
2. `SecurityConfig` deliberately only adds `/debug/**` to `permitAll` + CSRF-exempt when `debug.enabled=true`. With debug off, a `POST /debug/end-game` falls through to `anyRequest().authenticated()` + CSRF and is rejected with `403` **before** the dispatcher could ever produce a `404`.

We chose to keep the `403` (verified by `DebugEndGameDisabledIntegrationTest`) rather than loosen `SecurityConfig` to `permitAll` `/debug/**` unconditionally just to surface a `404` — that would remove an intentional defense-in-depth layer. The endpoint is verifiably unreachable when debug is disabled either way.
