### PR TITLE
329 refactor enforce authoritative server side turn loop and phase transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ PostgreSQL. Designed for reliability, scalability, and developer productivity.
   statuses.
 - **Game Logic Engine:** Calculates earnings, applies card effects based on dice rolls, and detects win conditions (
   e.g., landmark completion).
+- **Authoritative Turns:** Clients request roll, resolve, purchase, and end-turn actions; only the server advances legal phases.
 - **In-Game Chat:** Built-in chat system for players in the lobby and during the game.
 - **Data Persistence:** Uses JetBrains Exposed ORM to safely store users, games, cards, and landmarks in PostgreSQL.
 - **Quality Assured:** Comprehensive test suite with Testcontainers, JUnit5, and a strict ≥80% Jacoco coverage quality
@@ -288,6 +289,8 @@ Sonar analysis settings are defined in `build.gradle.kts` under the Gradle `sona
 ## API & WebSocket Documentation
 
 For detailed API documentation, the server exposes both standard REST and asynchronous API documentation.
+
+The gameplay loop is action-driven: `ROLL_DICE --rollDice--> RESOLVE_EFFECTS --resolveEffects--> BUY_OR_BUILD --endTurn--> ROLL_DICE`. Purchases are optional and limited to one during `BUY_OR_BUILD`. `/app/game.advancePhase` is a deprecated compatibility destination that is rejected and cannot skip required turn actions.
 
 - **Swagger UI (REST):** Accessible at `http://localhost:8080/swagger-ui.html`. Powered by Springdoc OpenAPI, this interface provides interactive documentation for our standard REST endpoints.
 - **Springwolf UI (AsyncAPI/WebSockets):** Accessible at `http://localhost:8080/springwolf/asyncapi-ui.html`. Powered by Springwolf, this provides interactive documentation and an event publisher for our STOMP over WebSocket channels, which are the backbone of our real-time game communications.

--- a/docs/websocket-game-protocol.md
+++ b/docs/websocket-game-protocol.md
@@ -30,6 +30,7 @@ Clients should subscribe before sending lobby or game commands so they do not mi
 | `/topic/game/{gameId}` | All players in one lobby or game | Lobby membership changes, game start, dice, phase, purchase, effects, game end, and broadcast errors |
 | `/queue/lobby-user{sessionId}` | Single WebSocket session | Lobby creation result, lobby roster after join, and lobby-specific request errors |
 | `/user/queue/game-sync` | Single WebSocket session | Full `SYNC` snapshot for reconnect and explicit state refresh |
+| `/user/queue/errors` | Single WebSocket session | Domain rejections routed privately to the requesting client, including forbidden direct phase advancement |
 | `/topic/public` | Global chat only | Chat and connection announcements from `/app/chat.*` |
 
 `{sessionId}` is the STOMP session id assigned by Spring. Browser clients usually receive it from the STOMP session object after connection. The server sends private lobby replies to `/queue/lobby-user{sessionId}` and sends reconnect sync replies to the resolved broker destination `/queue/game-sync-user{sessionId}`, which clients consume by subscribing to `/user/queue/game-sync`.
@@ -46,7 +47,7 @@ Game clients must not use `/topic/public` for game state. All game-state broadca
 | `/app/game.start` | `StartGameRequest` | `GAME_STARTED` and a `GAME_ACTION` snapshot to `/topic/game/{gameId}` |
 | `/app/game.rollDice` | `RollDiceRequest` | `ROLL_DICE` and a `GAME_ACTION` snapshot to `/topic/game/{gameId}` |
 | `/app/game.resolveEffects` | `ResolveEffectsRequest` | `GAME_ACTION` income/effects result to `/topic/game/{gameId}` |
-| `/app/game.advancePhase` | `AdvancePhaseRequest` | `GAME_ACTION` phase snapshot to `/topic/game/{gameId}` |
+| `/app/game.advancePhase` | `AdvancePhaseRequest` | Private error on `/user/queue/errors` (`DIRECT_PHASE_ADVANCE_FORBIDDEN`); never mutates game state |
 | `/app/game.purchase` | `PurchaseRequest` | `GAME_ACTION` purchase snapshot or `ERROR` purchase failure to `/topic/game/{gameId}` |
 | `/app/game.endTurn` | `EndTurnRequest` | `GAME_ACTION` next-turn snapshot or `GAME_END` to `/topic/game/{gameId}` |
 | `/app/game.sync` | `SyncGameRequest` | `SYNC` to `/queue/game-sync-user{sessionId}` |
@@ -81,6 +82,21 @@ Core game message types:
 
 Lobby-specific message types include `LOBBY_CREATED`, `LOBBY_JOINED`, `LOBBY_ROSTER`, `LOBBY_LEFT`, and `HOST_LEFT`.
 
+## Authoritative Turn Loop
+
+Clients request gameplay actions; they do not choose phases. For an in-progress turn, only the active player's legal request can produce the following transition:
+
+| Current phase | Accepted action | Resulting phase and state |
+| --- | --- | --- |
+| `ROLL_DICE` | `/app/game.rollDice` | Persists exactly one roll and enters `RESOLVE_EFFECTS` |
+| `RESOLVE_EFFECTS` | `/app/game.resolveEffects` | Applies the stored roll exactly once and enters `BUY_OR_BUILD` |
+| `BUY_OR_BUILD` | `/app/game.purchase` | Applies at most one affordable, available purchase; phase remains `BUY_OR_BUILD` |
+| `BUY_OR_BUILD` | `/app/game.endTurn` | Checks for a winner; otherwise changes active player and enters `ROLL_DICE` |
+
+Ending a turn without purchasing is the supported skip action. A continuing next turn clears `lastDiceRoll` and `hasPurchasedThisTurn`. Invalid, duplicated, out-of-order, unaffordable, unavailable, or non-active-player requests do not mutate the stored game state.
+
+Every successful action publishes a server snapshot. Clients must replace local phase, roll, coins, supply, ownership, and active-player state from that snapshot.
+
 ## Purchase Rejections
 
 When `/app/game.purchase` is rejected after authorization succeeds, the server broadcasts an `ERROR` message on `/topic/game/{gameId}`. Clients with a pending shop action must consume `payload.event = "PURCHASE_FAILED"` as a failed purchase and clear their pending state.
@@ -114,7 +130,7 @@ For rejected landmark purchases the payload uses `landmarkType` instead of `card
 6. Player B receives `LOBBY_ROSTER` privately. Both players receive `LOBBY_JOINED` on `/topic/game/{gameId}`.
 7. Player A sends `/app/game.start`.
 8. Both players receive `GAME_STARTED` and the initial `GAME_ACTION` snapshot on `/topic/game/{gameId}`.
-9. During the game, the active player sends dice, effects, phase, purchase, and end-turn commands. Both players consume the resulting `ROLL_DICE`, `GAME_ACTION`, or `GAME_END` messages from `/topic/game/{gameId}` and replace their local state with the included `state` snapshot.
+9. During the game, the active player sends `rollDice`, `resolveEffects`, an optional `purchase`, and `endTurn`. Both players consume the resulting `ROLL_DICE`, `GAME_ACTION`, or `GAME_END` messages from `/topic/game/{gameId}` and replace their local state with the included `state` snapshot.
 
 Clients should treat the server snapshot as authoritative. Local UI state may optimistically display pending actions, but it must reconcile to the latest broadcast payload.
 

--- a/src/main/kotlin/org/machikoro/server/config/OpenApiConfig.kt
+++ b/src/main/kotlin/org/machikoro/server/config/OpenApiConfig.kt
@@ -28,8 +28,15 @@ class OpenApiConfig {
     
     ### Game Synchronization
     Subscribe to `/topic/game/{gameId}` for lobby and game-state broadcasts.
-    Subscribe to `/queue/lobby-user{sessionId}` for private lobby replies and `/user/queue/game-sync` for reconnect snapshots.
+    Subscribe to `/queue/lobby-user{sessionId}` for private lobby replies, `/user/queue/game-sync` for reconnect snapshots,
+    and `/user/queue/errors` for private domain rejections.
     `/topic/public` is reserved for global chat only.
+
+    ### Authoritative Turn Loop
+    The server advances phases only after successful domain actions:
+    `ROLL_DICE --rollDice--> RESOLVE_EFFECTS --resolveEffects--> BUY_OR_BUILD --endTurn--> ROLL_DICE`.
+    A purchase is optional during `BUY_OR_BUILD` and at most one purchase is accepted per turn.
+    `/app/game.advancePhase` is retained for compatibility only and rejects gameplay requests with `DIRECT_PHASE_ADVANCE_FORBIDDEN`.
     
     | Client destination | Payload | Server publishes |
     |---|---|---|
@@ -38,7 +45,7 @@ class OpenApiConfig {
     | `/app/game.start` | `StartGameRequest` | `GAME_STARTED`, `GAME_ACTION` to `/topic/game/{gameId}` |
     | `/app/game.rollDice` | `RollDiceRequest` | `ROLL_DICE`, `GAME_ACTION` to `/topic/game/{gameId}` |
     | `/app/game.resolveEffects` | `ResolveEffectsRequest` | `GAME_ACTION` to `/topic/game/{gameId}` |
-    | `/app/game.advancePhase` | `AdvancePhaseRequest` | `GAME_ACTION` to `/topic/game/{gameId}` |
+    | `/app/game.advancePhase` | `AdvancePhaseRequest` | `DIRECT_PHASE_ADVANCE_FORBIDDEN` to `/user/queue/errors`; no state changes |
     | `/app/game.purchase` | `PurchaseRequest` | `GAME_ACTION`, or `ERROR` with `payload.event = PURCHASE_FAILED`, to `/topic/game/{gameId}` |
     | `/app/game.endTurn` | `EndTurnRequest` | `GAME_ACTION` or `GAME_END` to `/topic/game/{gameId}` |
     | `/app/game.sync` | `SyncGameRequest` | `SYNC` to resolved `/queue/game-sync-user{sessionId}` |

--- a/src/main/kotlin/org/machikoro/server/controller/EarningsController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/EarningsController.kt
@@ -6,6 +6,7 @@ import org.machikoro.server.auth.requireUserPrincipal
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.ResolveEffectsRequest
 import org.machikoro.server.dto.WebSocketMessage
+import org.machikoro.server.exception.CustomWebSocketException
 import org.machikoro.server.service.GameStateGuard
 import org.machikoro.server.service.GameSyncService
 import org.machikoro.server.service.interfaces.EarningsService
@@ -57,6 +58,21 @@ class EarningsController(
                         "turnPhase" to state.game.turnPhase.name,
                         "activePlayerId" to state.activePlayerId,
                         "state" to state,
+                    ),
+                    gameId = request.gameId,
+                )
+            )
+        } catch (e: CustomWebSocketException) {
+            logger.warn("Resolve effects rejected for game {} [{}]: {}", request.gameId, e.errorCode, e.message)
+            messagingTemplate.convertAndSend(
+                gameTopic,
+                WebSocketMessage(
+                    type = MessageType.ERROR,
+                    sender = "server",
+                    payload = mapOf(
+                        "event" to "EFFECTS_FAILED",
+                        "code" to e.errorCode,
+                        "message" to e.message,
                     ),
                     gameId = request.gameId,
                 )

--- a/src/main/kotlin/org/machikoro/server/controller/GameController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/GameController.kt
@@ -112,7 +112,7 @@ class GameController(
 
             // Immediately broadcast a GAME_ACTION so clients that parse turn
             // metadata from GAME_ACTION frames know whose turn it is without
-            // waiting for the first advancePhase or endTurn call.
+            // waiting for the first turn action.
             messagingTemplate.convertAndSend(
                 gameTopic,
                 WebSocketMessage(
@@ -205,22 +205,21 @@ class GameController(
     }
 
     /**
-     * Advances the current turn phase for a game and broadcasts the resulting
-     * phase to all subscribers of the game topic.
-     *
-     * Message is sent to /app/game.advancePhase and broadcast to /topic/game/{gameId}.
+     * Retained only to provide a stable error to older clients. Turn phases
+     * advance solely as results of rollDice, resolveEffects, and endTurn.
      */
     @MessageMapping("/game.advancePhase")
     @AsyncListener(operation = AsyncOperation(
         channelName = "/game.advancePhase",
-        description = "Advances the current turn phase. Must be sent by the active player.",
+        description = "Rejected compatibility endpoint. Use explicit gameplay actions to advance the turn.",
         payloadType = AdvancePhaseRequest::class,
     ))
     fun advancePhase(@Payload request: AdvancePhaseRequest, headerAccessor: SimpMessageHeaderAccessor) {
         requireActivePlayer(request.gameId, headerAccessor)
-        val newPhase = gamePhaseService.advancePhase(request.gameId)
-        logger.info("Advanced phase for game ${request.gameId} to $newPhase")
-        broadcastPhase(request.gameId, "PHASE_ADVANCED")
+        throw CustomWebSocketException(
+            "DIRECT_PHASE_ADVANCE_FORBIDDEN",
+            "Phase progression is controlled by rollDice, resolveEffects, and endTurn actions",
+        )
     }
 
     /**
@@ -332,6 +331,16 @@ class GameController(
                         "completed" to result.completed,
                     ),
                     gameId = request.gameId,
+                )
+            )
+        } catch (e: CustomWebSocketException) {
+            logger.warn("Roll dice rejected for game {} [{}]: {}", request.gameId, e.errorCode, e.message)
+            messagingTemplate.convertAndSend(
+                gameTopic,
+                WebSocketMessage(
+                    type = MessageType.ERROR,
+                    sender = "SERVER",
+                    payload = mapOf("event" to "ROLL_FAILED", "code" to e.errorCode, "message" to e.message)
                 )
             )
         } catch (e: Exception) {

--- a/src/main/kotlin/org/machikoro/server/dao/GameDao.kt
+++ b/src/main/kotlin/org/machikoro/server/dao/GameDao.kt
@@ -3,6 +3,7 @@ package org.machikoro.server.dao
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.isNull
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
 import org.jetbrains.exposed.v1.jdbc.selectAll
@@ -139,6 +140,33 @@ class GameDao {
             it[Games.turnPhase] = phase
         }
         if (updatedRows == 0) throw GameNotFoundException("Game $id not found")
+    }
+
+    /**
+     * Persists the only legal transition out of ROLL_DICE. The conditional
+     * update prevents two simultaneous requests from recording separate rolls.
+     */
+    fun tryRecordDiceRoll(id: Int, diceRoll: Int): Boolean = transaction {
+        Games.update({
+            (Games.id eq id) and
+                (Games.turnPhase eq TurnPhase.ROLL_DICE) and
+                Games.lastDiceRoll.isNull()
+        }) {
+            it[Games.lastDiceRoll] = diceRoll
+            it[Games.turnPhase] = TurnPhase.RESOLVE_EFFECTS
+        } > 0
+    }
+
+    /**
+     * Changes phase only when the stored phase still matches the action that
+     * requested the transition.
+     */
+    fun tryTransitionPhase(id: Int, expected: TurnPhase, next: TurnPhase): Boolean = transaction {
+        Games.update({
+            (Games.id eq id) and (Games.turnPhase eq expected)
+        }) {
+            it[Games.turnPhase] = next
+        } > 0
     }
 
     /**

--- a/src/main/kotlin/org/machikoro/server/dto/AdvancePhaseRequest.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/AdvancePhaseRequest.kt
@@ -2,8 +2,8 @@ package org.machikoro.server.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "Request to advance the current turn phase — sent to /app/game.advancePhase")
+@Schema(description = "Deprecated phase-advance request. /app/game.advancePhase always rejects gameplay use.")
 data class AdvancePhaseRequest(
-    @Schema(description = "ID of the game to advance", example = "1")
+    @Schema(description = "ID of the game", example = "1")
     val gameId: Int
 )

--- a/src/main/kotlin/org/machikoro/server/service/DiceService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/DiceService.kt
@@ -21,7 +21,7 @@ class DiceService(
     fun rollDice(request: RollDiceRequest, rollingPlayerId: Int): RollDiceResponse = synchronized(rollLocks.computeIfAbsent(request.gameId) { Any() }) {
         val game = gameStateGuard.ensureGameIsRunning(request.gameId)
 
-        if (game.turnPhase != TurnPhase.ROLL_DICE) {
+        if (game.turnPhase != TurnPhase.ROLL_DICE || game.lastDiceRoll != null) {
             throw CustomWebSocketException("ROLL_ALREADY_COMPLETED", "Dice have already been rolled for this turn")
         }
 
@@ -47,7 +47,9 @@ class DiceService(
         }
         val total = dice.sum()
 
-        gameDao.updateAfterRoll(request.gameId, total, TurnPhase.RESOLVE_EFFECTS)
+        if (!gameDao.tryRecordDiceRoll(request.gameId, total)) {
+            throw CustomWebSocketException("ROLL_ALREADY_COMPLETED", "Dice have already been rolled for this turn")
+        }
 
         return RollDiceResponse(dice = dice, total = total)
     }

--- a/src/main/kotlin/org/machikoro/server/service/EarningsServiceImpl.kt
+++ b/src/main/kotlin/org/machikoro/server/service/EarningsServiceImpl.kt
@@ -10,7 +10,7 @@ import org.machikoro.server.domain.enums.TurnPhase
 import org.machikoro.server.domain.models.CardModel
 import org.machikoro.server.domain.models.PlayerCardModel
 import org.machikoro.server.domain.models.PlayerModel
-import org.machikoro.server.exception.GameNotFoundException
+import org.machikoro.server.exception.CustomWebSocketException
 import org.machikoro.server.service.interfaces.EarningsService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -27,7 +27,8 @@ class EarningsServiceImpl(
     private val playerCardDao: PlayerCardDao,
     private val cardDao: CardDao,
     private val gameDao: GameDao,
-    private val gamePhaseService: GamePhaseService
+    private val gameStateGuard: GameStateGuard,
+    private val gameTransactionRunner: GameTransactionRunner,
 ) : EarningsService {
 
     fun computeEarnings(pairs: List<Pair<Int, Int>>): Int =
@@ -167,22 +168,35 @@ class EarningsServiceImpl(
      * This is the handoff point introduced for the buying-phase flow: earnings
      * are resolved first, and only then does the turn enter BUY_OR_BUILD.
      */
-    @Transactional
-    override fun resolveEffects(gameId: Int) {
-        val game = gameDao.findById(gameId)
-            ?: throw GameNotFoundException("Game $gameId not found")
+    override fun resolveEffects(gameId: Int): Unit = gameTransactionRunner.inTransaction {
+        val game = gameStateGuard.ensureGameIsRunning(gameId)
+        when (game.turnPhase) {
+            TurnPhase.ROLL_DICE -> throw CustomWebSocketException(
+                "DICE_ROLL_REQUIRED",
+                "Effects cannot be resolved before dice are rolled",
+            )
+            TurnPhase.BUY_OR_BUILD, TurnPhase.END_TURN -> throw CustomWebSocketException(
+                "EFFECTS_ALREADY_RESOLVED",
+                "Effects have already been resolved for this turn",
+            )
+            TurnPhase.RESOLVE_EFFECTS -> Unit
+        }
+        val diceRoll = game.lastDiceRoll ?: throw CustomWebSocketException(
+            "DICE_ROLL_REQUIRED",
+            "Effects require a stored dice roll",
+        )
 
-        // Ensure exact phase where earnings are calculated
-        check(game.turnPhase == TurnPhase.RESOLVE_EFFECTS) { "Game is not in RESOLVE_EFFECTS phase" }
-        val diceRoll = checkNotNull(game.lastDiceRoll) { "Dice roll not set" }
+        if (!gameDao.tryTransitionPhase(gameId, TurnPhase.RESOLVE_EFFECTS, TurnPhase.BUY_OR_BUILD)) {
+            throw CustomWebSocketException(
+                "EFFECTS_ALREADY_RESOLVED",
+                "Effects have already been resolved for this turn",
+            )
+        }
 
         val players = playerDao.getPlayers(gameId)
-        val activePlayer = players[game.currentTurnIndex]
+        val activePlayer = players.getOrNull(game.currentTurnIndex)
+            ?: throw CustomWebSocketException("NO_ACTIVE_PLAYER", "Game $gameId has no active player")
 
-        // Distribute coins
         processEarnings(gameId, diceRoll, activePlayer.id)
-
-        // Route through phase service so all transition logic is applied consistently
-        gamePhaseService.advancePhase(gameId)
     }
 }

--- a/src/main/kotlin/org/machikoro/server/service/GamePhaseService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/GamePhaseService.kt
@@ -9,6 +9,7 @@ import org.machikoro.server.dao.UserDao
 import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.enums.TurnPhase
 import org.machikoro.server.dto.EndTurnOutcome
+import org.machikoro.server.exception.CustomWebSocketException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -22,47 +23,35 @@ class GamePhaseService(
     private val gameMarketplaceDao: GameMarketplaceDao,
     private val gameStateGuard: GameStateGuard,
     private val winConditionService: WinConditionService,
+    private val gameTransactionRunner: GameTransactionRunner,
 ) {
-
-    /** Returns the next phase in the Machi Koro turn cycle. */
-    fun nextPhase(currentPhase: TurnPhase): TurnPhase = when (currentPhase) {
-        TurnPhase.ROLL_DICE -> TurnPhase.RESOLVE_EFFECTS
-        TurnPhase.RESOLVE_EFFECTS -> TurnPhase.BUY_OR_BUILD
-        TurnPhase.BUY_OR_BUILD -> TurnPhase.END_TURN
-        TurnPhase.END_TURN -> TurnPhase.ROLL_DICE
-    }
-
-    /** Returns the phase that begins every new turn. */
-    fun initialPhase(): TurnPhase = TurnPhase.ROLL_DICE
-
-    /** Advances a game to the next phase and persists it. */
-    fun advancePhase(gameId: Int): TurnPhase {
-        val game = gameStateGuard.ensureGameIsRunning(gameId)
-        val next = nextPhase(game.turnPhase)
-        gameDao.updateTurnPhase(gameId, next)
-        return next
-    }
 
     /**
      * Ends the active player's buy-or-build window, checks for a winner, and
      * either finishes the game or starts the next turn.
      */
-    @Transactional
-    fun endTurn(gameId: Int): EndTurnOutcome {
+    fun endTurn(gameId: Int): EndTurnOutcome = gameTransactionRunner.inTransaction {
         val game = gameStateGuard.ensureGameIsRunning(gameId)
-        check(game.turnPhase == TurnPhase.BUY_OR_BUILD) { "Game is not in BUY_OR_BUILD phase" }
+        if (game.turnPhase != TurnPhase.BUY_OR_BUILD) {
+            throw CustomWebSocketException(
+                "INVALID_TURN_PHASE",
+                "Turn can only be ended during BUY_OR_BUILD",
+            )
+        }
 
-        gameDao.updateTurnPhase(gameId, TurnPhase.END_TURN)
+        if (!gameDao.tryTransitionPhase(gameId, TurnPhase.BUY_OR_BUILD, TurnPhase.END_TURN)) {
+            throw CustomWebSocketException("TURN_ALREADY_ENDED", "This turn has already ended")
+        }
 
         winConditionService.detectWinner(gameId)?.let { winner ->
             userDao.incrementWins(winner.userId)
             playerDao.getPlayers(gameId).forEach { userDao.incrementGamesPlayed(it.userId) }
             gameDao.updateStatus(gameId, GameStatus.FINISHED)
-            return EndTurnOutcome.Won(winner.id, game.roundNumber)
+            return@inTransaction EndTurnOutcome.Won(winner.id, game.roundNumber)
         }
 
         val nextPhase = advanceTurn(gameId)
-        return EndTurnOutcome.Continue(nextPhase)
+        EndTurnOutcome.Continue(nextPhase)
     }
 
     /** Advances a game to the next player's turn and persists it. */

--- a/src/main/kotlin/org/machikoro/server/service/GameTransactionRunner.kt
+++ b/src/main/kotlin/org/machikoro/server/service/GameTransactionRunner.kt
@@ -1,0 +1,15 @@
+package org.machikoro.server.service
+
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.springframework.stereotype.Component
+
+interface GameTransactionRunner {
+    fun <T> inTransaction(action: () -> T): T
+}
+
+@Component
+class ExposedGameTransactionRunner : GameTransactionRunner {
+    override fun <T> inTransaction(action: () -> T): T = transaction {
+        action()
+    }
+}

--- a/src/test/kotlin/org/machikoro/server/controller/EarningsControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/EarningsControllerTest.kt
@@ -108,6 +108,21 @@ class EarningsControllerTest {
     }
 
     @Test
+    fun `resolveEffects broadcasts domain rejection code for duplicate resolution`() {
+        val request = ResolveEffectsRequest(gameId = 1)
+        doThrow(CustomWebSocketException("EFFECTS_ALREADY_RESOLVED", "Effects have already been resolved for this turn"))
+            .whenever(earningsService).resolveEffects(1)
+
+        controller.resolveEffects(request, authedAccessor())
+
+        val captor = argumentCaptor<WebSocketMessage>()
+        verify(messagingTemplate).convertAndSend(eq("/topic/game/1"), captor.capture())
+        val payload = captor.firstValue.payload as Map<*, *>
+        assertEquals("EFFECTS_FAILED", payload["event"])
+        assertEquals("EFFECTS_ALREADY_RESOLVED", payload["code"])
+    }
+
+    @Test
     fun `resolveEffects propagates NOT_YOUR_TURN and does not call service or broadcast`() {
         val request = ResolveEffectsRequest(gameId = 1)
         whenever(gameStateGuard.ensureSenderIsActivePlayer(1, alice))

--- a/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
@@ -243,39 +243,28 @@ class GameControllerTest {
     // ── advancePhase ──────────────────────────────────────────────────────────
 
     @Test
-    fun `advancePhase delegates to service with the requested game id`() {
+    fun `advancePhase is rejected without mutating state`() {
         val gameId = 42
-        val snapshot = gameStateDto(gameId, turnPhase = TurnPhase.RESOLVE_EFFECTS)
-        whenever(gamePhaseService.advancePhase(gameId)).thenReturn(TurnPhase.RESOLVE_EFFECTS)
-        whenever(gameSyncService.buildSnapshot(gameId)).thenReturn(snapshot)
 
-        controller.advancePhase(AdvancePhaseRequest(gameId), authedAccessor())
+        val ex = assertThrows<CustomWebSocketException> {
+            controller.advancePhase(AdvancePhaseRequest(gameId), authedAccessor())
+        }
 
+        assertEquals("DIRECT_PHASE_ADVANCE_FORBIDDEN", ex.errorCode)
         verify(gameStateGuard).ensureSenderIsActivePlayer(gameId, alice)
-        verify(gamePhaseService).advancePhase(gameId)
+        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
+        verify(gameSyncService, never()).buildSnapshot(any())
     }
 
     @Test
-    fun `advancePhase broadcasts new phase and activePlayerId as GAME_ACTION`() {
+    fun `advancePhase rejection does not invoke end turn behavior`() {
         val gameId = 42
-        val snapshot = gameStateDto(gameId, turnPhase = TurnPhase.RESOLVE_EFFECTS)
-        whenever(gamePhaseService.advancePhase(gameId)).thenReturn(TurnPhase.RESOLVE_EFFECTS)
-        whenever(gameSyncService.buildSnapshot(gameId)).thenReturn(snapshot)
 
-        controller.advancePhase(AdvancePhaseRequest(gameId), authedAccessor())
+        assertThrows<CustomWebSocketException> {
+            controller.advancePhase(AdvancePhaseRequest(gameId), authedAccessor())
+        }
 
-        val captor = argumentCaptor<WebSocketMessage>()
-        verify(messagingTemplate).convertAndSend(eq("/topic/game/$gameId"), captor.capture())
-
-        val message = captor.firstValue
-        assertEquals(MessageType.GAME_ACTION, message.type)
-        assertEquals("server", message.sender)
-        @Suppress("UNCHECKED_CAST")
-        val payload = message.payload as Map<String, Any?>
-        assertEquals("PHASE_ADVANCED", payload["event"])
-        assertEquals("RESOLVE_EFFECTS", payload["turnPhase"])
-        assertEquals(1, payload["activePlayerId"])
-        assertEquals(snapshot, payload["state"])
+        verify(gamePhaseService, never()).endTurn(any())
     }
 
     @Test
@@ -288,7 +277,6 @@ class GameControllerTest {
             controller.advancePhase(AdvancePhaseRequest(gameId), authedAccessor())
         }
         assertEquals("NOT_YOUR_TURN", ex.errorCode)
-        verify(gamePhaseService, never()).advancePhase(any())
         verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
     }
 
@@ -302,7 +290,6 @@ class GameControllerTest {
             controller.advancePhase(AdvancePhaseRequest(gameId), authedAccessor())
         }
         assertEquals("GAME_NOT_STARTED", ex.errorCode)
-        verify(gamePhaseService, never()).advancePhase(any())
         verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
     }
 
@@ -612,7 +599,6 @@ class GameControllerTest {
     @Test
     fun `advancePhase throws UNAUTHENTICATED when accessor has no principal`() {
         assertUnauthenticated { controller.advancePhase(AdvancePhaseRequest(42), it) }
-        verify(gamePhaseService, never()).advancePhase(any())
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
@@ -548,6 +548,34 @@ class GameControllerTest {
     }
 
     @Test
+    fun `rollDice broadcasts domain error code to game topic on rejected roll`() {
+        val gameId = 1
+        val activePlayer = PlayerModel(id = 9, gameId = gameId, userId = alice.userId, turnOrder = 0, coins = 3, lastSeenAt = null)
+        val request = RollDiceRequest(gameId = gameId, playerId = null)
+        whenever(gameStateGuard.ensureSenderIsActivePlayer(gameId, alice)).thenReturn(activePlayer)
+        whenever(diceService.rollDice(request, activePlayer.id))
+            .thenThrow(CustomWebSocketException("ROLL_ALREADY_COMPLETED", "Dice have already been rolled for this turn"))
+
+        controller.rollDice(request, authedAccessor())
+
+        val captor = argumentCaptor<WebSocketMessage>()
+        verify(messagingTemplate).convertAndSend(eq("/topic/game/$gameId"), captor.capture())
+        val message = captor.firstValue
+        assertEquals(MessageType.ERROR, message.type)
+        assertEquals("SERVER", message.sender)
+        assertEquals(
+            mapOf(
+                "event" to "ROLL_FAILED",
+                "code" to "ROLL_ALREADY_COMPLETED",
+                "message" to "Dice have already been rolled for this turn",
+            ),
+            message.payload,
+        )
+        verify(diceService).rollDice(request, activePlayer.id)
+        verify(gameStateGuard, never()).ensureSenderOwnsPlayer(any(), any(), any())
+    }
+
+    @Test
     fun `rollDice propagates NOT_YOUR_TURN and does not call service or broadcast`() {
         val gameId = 1
         val playerId = 2

--- a/src/test/kotlin/org/machikoro/server/controller/GameWebSocketBroadcastIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/GameWebSocketBroadcastIntegrationTest.kt
@@ -18,13 +18,16 @@ import org.machikoro.server.dto.EndTurnOutcome
 import org.machikoro.server.dto.GameStateDto
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.PurchaseType
+import org.machikoro.server.dto.RollDiceResponse
 import org.machikoro.server.dto.WebSocketMessage
 import org.machikoro.server.exception.CustomWebSocketException
+import org.machikoro.server.service.DiceService
 import org.machikoro.server.service.GamePhaseService
 import org.machikoro.server.service.GameStateGuard
 import org.machikoro.server.service.GameSyncService
 import org.machikoro.server.service.LobbyService
 import org.machikoro.server.service.PurchaseService
+import org.machikoro.server.service.interfaces.EarningsService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
@@ -95,6 +98,12 @@ class GameWebSocketBroadcastIntegrationTest {
     @MockitoBean
     private lateinit var purchaseService: PurchaseService
 
+    @MockitoBean
+    private lateinit var diceService: DiceService
+
+    @MockitoBean
+    private lateinit var earningsService: EarningsService
+
     @AfterEach
     fun disconnectSessions() {
         activeSessions.filter { it.isConnected }.forEach(StompSession::disconnect)
@@ -154,11 +163,12 @@ class GameWebSocketBroadcastIntegrationTest {
 
         val firstActiveUserId = startedPair.first["payload"]["activePlayerId"].asInt()
         val firstActiveSession = sessionFor(firstActiveUserId, host, hostSession, guestSession)
-        sendJson(firstActiveSession, "/app/game.advancePhase", mapOf("gameId" to gameId))
-        assertSameGameActionBroadcast(hostGameQueue, guestGameQueue, "PHASE_ADVANCED")
+        sendJson(firstActiveSession, "/app/game.rollDice", mapOf("gameId" to gameId))
+        assertSameGameBroadcast(hostGameQueue, guestGameQueue, MessageType.ROLL_DICE)
+        assertSameGameActionBroadcast(hostGameQueue, guestGameQueue, "DICE_ROLLED")
 
-        sendJson(firstActiveSession, "/app/game.advancePhase", mapOf("gameId" to gameId))
-        assertSameGameActionBroadcast(hostGameQueue, guestGameQueue, "PHASE_ADVANCED")
+        sendJson(firstActiveSession, "/app/game.resolveEffects", mapOf("gameId" to gameId))
+        assertSameGameActionBroadcast(hostGameQueue, guestGameQueue, "EFFECTS_RESOLVED")
 
         sendJson(firstActiveSession, "/app/game.endTurn", mapOf("gameId" to gameId))
         val turnEnded = assertSameGameActionBroadcast(hostGameQueue, guestGameQueue, "TURN_ENDED")
@@ -173,8 +183,9 @@ class GameWebSocketBroadcastIntegrationTest {
         )
 
         val secondActiveSession = sessionFor(secondActiveUserId, host, hostSession, guestSession)
-        sendJson(secondActiveSession, "/app/game.advancePhase", mapOf("gameId" to gameId))
-        assertSameGameActionBroadcast(hostGameQueue, guestGameQueue, "PHASE_ADVANCED")
+        sendJson(secondActiveSession, "/app/game.rollDice", mapOf("gameId" to gameId))
+        assertSameGameBroadcast(hostGameQueue, guestGameQueue, MessageType.ROLL_DICE)
+        assertSameGameActionBroadcast(hostGameQueue, guestGameQueue, "DICE_ROLLED")
     }
 
     @Test
@@ -267,8 +278,8 @@ class GameWebSocketBroadcastIntegrationTest {
         whenever(lobbyService.joinLobby(lobbyCode, guest.userId)).thenReturn(guestPlayer)
         whenever(lobbyService.getLobbyRoster(gameId)).thenReturn(emptyList())
         whenever(lobbyService.startGame(gameId, host.userId)).thenReturn(startedState)
-        whenever(gamePhaseService.advancePhase(gameId)).thenReturn(TurnPhase.RESOLVE_EFFECTS, TurnPhase.BUY_OR_BUILD)
         whenever(gamePhaseService.endTurn(gameId)).thenReturn(EndTurnOutcome.Continue(TurnPhase.ROLL_DICE))
+        whenever(diceService.rollDice(any(), any())).thenReturn(RollDiceResponse(dice = listOf(4), total = 4))
         whenever(gameSyncService.buildSnapshot(gameId)).thenReturn(
             resolveEffectsState,
             buyOrBuildState,

--- a/src/test/kotlin/org/machikoro/server/controller/GameWebSocketBroadcastIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/GameWebSocketBroadcastIntegrationTest.kt
@@ -158,14 +158,26 @@ class GameWebSocketBroadcastIntegrationTest {
         )
 
         sendJson(hostSession, "/app/game.start", mapOf("gameId" to gameId))
-        val startedPair = assertSameGameBroadcast(hostGameQueue, guestGameQueue, MessageType.GAME_STARTED)
-        assertSameGameActionBroadcast(hostGameQueue, guestGameQueue, "GAME_STARTED")
+        val startMessages = takeSameMessageBatch(hostGameQueue, guestGameQueue, expectedMessages = 2, description = "game start")
+        val startedPair = assertSameBroadcastInBatch(startMessages, "GAME_STARTED frame") {
+            it["type"].asText() == MessageType.GAME_STARTED.name
+        }
+        assertSameBroadcastInBatch(startMessages, "GAME_STARTED action") {
+            it["type"].asText() == MessageType.GAME_ACTION.name &&
+                it["payload"]["event"].asText() == "GAME_STARTED"
+        }
 
         val firstActiveUserId = startedPair.first["payload"]["activePlayerId"].asInt()
         val firstActiveSession = sessionFor(firstActiveUserId, host, hostSession, guestSession)
         sendJson(firstActiveSession, "/app/game.rollDice", mapOf("gameId" to gameId))
-        assertSameGameBroadcast(hostGameQueue, guestGameQueue, MessageType.ROLL_DICE)
-        assertSameGameActionBroadcast(hostGameQueue, guestGameQueue, "DICE_ROLLED")
+        val firstRollMessages = takeSameMessageBatch(hostGameQueue, guestGameQueue, expectedMessages = 2, description = "first dice roll")
+        assertSameBroadcastInBatch(firstRollMessages, "ROLL_DICE frame") {
+            it["type"].asText() == MessageType.ROLL_DICE.name
+        }
+        assertSameBroadcastInBatch(firstRollMessages, "DICE_ROLLED action") {
+            it["type"].asText() == MessageType.GAME_ACTION.name &&
+                it["payload"]["event"].asText() == "DICE_ROLLED"
+        }
 
         sendJson(firstActiveSession, "/app/game.resolveEffects", mapOf("gameId" to gameId))
         assertSameGameActionBroadcast(hostGameQueue, guestGameQueue, "EFFECTS_RESOLVED")
@@ -184,8 +196,14 @@ class GameWebSocketBroadcastIntegrationTest {
 
         val secondActiveSession = sessionFor(secondActiveUserId, host, hostSession, guestSession)
         sendJson(secondActiveSession, "/app/game.rollDice", mapOf("gameId" to gameId))
-        assertSameGameBroadcast(hostGameQueue, guestGameQueue, MessageType.ROLL_DICE)
-        assertSameGameActionBroadcast(hostGameQueue, guestGameQueue, "DICE_ROLLED")
+        val secondRollMessages = takeSameMessageBatch(hostGameQueue, guestGameQueue, expectedMessages = 2, description = "second dice roll")
+        assertSameBroadcastInBatch(secondRollMessages, "second ROLL_DICE frame") {
+            it["type"].asText() == MessageType.ROLL_DICE.name
+        }
+        assertSameBroadcastInBatch(secondRollMessages, "second DICE_ROLLED action") {
+            it["type"].asText() == MessageType.GAME_ACTION.name &&
+                it["payload"]["event"].asText() == "DICE_ROLLED"
+        }
     }
 
     @Test
@@ -406,6 +424,29 @@ class GameWebSocketBroadcastIntegrationTest {
         return hostMessage to guestMessage
     }
 
+    private fun takeSameMessageBatch(
+        hostQueue: BlockingQueue<JsonNode>,
+        guestQueue: BlockingQueue<JsonNode>,
+        expectedMessages: Int,
+        description: String,
+    ): Pair<List<JsonNode>, List<JsonNode>> =
+        takeMessages(hostQueue, expectedMessages, description) to
+            takeMessages(guestQueue, expectedMessages, description)
+
+    private fun assertSameBroadcastInBatch(
+        messages: Pair<List<JsonNode>, List<JsonNode>>,
+        description: String,
+        predicate: (JsonNode) -> Boolean,
+    ): Pair<JsonNode, JsonNode> {
+        val (hostMessages, guestMessages) = messages
+        val hostMessage = hostMessages.firstOrNull(predicate)
+            ?: error("Timed out waiting for $description; seen=$hostMessages")
+        val guestMessage = guestMessages.firstOrNull(predicate)
+            ?: error("Timed out waiting for $description; seen=$guestMessages")
+        assertEquivalentGameBroadcast(hostMessage, guestMessage)
+        return hostMessage to guestMessage
+    }
+
     private fun takeGameAction(queue: BlockingQueue<JsonNode>, event: String): JsonNode =
         generateSequence { takeMessage(queue, MessageType.GAME_ACTION) }
             .first { it["payload"]["event"].asText() == event }
@@ -442,6 +483,20 @@ class GameWebSocketBroadcastIntegrationTest {
             }
         }
         error("Timed out waiting for $type; seen=$seen")
+    }
+
+    private fun takeMessages(queue: BlockingQueue<JsonNode>, count: Int, description: String): List<JsonNode> {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(MESSAGE_TIMEOUT_SECONDS)
+        val messages = mutableListOf<JsonNode>()
+        while (messages.size < count && System.nanoTime() < deadline) {
+            val remaining = deadline - System.nanoTime()
+            val message = queue.poll(remaining, TimeUnit.NANOSECONDS) ?: break
+            messages.add(message)
+        }
+        if (messages.size < count) {
+            error("Timed out waiting for $count messages for $description; seen=$messages")
+        }
+        return messages
     }
 
     private fun sessionFor(

--- a/src/test/kotlin/org/machikoro/server/dao/GameDaoTest.kt
+++ b/src/test/kotlin/org/machikoro/server/dao/GameDaoTest.kt
@@ -131,6 +131,26 @@ class GameDaoTest : AbstractDBSetup() {
     }
 
     @Test
+    fun `tryRecordDiceRoll records exactly one roll in a turn`() {
+        val id = gameDao.create(hostId)
+
+        assertTrue(gameDao.tryRecordDiceRoll(id, diceRoll = 4))
+        assertFalse(gameDao.tryRecordDiceRoll(id, diceRoll = 6))
+
+        val game = gameDao.findById(id)!!
+        assertEquals(4, game.lastDiceRoll)
+        assertEquals(TurnPhase.RESOLVE_EFFECTS, game.turnPhase)
+    }
+
+    @Test
+    fun `tryTransitionPhase rejects a stale expected phase`() {
+        val id = gameDao.create(hostId)
+
+        assertFalse(gameDao.tryTransitionPhase(id, TurnPhase.RESOLVE_EFFECTS, TurnPhase.BUY_OR_BUILD))
+        assertEquals(TurnPhase.ROLL_DICE, gameDao.findById(id)!!.turnPhase)
+    }
+
+    @Test
     fun `updateHasPurchasedThisTurn changes purchase state`() {
         val id = gameDao.create(hostId)
         gameDao.updateHasPurchasedThisTurn(id, true)

--- a/src/test/kotlin/org/machikoro/server/service/BackendContainerRestartRecoverySmokeTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/BackendContainerRestartRecoverySmokeTest.kt
@@ -187,9 +187,9 @@ class BackendContainerRestartRecoverySmokeTest {
         gameId: Int,
         queue: BlockingQueue<JsonNode>,
     ) {
-        sendJson(session, "/app/game.advancePhase", mapOf("gameId" to gameId))
-        takeGameAction(queue) { it.path("turnPhase").asText() == TurnPhase.RESOLVE_EFFECTS.name }
-        sendJson(session, "/app/game.advancePhase", mapOf("gameId" to gameId))
+        sendJson(session, "/app/game.rollDice", mapOf("gameId" to gameId))
+        takeGameAction(queue) { it.path("event").asText() == "DICE_ROLLED" }
+        sendJson(session, "/app/game.resolveEffects", mapOf("gameId" to gameId))
         takeGameAction(queue) { it.path("turnPhase").asText() == TurnPhase.BUY_OR_BUILD.name }
     }
 

--- a/src/test/kotlin/org/machikoro/server/service/DiceServiceTests.kt
+++ b/src/test/kotlin/org/machikoro/server/service/DiceServiceTests.kt
@@ -103,6 +103,21 @@ class DiceServiceTests {
     }
 
     @Test
+    fun rollDiceShouldThrowWhenRollPhaseAlreadyHasStoredRoll() {
+        whenever(gameStateGuard.ensureGameIsRunning(1))
+            .thenReturn(defaultGame.copy(lastDiceRoll = 4))
+
+        val request = RollDiceRequest(gameId = 1, playerId = 2)
+
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            diceService.rollDice(request, rollingPlayerId = 2)
+        }
+
+        assertEquals("ROLL_ALREADY_COMPLETED", ex.errorCode)
+        verify(gameDao, never()).tryRecordDiceRoll(any(), any())
+    }
+
+    @Test
     fun rollDiceShouldRejectDuplicateAfterCompletedRoll() {
         whenever(gameStateGuard.ensureGameIsRunning(1))
             .thenReturn(defaultGame)
@@ -187,6 +202,48 @@ class DiceServiceTests {
         assertEquals(2, result.dice.size)
         assert(result.total in 2..12)
         assertEquals(result.dice.sum(), result.total)
+    }
+
+    @Test
+    fun rollTwoDiceShouldUseTopLevelLegacyDiceCountWhenTrainStationOwned() {
+        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(defaultGame)
+        whenever(playerLandmarkDao.findByPlayerIdAndType(2, LandmarkType.TRAIN_STATION))
+            .thenReturn(PlayerLandmarkModel(playerId = 2, landmarkType = LandmarkType.TRAIN_STATION, isBuilt = true))
+
+        val request = RollDiceRequest(gameId = 1, diceCount = 2)
+        val result = diceService.rollDice(request, rollingPlayerId = 2)
+
+        assertEquals(2, result.dice.size)
+        assert(result.total in 2..12)
+        assertEquals(result.dice.sum(), result.total)
+    }
+
+    @Test
+    fun rollTwoDiceShouldUseNestedLegacyRollTwoDiceWhenTrainStationOwned() {
+        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(defaultGame)
+        whenever(playerLandmarkDao.findByPlayerIdAndType(2, LandmarkType.TRAIN_STATION))
+            .thenReturn(PlayerLandmarkModel(playerId = 2, landmarkType = LandmarkType.TRAIN_STATION, isBuilt = true))
+
+        val request = RollDiceRequest(gameId = 1, payload = RollDicePayload(gameId = 1, rollTwoDice = true))
+        val result = diceService.rollDice(request, rollingPlayerId = 2)
+
+        assertEquals(2, result.dice.size)
+        assert(result.total in 2..12)
+        assertEquals(result.dice.sum(), result.total)
+    }
+
+    @Test
+    fun rollDiceShouldRejectWhenAtomicRecordFails() {
+        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(defaultGame)
+        whenever(gameDao.tryRecordDiceRoll(any(), any())).thenReturn(false)
+
+        val request = RollDiceRequest(gameId = 1, playerId = 2)
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            diceService.rollDice(request, rollingPlayerId = 2)
+        }
+
+        assertEquals("ROLL_ALREADY_COMPLETED", ex.errorCode)
+        verify(gameDao).tryRecordDiceRoll(any(), any())
     }
 
 

--- a/src/test/kotlin/org/machikoro/server/service/DiceServiceTests.kt
+++ b/src/test/kotlin/org/machikoro/server/service/DiceServiceTests.kt
@@ -2,6 +2,7 @@ package org.machikoro.server.service
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.machikoro.server.dao.GameDao
 import org.machikoro.server.dao.PlayerLandmarkDao
@@ -30,6 +31,11 @@ class DiceServiceTests {
     private val playerLandmarkDao = mock<PlayerLandmarkDao>()
     private val gameStateGuard = mock<GameStateGuard>()
     private val diceService = DiceService(gameDao, playerLandmarkDao, gameStateGuard)
+
+    @BeforeEach
+    fun permitFirstRecordedRoll() {
+        whenever(gameDao.tryRecordDiceRoll(any(), any())).thenReturn(true)
+    }
 
     private val defaultGame = GameModel(
         id = 1,
@@ -66,7 +72,7 @@ class DiceServiceTests {
         assertThrows(GameNotFoundException::class.java) {
             diceService.rollDice(request, rollingPlayerId = 2)
         }
-        verify(gameDao, never()).updateAfterRoll(any(), any(), any())
+        verify(gameDao, never()).tryRecordDiceRoll(any(), any())
     }
 
     @Test
@@ -80,7 +86,7 @@ class DiceServiceTests {
             diceService.rollDice(request, rollingPlayerId = 2)
         }
         assertEquals("GAME_FINISHED", ex.errorCode)
-        verify(gameDao, never()).updateAfterRoll(any(), any(), any())
+        verify(gameDao, never()).tryRecordDiceRoll(any(), any())
     }
 
     @Test
@@ -191,7 +197,7 @@ class DiceServiceTests {
         val request = RollDiceRequest(gameId = 1, playerId = 2)
         val result = diceService.rollDice(request, rollingPlayerId = 2)
 
-        verify(gameDao).updateAfterRoll(1, result.total, TurnPhase.RESOLVE_EFFECTS)
+        verify(gameDao).tryRecordDiceRoll(1, result.total)
         assertEquals(true, result.completed)
         assertEquals(TurnPhase.RESOLVE_EFFECTS, result.turnPhase)
     }
@@ -203,7 +209,7 @@ class DiceServiceTests {
         val request = RollDiceRequest(gameId = 1, playerId = 2)
         val result = diceService.rollDice(request, rollingPlayerId = 2)
 
-        verify(gameDao).updateAfterRoll(any(), any(), org.mockito.kotlin.eq(TurnPhase.RESOLVE_EFFECTS))
+        verify(gameDao).tryRecordDiceRoll(any(), any())
     }
 
     @Test
@@ -216,6 +222,6 @@ class DiceServiceTests {
         assertThrows(CustomWebSocketException::class.java) {
             diceService.rollDice(request, rollingPlayerId = 2)
         }
-        verify(gameDao, never()).updateAfterRoll(any(), any(), any())
+        verify(gameDao, never()).tryRecordDiceRoll(any(), any())
     }
 }

--- a/src/test/kotlin/org/machikoro/server/service/EarningsIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/EarningsIntegrationTest.kt
@@ -7,6 +7,7 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.assertThrows
 import org.machikoro.server.database.AbstractDBSetup
 import org.machikoro.server.database.CardActivationNumbers
 import org.machikoro.server.database.Cards
@@ -20,6 +21,7 @@ import org.machikoro.server.domain.enums.EstablishmentType
 import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.enums.PaymentSource
 import org.machikoro.server.domain.enums.TurnPhase
+import org.machikoro.server.exception.CustomWebSocketException
 import org.machikoro.server.service.interfaces.EarningsService
 import org.springframework.beans.factory.annotation.Autowired
 import kotlin.test.Test
@@ -151,6 +153,21 @@ class EarningsIntegrationTest : AbstractDBSetup() {
         // P2: 3 + 1 (Cafe, from P1) = 4
         assertEquals(2, p1.coins)
         assertEquals(4, p2.coins)
+        assertEquals(TurnPhase.BUY_OR_BUILD, gameDao.findById(gameId)!!.turnPhase)
+    }
+
+    @Test
+    fun `duplicate effect resolution is rejected without changing coins`() {
+        earningsService.resolveEffects(gameId)
+        val before = playerDao.getPlayers(gameId).map { it.id to it.coins }
+
+        val ex = assertThrows<CustomWebSocketException> {
+            earningsService.resolveEffects(gameId)
+        }
+
+        assertEquals("EFFECTS_ALREADY_RESOLVED", ex.errorCode)
+        assertEquals(before, playerDao.getPlayers(gameId).map { it.id to it.coins })
+        assertEquals(TurnPhase.BUY_OR_BUILD, gameDao.findById(gameId)!!.turnPhase)
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/service/EarningsServiceImplTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/EarningsServiceImplTest.kt
@@ -295,6 +295,99 @@ class EarningsServiceImplTest {
         assertEquals("DICE_ROLL_REQUIRED", ex.errorCode)
     }
 
+    @Test
+    fun `resolveEffects rejects duplicate resolution in buy phase`() {
+        val game = GameModel(
+            id = 1, status = GameStatus.IN_PROGRESS, hostUserId = 1, lobbyCode = "TEST",
+            maxPlayers = 4, currentTurnIndex = 0, turnPhase = TurnPhase.BUY_OR_BUILD,
+            lastDiceRoll = 4, roundNumber = 1, hasPurchasedThisTurn = false
+        )
+        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(game)
+
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            service.resolveEffects(1)
+        }
+
+        assertEquals("EFFECTS_ALREADY_RESOLVED", ex.errorCode)
+        verify(gameDao, never()).tryTransitionPhase(1, TurnPhase.RESOLVE_EFFECTS, TurnPhase.BUY_OR_BUILD)
+        verify(playerDao, never()).getPlayers(anyInt())
+    }
+
+    @Test
+    fun `resolveEffects rejects duplicate resolution in end turn phase`() {
+        val game = GameModel(
+            id = 1, status = GameStatus.IN_PROGRESS, hostUserId = 1, lobbyCode = "TEST",
+            maxPlayers = 4, currentTurnIndex = 0, turnPhase = TurnPhase.END_TURN,
+            lastDiceRoll = 4, roundNumber = 1, hasPurchasedThisTurn = false
+        )
+        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(game)
+
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            service.resolveEffects(1)
+        }
+
+        assertEquals("EFFECTS_ALREADY_RESOLVED", ex.errorCode)
+        verify(gameDao, never()).tryTransitionPhase(1, TurnPhase.RESOLVE_EFFECTS, TurnPhase.BUY_OR_BUILD)
+        verify(playerDao, never()).getPlayers(anyInt())
+    }
+
+    @Test
+    fun `resolveEffects requires stored dice roll in resolve phase`() {
+        val game = GameModel(
+            id = 1, status = GameStatus.IN_PROGRESS, hostUserId = 1, lobbyCode = "TEST",
+            maxPlayers = 4, currentTurnIndex = 0, turnPhase = TurnPhase.RESOLVE_EFFECTS,
+            lastDiceRoll = null, roundNumber = 1, hasPurchasedThisTurn = false
+        )
+        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(game)
+
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            service.resolveEffects(1)
+        }
+
+        assertEquals("DICE_ROLL_REQUIRED", ex.errorCode)
+        verify(gameDao, never()).tryTransitionPhase(1, TurnPhase.RESOLVE_EFFECTS, TurnPhase.BUY_OR_BUILD)
+        verify(playerDao, never()).getPlayers(anyInt())
+    }
+
+    @Test
+    fun `resolveEffects rejects stale transition without applying earnings`() {
+        val game = GameModel(
+            id = 1, status = GameStatus.IN_PROGRESS, hostUserId = 1, lobbyCode = "TEST",
+            maxPlayers = 4, currentTurnIndex = 0, turnPhase = TurnPhase.RESOLVE_EFFECTS,
+            lastDiceRoll = 4, roundNumber = 1, hasPurchasedThisTurn = false
+        )
+        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(game)
+        whenever(gameDao.tryTransitionPhase(1, TurnPhase.RESOLVE_EFFECTS, TurnPhase.BUY_OR_BUILD))
+            .thenReturn(false)
+
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            service.resolveEffects(1)
+        }
+
+        assertEquals("EFFECTS_ALREADY_RESOLVED", ex.errorCode)
+        verify(playerDao, never()).getPlayers(anyInt())
+    }
+
+    @Test
+    fun `resolveEffects rejects missing active player after phase transition`() {
+        val game = GameModel(
+            id = 1, status = GameStatus.IN_PROGRESS, hostUserId = 1, lobbyCode = "TEST",
+            maxPlayers = 4, currentTurnIndex = 1, turnPhase = TurnPhase.RESOLVE_EFFECTS,
+            lastDiceRoll = 4, roundNumber = 1, hasPurchasedThisTurn = false
+        )
+        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(game)
+        whenever(gameDao.tryTransitionPhase(1, TurnPhase.RESOLVE_EFFECTS, TurnPhase.BUY_OR_BUILD))
+            .thenReturn(true)
+        whenever(playerDao.getPlayers(1)).thenReturn(listOf(player(1, 3)))
+
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            service.resolveEffects(1)
+        }
+
+        assertEquals("NO_ACTIVE_PLAYER", ex.errorCode)
+        verify(cardDao, never()).findByActivationNumber(anyInt())
+    }
+
     private fun player(id: Int, coins: Int): PlayerModel =
         PlayerModel(id = id, gameId = 1, userId = id, turnOrder = 0, coins = coins, lastSeenAt = null)
 

--- a/src/test/kotlin/org/machikoro/server/service/EarningsServiceImplTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/EarningsServiceImplTest.kt
@@ -21,6 +21,7 @@ import org.mockito.kotlin.whenever
 import org.machikoro.server.domain.enums.CardType
 import org.machikoro.server.domain.enums.EstablishmentType
 import org.machikoro.server.domain.enums.GameStatus
+import org.machikoro.server.exception.CustomWebSocketException
 
 class EarningsServiceImplTest {
 
@@ -28,7 +29,10 @@ class EarningsServiceImplTest {
     private lateinit var playerCardDao: PlayerCardDao
     private lateinit var cardDao: CardDao
     private lateinit var gameDao: GameDao
-    private lateinit var gamePhaseService: GamePhaseService
+    private lateinit var gameStateGuard: GameStateGuard
+    private val transactionRunner = object : GameTransactionRunner {
+        override fun <T> inTransaction(action: () -> T): T = action()
+    }
 
     private lateinit var service: EarningsServiceImpl
 
@@ -38,14 +42,15 @@ class EarningsServiceImplTest {
         playerCardDao = mock(PlayerCardDao::class.java)
         cardDao = mock(CardDao::class.java)
         gameDao = mock(GameDao::class.java)
-        gamePhaseService = mock(GamePhaseService::class.java)
+        gameStateGuard = mock(GameStateGuard::class.java)
 
         service = EarningsServiceImpl(
             playerDao,
             playerCardDao,
             cardDao,
             gameDao,
-            gamePhaseService,
+            gameStateGuard,
+            transactionRunner,
         )
     }
 
@@ -252,8 +257,10 @@ class EarningsServiceImplTest {
             lastDiceRoll = 1, roundNumber = 1, hasPurchasedThisTurn = false
         )
 
-        whenever(gameDao.findById(1))
+        whenever(gameStateGuard.ensureGameIsRunning(1))
             .thenReturn(game)
+        whenever(gameDao.tryTransitionPhase(1, TurnPhase.RESOLVE_EFFECTS, TurnPhase.BUY_OR_BUILD))
+            .thenReturn(true)
 
         whenever(playerDao.getPlayers(1))
             .thenReturn(listOf(player(1, 3)))
@@ -266,7 +273,7 @@ class EarningsServiceImplTest {
 
         service.resolveEffects(1)
 
-        verify(gamePhaseService).advancePhase(1)
+        verify(gameDao).tryTransitionPhase(1, TurnPhase.RESOLVE_EFFECTS, TurnPhase.BUY_OR_BUILD)
     }
 
     // Invalid phases should fail immediately
@@ -279,12 +286,13 @@ class EarningsServiceImplTest {
             lastDiceRoll = null, roundNumber = 1, hasPurchasedThisTurn = false
         )
 
-        whenever(gameDao.findById(1))
+        whenever(gameStateGuard.ensureGameIsRunning(1))
             .thenReturn(game)
 
-        assertThrows(IllegalStateException::class.java) {
+        val ex = assertThrows(CustomWebSocketException::class.java) {
             service.resolveEffects(1)
         }
+        assertEquals("DICE_ROLL_REQUIRED", ex.errorCode)
     }
 
     private fun player(id: Int, coins: Int): PlayerModel =

--- a/src/test/kotlin/org/machikoro/server/service/GamePhaseServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GamePhaseServiceTest.kt
@@ -34,6 +34,9 @@ class GamePhaseServiceTest {
     private val gameMarketplaceDao = mock<GameMarketplaceDao>()
     private val gameStateGuard = mock<GameStateGuard>()
     private val winConditionService = mock<WinConditionService>()
+    private val transactionRunner = object : GameTransactionRunner {
+        override fun <T> inTransaction(action: () -> T): T = action()
+    }
 
     private val service = GamePhaseService(
         gameDao,
@@ -43,7 +46,8 @@ class GamePhaseServiceTest {
         playerLandmarkDao,
         gameMarketplaceDao,
         gameStateGuard,
-        winConditionService
+        winConditionService,
+        transactionRunner,
     )
 
     private fun gameInPhase(
@@ -64,63 +68,19 @@ class GamePhaseServiceTest {
         roundNumber = roundNumber,
     )
 
-
     @Test
-    fun `ROLL_DICE advances to RESOLVE_EFFECTS`() {
-        assertEquals(TurnPhase.RESOLVE_EFFECTS, service.nextPhase(TurnPhase.ROLL_DICE))
-    }
-
-    @Test
-    fun `RESOLVE_EFFECTS advances to BUY_OR_BUILD`() {
-        assertEquals(TurnPhase.BUY_OR_BUILD, service.nextPhase(TurnPhase.RESOLVE_EFFECTS))
-    }
-
-    @Test
-    fun `BUY_OR_BUILD advances to END_TURN`() {
-        assertEquals(TurnPhase.END_TURN, service.nextPhase(TurnPhase.BUY_OR_BUILD))
-    }
-
-    @Test
-    fun `END_TURN cycles back to ROLL_DICE`() {
-        assertEquals(TurnPhase.ROLL_DICE, service.nextPhase(TurnPhase.END_TURN))
-    }
-
-    @Test
-    fun `nextPhase handles every TurnPhase value`() {
-        TurnPhase.entries.forEach { phase ->
-            service.nextPhase(phase)
-        }
-    }
-
-    @Test
-    fun `full cycle completes correctly`() {
-        var phase = TurnPhase.ROLL_DICE
-        assertEquals(TurnPhase.ROLL_DICE, phase)
-
-        phase = service.nextPhase(phase)
-        assertEquals(TurnPhase.RESOLVE_EFFECTS, phase)
-
-        phase = service.nextPhase(phase)
-        assertEquals(TurnPhase.BUY_OR_BUILD, phase)
-
-        phase = service.nextPhase(phase)
-        assertEquals(TurnPhase.END_TURN, phase)
-
-        phase = service.nextPhase(phase)
-        assertEquals(TurnPhase.ROLL_DICE, phase)
-    }
-
-    @Test
-    fun `advancePhase reads current phase and persists the next one`() {
+    fun `endTurn rejects when another request has already completed the transition`() {
         val gameId = 42
         whenever(gameStateGuard.ensureGameIsRunning(gameId))
-            .thenReturn(gameInPhase(gameId, TurnPhase.ROLL_DICE))
+            .thenReturn(gameInPhase(gameId, TurnPhase.BUY_OR_BUILD))
+        whenever(gameDao.tryTransitionPhase(gameId, TurnPhase.BUY_OR_BUILD, TurnPhase.END_TURN))
+            .thenReturn(false)
 
-        val result = service.advancePhase(gameId)
+        val ex = assertThrows<CustomWebSocketException> { service.endTurn(gameId) }
 
-        assertEquals(TurnPhase.RESOLVE_EFFECTS, result)
-        verify(gameStateGuard).ensureGameIsRunning(gameId)
-        verify(gameDao).updateTurnPhase(gameId, TurnPhase.RESOLVE_EFFECTS)
+        assertEquals("TURN_ALREADY_ENDED", ex.errorCode)
+        verify(gameDao).tryTransitionPhase(gameId, TurnPhase.BUY_OR_BUILD, TurnPhase.END_TURN)
+        verify(gameDao, never()).advanceTurn(any(), any(), any())
     }
 
     @Test
@@ -132,23 +92,12 @@ class GamePhaseServiceTest {
             .thenReturn(listOf(mock<PlayerModel>()))
         whenever(winConditionService.detectWinner(gameId))
             .thenReturn(null)
+        whenever(gameDao.tryTransitionPhase(gameId, TurnPhase.BUY_OR_BUILD, TurnPhase.END_TURN))
+            .thenReturn(true)
 
         val result = service.endTurn(gameId)
         assertTrue(result is EndTurnOutcome.Continue)
         assertEquals(TurnPhase.ROLL_DICE, result.nextPhase)
-    }
-
-    @Test
-    fun `advancePhase rejects FINISHED games and does not persist`() {
-        val gameId = 99
-        whenever(gameStateGuard.ensureGameIsRunning(gameId))
-            .thenThrow(CustomWebSocketException("GAME_FINISHED", "Game $gameId has already ended"))
-
-        val ex = assertThrows<CustomWebSocketException> {
-            service.advancePhase(gameId)
-        }
-        assertEquals("GAME_FINISHED", ex.errorCode)
-        verify(gameDao, never()).updateTurnPhase(any(), any())
     }
 
     @Test
@@ -162,6 +111,8 @@ class GamePhaseServiceTest {
                 PlayerModel(2, gameId, 11, 1, 3, lastSeenAt = 30),
             )
         )
+        whenever(gameDao.tryTransitionPhase(gameId, TurnPhase.BUY_OR_BUILD, TurnPhase.END_TURN))
+            .thenReturn(true)
 
         val result = service.endTurn(gameId)
 
@@ -173,7 +124,7 @@ class GamePhaseServiceTest {
 
         val ordered = inOrder(gameStateGuard, gameDao)
         ordered.verify(gameStateGuard).ensureGameIsRunning(gameId)
-        ordered.verify(gameDao).updateTurnPhase(gameId, TurnPhase.END_TURN)
+        ordered.verify(gameDao).tryTransitionPhase(gameId, TurnPhase.BUY_OR_BUILD, TurnPhase.END_TURN)
         ordered.verify(gameDao).advanceTurn(gameId, 1, 1)
     }
 
@@ -188,6 +139,8 @@ class GamePhaseServiceTest {
                 PlayerModel(2, gameId, 11, 1, 3, lastSeenAt = 30),
             )
         )
+        whenever(gameDao.tryTransitionPhase(gameId, TurnPhase.BUY_OR_BUILD, TurnPhase.END_TURN))
+            .thenReturn(true)
 
         val result = service.endTurn(gameId)
 
@@ -197,7 +150,7 @@ class GamePhaseServiceTest {
             (result).nextPhase
         )
 
-        verify(gameDao).updateTurnPhase(gameId, TurnPhase.END_TURN)
+        verify(gameDao).tryTransitionPhase(gameId, TurnPhase.BUY_OR_BUILD, TurnPhase.END_TURN)
         verify(gameDao).advanceTurn(gameId, 0, 4)
     }
 
@@ -215,6 +168,8 @@ class GamePhaseServiceTest {
             .thenReturn(winner)
         whenever(playerDao.getPlayers(gameId))
             .thenReturn(listOf(winner))
+        whenever(gameDao.tryTransitionPhase(gameId, TurnPhase.BUY_OR_BUILD, TurnPhase.END_TURN))
+            .thenReturn(true)
 
         val result = service.endTurn(gameId)
 
@@ -228,7 +183,7 @@ class GamePhaseServiceTest {
             (result).roundsPlayed
         )
 
-        verify(gameDao).updateTurnPhase(gameId, TurnPhase.END_TURN)
+        verify(gameDao).tryTransitionPhase(gameId, TurnPhase.BUY_OR_BUILD, TurnPhase.END_TURN)
         verify(userDao).incrementWins(userId)
         verify(gameDao).updateStatus(gameId, GameStatus.FINISHED)
     }
@@ -239,11 +194,12 @@ class GamePhaseServiceTest {
         whenever(gameStateGuard.ensureGameIsRunning(gameId))
             .thenReturn(gameInPhase(gameId, TurnPhase.RESOLVE_EFFECTS))
 
-        assertThrows<IllegalStateException> {
+        val ex = assertThrows<CustomWebSocketException> {
             service.endTurn(gameId)
         }
+        assertEquals("INVALID_TURN_PHASE", ex.errorCode)
 
-        verify(gameDao, never()).updateTurnPhase(gameId, TurnPhase.END_TURN)
+        verify(gameDao, never()).tryTransitionPhase(gameId, TurnPhase.BUY_OR_BUILD, TurnPhase.END_TURN)
         verify(gameDao, never()).advanceTurn(any(), any(), any())
         verifyNoMoreInteractions(playerDao)
     }
@@ -259,7 +215,7 @@ class GamePhaseServiceTest {
         }
         assertEquals("GAME_FINISHED", ex.errorCode)
 
-        verify(gameDao, never()).updateTurnPhase(any(), any())
+        verify(gameDao, never()).tryTransitionPhase(any(), any(), any())
         verify(gameDao, never()).advanceTurn(any(), any(), any())
         verifyNoMoreInteractions(playerDao)
     }


### PR DESCRIPTION
## Summary

Enforces an authoritative server-side turn loop for gameplay actions.

The server now controls phase transitions through explicit domain actions instead of allowing clients to advance phases directly.

## Changes

- Added guarded turn transitions:
  - `ROLL_DICE -> RESOLVE_EFFECTS` via `rollDice`
  - `RESOLVE_EFFECTS -> BUY_OR_BUILD` via `resolveEffects`
  - `BUY_OR_BUILD -> END_TURN -> ROLL_DICE` via `endTurn`
- Rejected generic `/app/game.advancePhase` gameplay use with `DIRECT_PHASE_ADVANCE_FORBIDDEN`.
- Persist dice rolls atomically and prevent duplicate rolls per turn.
- Require a stored dice roll before resolving effects.
- Prevent duplicate effect resolution for the same turn.
- Enforce `endTurn` only during `BUY_OR_BUILD`.
- Reset per-turn state for the next player:
  - `lastDiceRoll = null`
  - `hasPurchasedThisTurn = false`
  - `turnPhase = ROLL_DICE`
- Keep purchase flow restricted to `BUY_OR_BUILD` and one purchase per turn.
- Broadcast authoritative game snapshots after successful actions.
- Updated WebSocket/OpenAPI/README documentation for the explicit turn loop.
- Added/updated tests for valid turn progression and invalid bypass attempts.

## Validation

Focused test suite passed locally:

```bash
./gradlew test \
  --tests org.machikoro.server.service.DiceServiceTests \
  --tests org.machikoro.server.service.EarningsServiceImplTest \
  --tests org.machikoro.server.service.GamePhaseServiceTest \
  --tests org.machikoro.server.controller.GameControllerTest \
  --tests org.machikoro.server.controller.EarningsControllerTest \
  --tests org.machikoro.server.controller.GameWebSocketBroadcastIntegrationTest \
  --no-daemon