### PR TITLE
Sync Player Ready State in Lobby

### DIFF
--- a/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
@@ -5,7 +5,6 @@ import io.github.springwolf.core.asyncapi.annotations.AsyncOperation
 import org.machikoro.server.auth.userPrincipal
 import org.machikoro.server.dto.LobbyLeavingOutcome
 import org.machikoro.server.dto.LobbyRosterDto
-import org.machikoro.server.dto.LobbyRosterPlayerDto
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.WebSocketMessage
 import org.machikoro.server.exception.CustomWebSocketException
@@ -162,7 +161,8 @@ class LobbyWebSocketController(
             )
         }
 
-        // Broadcast join to all members already subscribed to this lobby's topic
+        // Broadcast join event to existing members, then follow up with full roster so
+        // ready states remain accurate for everyone in the lobby
         messagingTemplate.convertAndSend(
             "/topic/game/${player.gameId}",
             WebSocketMessage(
@@ -179,28 +179,19 @@ class LobbyWebSocketController(
                 )
             )
         )
+        val updatedRoster = lobbyService.getLobbyRoster(player.gameId)
+        messagingTemplate.convertAndSend(
+            "/topic/game/${player.gameId}",
+            WebSocketMessage(
+                type = MessageType.LOBBY_ROSTER,
+                sender = "SERVER",
+                content = "Lobby roster",
+                gameId = player.gameId,
+                payload = LobbyRosterDto(players = updatedRoster)
+            )
+        )
     }
 
-    /**
-     * Handles a player leaving a lobby via WebSocket.
-     *
-     * Client sends a message to `/app/lobby.leave` with the `gameId`
-     * in the payload.
-     *
-     * The authenticated player is removed from the lobby. If the lobby
-     * still contains real players, a `LOBBY_LEFT` event is broadcast to
-     * `/topic/game/{gameId}` so remaining members can update screen.
-     *
-     * If no real players remain (debug/dummy players do not count), the
-     * lobby is deleted and a `HOST_LEFT` event is broadcast so clients
-     * can close the lobby UI.
-     *
-     * Authentication is derived from the WebSocket principal; the sender
-     * field in [WebSocketMessage] is ignored to prevent spoofing.
-     *
-     * @throws CustomWebSocketException when authentication is missing,
-     * the payload is invalid, or `gameId` is absent.
-     */
     /**
      * Handles a player toggling their ready state in the lobby.
      *
@@ -254,6 +245,26 @@ class LobbyWebSocketController(
         )
     }
 
+    /**
+     * Handles a player leaving a lobby via WebSocket.
+     *
+     * Client sends a message to `/app/lobby.leave` with the `gameId`
+     * in the payload.
+     *
+     * The authenticated player is removed from the lobby. If the lobby
+     * still contains real players, a `LOBBY_LEFT` event is broadcast to
+     * `/topic/game/{gameId}` so remaining members can update screen.
+     *
+     * If no real players remain (debug/dummy players do not count), the
+     * lobby is deleted and a `HOST_LEFT` event is broadcast so clients
+     * can close the lobby UI.
+     *
+     * Authentication is derived from the WebSocket principal; the sender
+     * field in [WebSocketMessage] is ignored to prevent spoofing.
+     *
+     * @throws CustomWebSocketException when authentication is missing,
+     * the payload is invalid, or `gameId` is absent.
+     */
     @MessageMapping("/lobby.leave")
     @Suppress("UNUSED_PARAMETER")
     fun leaveLobby(
@@ -297,6 +308,18 @@ class LobbyWebSocketController(
                         payload = mapOf(
                             "userId" to principal.userId,
                         )
+                    )
+                )
+                // Broadcast updated roster so remaining members see accurate ready states
+                val updatedRoster = lobbyService.getLobbyRoster(gameId)
+                messagingTemplate.convertAndSend(
+                    "/topic/game/$gameId",
+                    WebSocketMessage(
+                        type = MessageType.LOBBY_ROSTER,
+                        sender = "SERVER",
+                        content = "Lobby roster",
+                        gameId = gameId,
+                        payload = LobbyRosterDto(players = updatedRoster)
                     )
                 )
             }

--- a/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
@@ -5,6 +5,7 @@ import io.github.springwolf.core.asyncapi.annotations.AsyncOperation
 import org.machikoro.server.auth.userPrincipal
 import org.machikoro.server.dto.LobbyLeavingOutcome
 import org.machikoro.server.dto.LobbyRosterDto
+import org.machikoro.server.dto.LobbyRosterPlayerDto
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.WebSocketMessage
 import org.machikoro.server.exception.CustomWebSocketException
@@ -200,6 +201,59 @@ class LobbyWebSocketController(
      * @throws CustomWebSocketException when authentication is missing,
      * the payload is invalid, or `gameId` is absent.
      */
+    /**
+     * Handles a player toggling their ready state in the lobby.
+     *
+     * Client sends `{"gameId": <id>, "isReady": <bool>}` in the payload to `/app/lobby.ready`.
+     * Server updates in-memory ready state and broadcasts the full LOBBY_ROSTER with
+     * updated isReady flags to `/topic/game/{gameId}` so all lobby members stay in sync.
+     */
+    @MessageMapping("/lobby.ready")
+    fun toggleReady(
+        @Payload message: WebSocketMessage,
+        headerAccessor: SimpMessageHeaderAccessor,
+    ) {
+        val principal = headerAccessor.userPrincipal()
+            ?: throw CustomWebSocketException(
+                errorCode = "UNAUTHENTICATED",
+                message = "Authenticated principal not found",
+            )
+
+        val payload = message.payload as? Map<*, *>
+            ?: throw CustomWebSocketException(
+                errorCode = "INVALID_PAYLOAD",
+                message = "lobby.ready payload must contain gameId and isReady",
+            )
+
+        val gameId = (payload["gameId"] as? Number)?.toInt()
+            ?: throw CustomWebSocketException(
+                errorCode = "MISSING_GAME_ID",
+                message = "gameId is missing or not a number",
+            )
+
+        val isReady = payload["isReady"] as? Boolean
+            ?: throw CustomWebSocketException(
+                errorCode = "MISSING_IS_READY",
+                message = "isReady is missing or not a boolean",
+            )
+
+        logger.info("User '{}' set ready={} in game {}", principal.username, isReady, gameId)
+
+        val roster = lobbyService.setReadyState(gameId, principal.userId, isReady)
+
+        // Broadcast updated roster so all lobby members see the new ready state
+        messagingTemplate.convertAndSend(
+            "/topic/game/$gameId",
+            WebSocketMessage(
+                type = MessageType.LOBBY_ROSTER,
+                sender = "SERVER",
+                content = "Lobby roster updated",
+                gameId = gameId,
+                payload = LobbyRosterDto(players = roster)
+            )
+        )
+    }
+
     @MessageMapping("/lobby.leave")
     @Suppress("UNUSED_PARAMETER")
     fun leaveLobby(

--- a/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
@@ -10,6 +10,7 @@ import org.machikoro.server.dto.WebSocketMessage
 import org.machikoro.server.exception.CustomWebSocketException
 import org.machikoro.server.exception.GameNotFoundException
 import org.machikoro.server.service.LobbyService
+import org.machikoro.server.service.PendingLobbyCreatedCache
 import org.slf4j.LoggerFactory
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.handler.annotation.Payload
@@ -21,6 +22,7 @@ import org.springframework.stereotype.Controller
 class LobbyWebSocketController(
     private val lobbyService: LobbyService,
     private val messagingTemplate: SimpMessagingTemplate,
+    private val pendingLobbyCreatedCache: PendingLobbyCreatedCache,
 ) {
     private val logger = LoggerFactory.getLogger(LobbyWebSocketController::class.java)
 
@@ -64,21 +66,24 @@ class LobbyWebSocketController(
 
         val lobby = lobbyService.createLobby(principal.userId)
 
-        // Deliver only to the creator — avoids auto-joining unrelated clients
-        messagingTemplate.convertAndSend(
-            "/queue/lobby-user$sessionId",
-            WebSocketMessage(
-                type = MessageType.LOBBY_CREATED,
-                sender = "SERVER",
-                content = "Lobby created",
-                gameId = lobby.id,
-                payload = mapOf(
-                    "lobbyCode" to lobby.lobbyCode,
-                    "hostUserId" to lobby.hostUserId,
-                    "status" to lobby.status.name
-                )
+        val response = WebSocketMessage(
+            type = MessageType.LOBBY_CREATED,
+            sender = "SERVER",
+            content = "Lobby created",
+            gameId = lobby.id,
+            payload = mapOf(
+                "lobbyCode" to lobby.lobbyCode,
+                "hostUserId" to lobby.hostUserId,
+                "status" to lobby.status.name
             )
         )
+
+        // Store before sending: if the SUBSCRIBE frame races ahead of SEND in the inbound channel,
+        // the SessionSubscribeEvent listener will replay from here once the subscription is confirmed
+        pendingLobbyCreatedCache.put(sessionId, response)
+
+        // Deliver only to the creator — avoids auto-joining unrelated clients
+        messagingTemplate.convertAndSend("/queue/lobby-user$sessionId", response)
     }
 
     /**

--- a/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
@@ -294,6 +294,11 @@ class LobbyWebSocketController(
         val result = lobbyService.leaveLobby(gameId, principal.userId)
 
         when(result) {
+            is LobbyLeavingOutcome.NotAMember -> {
+                // Stale or duplicate frame — caller was not in the lobby; no topic broadcast
+                logger.debug("User '{}' not a member of game {} — suppressing HOST_LEFT", principal.username, gameId)
+                return
+            }
             is LobbyLeavingOutcome.LobbyRemains -> {
                 logger.info(
                     "Player ${principal.userId} left game"

--- a/src/main/kotlin/org/machikoro/server/dto/LobbyLeavingOutcome.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/LobbyLeavingOutcome.kt
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(
     description = "Result of leaving lobby",
-    oneOf = [LobbyLeavingOutcome.LobbyRemains::class, LobbyLeavingOutcome.LobbyDeleted::class]
+    oneOf = [LobbyLeavingOutcome.LobbyRemains::class, LobbyLeavingOutcome.LobbyDeleted::class, LobbyLeavingOutcome.NotAMember::class]
 )
 sealed interface LobbyLeavingOutcome {
 
@@ -19,4 +19,8 @@ sealed interface LobbyLeavingOutcome {
         @field:Schema(description = "ID of the game to close lobby for", example = "1")
         val gameId: Int
     ) : LobbyLeavingOutcome
+
+    // Stale/duplicate leave frame — caller was not a member; no broadcast needed
+    @Schema(description = "Caller was not in the lobby; no-op, no topic broadcast")
+    data object NotAMember : LobbyLeavingOutcome
 }

--- a/src/main/kotlin/org/machikoro/server/dto/LobbyRosterDto.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/LobbyRosterDto.kt
@@ -11,4 +11,6 @@ data class LobbyRosterPlayerDto(
     val gameId: Int,
     val turnOrder: Int,
     val coins: Int,
+    // Populated from in-memory ready state, not from DB
+    val isReady: Boolean = false,
 )

--- a/src/main/kotlin/org/machikoro/server/exception/NotAllPlayersReadyException.kt
+++ b/src/main/kotlin/org/machikoro/server/exception/NotAllPlayersReadyException.kt
@@ -1,0 +1,9 @@
+package org.machikoro.server.exception
+
+/**
+ * Raised when startGame is called but at least one player has not toggled ready.
+ */
+class NotAllPlayersReadyException(message: String) : CustomWebSocketException(
+    errorCode = "NOT_ALL_PLAYERS_READY",
+    message = message,
+)

--- a/src/main/kotlin/org/machikoro/server/listener/WebSocketEventListener.kt
+++ b/src/main/kotlin/org/machikoro/server/listener/WebSocketEventListener.kt
@@ -2,6 +2,7 @@ package org.machikoro.server.listener
 
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.WebSocketMessage
+import org.machikoro.server.service.PendingLobbyCreatedCache
 import org.machikoro.server.service.WebSocketConnectionTracker
 import org.slf4j.LoggerFactory
 import org.springframework.context.event.EventListener
@@ -9,13 +10,37 @@ import org.springframework.messaging.simp.SimpMessageSendingOperations
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor
 import org.springframework.stereotype.Component
 import org.springframework.web.socket.messaging.SessionDisconnectEvent
+import org.springframework.web.socket.messaging.SessionSubscribeEvent
 
 @Component
 class WebSocketEventListener(
     private val template: SimpMessageSendingOperations,
-    private val connectionTracker: WebSocketConnectionTracker
+    private val connectionTracker: WebSocketConnectionTracker,
+    private val pendingLobbyCreatedCache: PendingLobbyCreatedCache,
 ) {
     private val logger = LoggerFactory.getLogger(WebSocketEventListener::class.java)
+
+    /**
+     * Replay a pending LOBBY_CREATED message when the client's user queue subscription is confirmed.
+     *
+     * Spring's simple broker processes STOMP frames on a thread pool, so a SEND can race
+     * ahead of its sibling SUBSCRIBE in the inbound channel. [PendingLobbyCreatedCache] stores
+     * the response from createLobby; this handler delivers it once the subscription is guaranteed
+     * to be registered (the event fires after the broker records the subscription).
+     */
+    @EventListener
+    fun handleSubscribeEvent(event: SessionSubscribeEvent) {
+        val accessor = StompHeaderAccessor.wrap(event.message)
+        val sessionId = accessor.sessionId ?: return
+        val destination = accessor.destination ?: return
+
+        // Only replay on the creator's personal lobby queue, not on game topics or other queues
+        if (destination != "/queue/lobby-user$sessionId") return
+
+        val pending = pendingLobbyCreatedCache.consume(sessionId) ?: return
+        logger.debug("Replaying LOBBY_CREATED for session '{}' — subscription confirmed late", sessionId)
+        template.convertAndSend(destination, pending)
+    }
 
     /**
      * Listen for WebSocket disconnect events.
@@ -29,6 +54,8 @@ class WebSocketEventListener(
         val username = headerAccessor.sessionAttributes?.get("username") as? String
 
         if (sessionId != null) {
+            // Evict any un-replayed pending message so the cache does not grow unbounded
+            pendingLobbyCreatedCache.evict(sessionId)
             connectionTracker.unregister(sessionId)
         }
 

--- a/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
@@ -22,7 +22,6 @@ import org.machikoro.server.exception.LobbyFullException
 import org.machikoro.server.exception.NotAllPlayersReadyException
 import org.machikoro.server.exception.NotEnoughPlayersException
 import org.machikoro.server.exception.NotHostException
-import org.machikoro.server.exception.PlayerNotFoundException
 import org.springframework.stereotype.Service
 import java.util.concurrent.ConcurrentHashMap
 
@@ -200,15 +199,15 @@ open class LobbyService(
      * [LobbyLeavingOutcome.LobbyRemains] if the host is still present and the
      * lobby remains active.
      *
-     * @throws PlayerNotFoundException if the user is not part of the lobby
-     * @throws GameNotFoundException if the game does not exist
+     * @throws GameNotFoundException if the game does not exist (stale gameId from reconnect)
      */
     fun leaveLobby(gameId: Int, userId: Int): LobbyLeavingOutcome = runInTransaction {
+        // Game or player already gone (e.g. purged by debug endpoint) — treat as already left
         val player = playerDao.findByGameIdAndUserId(gameId, userId)
-            ?: throw PlayerNotFoundException("Player $userId not found in game $gameId")
+            ?: return@runInTransaction LobbyLeavingOutcome.LobbyDeleted(gameId)
 
         val game = gameDao.findById(gameId)
-            ?: throw GameNotFoundException("Game $gameId not found")
+            ?: return@runInTransaction LobbyLeavingOutcome.LobbyDeleted(gameId)
 
         val shouldDeleteLobby =
             player.userId == game.hostUserId

--- a/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
@@ -215,6 +215,8 @@ open class LobbyService(
 
         if (!shouldDeleteLobby) {
             playerDao.deleteByPlayerId(player.id)
+            // Clear ready state so a rejoining player must re-ready
+            readyPlayers[gameId]?.remove(player.userId)
         }
 
         if (shouldDeleteLobby || noRealPlayersRemain(gameId)) {

--- a/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
@@ -22,6 +22,7 @@ import org.machikoro.server.exception.LobbyFullException
 import org.machikoro.server.exception.NotAllPlayersReadyException
 import org.machikoro.server.exception.NotEnoughPlayersException
 import org.machikoro.server.exception.NotHostException
+import org.machikoro.server.exception.PlayerNotFoundException
 import org.springframework.stereotype.Service
 import java.util.concurrent.ConcurrentHashMap
 
@@ -112,11 +113,29 @@ open class LobbyService(
     /**
      * Toggles [userId]'s ready state in [gameId] and returns the updated roster.
      *
-     * Thread-safe via [ConcurrentHashMap.newKeySet] on the inner set.
+     * Validates the game exists, is WAITING, and the caller is a member before
+     * touching in-memory state. Thread-safe via [ConcurrentHashMap.newKeySet].
+     *
+     * @throws GameNotFoundException   if no game with [gameId] exists.
+     * @throws GameStartedException    if the game is not in WAITING state.
+     * @throws PlayerNotFoundException if [userId] is not a member of [gameId].
      */
     fun setReadyState(gameId: Int, userId: Int, isReady: Boolean): List<LobbyRosterPlayerDto> {
-        val readySet = readyPlayers.computeIfAbsent(gameId) { ConcurrentHashMap.newKeySet() }
-        if (isReady) readySet.add(userId) else readySet.remove(userId)
+        runInTransaction {
+            val game = gameDao.findById(gameId)
+                ?: throw GameNotFoundException("Game $gameId not found")
+            if (game.status != GameStatus.WAITING) {
+                throw GameStartedException("Game $gameId is not accepting ready state changes")
+            }
+            playerDao.findByGameIdAndUserId(gameId, userId)
+                ?: throw PlayerNotFoundException("User $userId is not in game $gameId")
+        }
+        // Only create the set when adding — avoids orphaned empty entries for non-members
+        if (isReady) {
+            readyPlayers.computeIfAbsent(gameId) { ConcurrentHashMap.newKeySet() }.add(userId)
+        } else {
+            readyPlayers[gameId]?.remove(userId)
+        }
         return getLobbyRoster(gameId)
     }
 
@@ -162,7 +181,10 @@ open class LobbyService(
             if (players.size >= game.maxPlayers) {
                 throw LobbyFullException("Game $gameId is full (max ${game.maxPlayers} players)")
             }
-            return playerDao.addPlayer(gameId, userId)
+            val newPlayer = playerDao.addPlayer(gameId, userId)
+            // Reset ready states so all players must re-ready with the new roster
+            readyPlayers.remove(gameId)
+            return newPlayer
         }
     }
 
@@ -202,12 +224,12 @@ open class LobbyService(
      * @throws GameNotFoundException if the game does not exist (stale gameId from reconnect)
      */
     fun leaveLobby(gameId: Int, userId: Int): LobbyLeavingOutcome = runInTransaction {
-        // Game or player already gone (e.g. purged by debug endpoint) — treat as already left
+        // Player or game already gone — return no-op to suppress HOST_LEFT broadcast
         val player = playerDao.findByGameIdAndUserId(gameId, userId)
-            ?: return@runInTransaction LobbyLeavingOutcome.LobbyDeleted(gameId)
+            ?: return@runInTransaction LobbyLeavingOutcome.NotAMember
 
         val game = gameDao.findById(gameId)
-            ?: return@runInTransaction LobbyLeavingOutcome.LobbyDeleted(gameId)
+            ?: return@runInTransaction LobbyLeavingOutcome.NotAMember
 
         val shouldDeleteLobby =
             player.userId == game.hostUserId
@@ -307,8 +329,20 @@ open class LobbyService(
                     )
                 }
 
+                // Auto-ready the host — calling startGame is implicit readiness consent
+                if (requestingUserId != null) {
+                    readyPlayers.computeIfAbsent(gameId) { ConcurrentHashMap.newKeySet() }.add(requestingUserId)
+                }
+
+                // Fetch roster once for the ready gate and post-start snapshot
+                val lobbyRoster = playerDao.getLobbyRoster(gameId)
+                // Debug bots have no client to press ready — exclude from the gate
+                val realPlayerIds = lobbyRoster
+                    .filter { !it.username.startsWith(DEBUG_USER_PREFIX) }
+                    .map { it.userId }
+                    .toSet()
                 val ready = readyPlayers[gameId] ?: emptySet()
-                val notReady = players.filter { it.userId !in ready }
+                val notReady = realPlayerIds.filter { it !in ready }
                 if (notReady.isNotEmpty()) {
                     throw NotAllPlayersReadyException(
                         "Game $gameId: ${notReady.size} player(s) not ready"
@@ -329,7 +363,11 @@ open class LobbyService(
                 val marketplace = gameMarketplaceDao.findByGameIdAsMap(gameId)
                 val cardDefinitions = cardDao.findAll().map { it.toDefinitionDto() }
                 val landmarkDefinitions = landmarkDao.findAll().map { it.toDefinitionDto() }
-                val playerUsernames = playerDao.getLobbyRoster(gameId).associate { it.playerId to it.username }
+                // Reuse roster already fetched above
+                val playerUsernames = lobbyRoster.associate { it.playerId to it.username }
+
+                // Lobby state no longer needed inside the lock
+                readyPlayers.remove(gameId)
 
                 GameStateDto(
                     game = updatedGame,
@@ -345,9 +383,8 @@ open class LobbyService(
                 )
             }
         }
-        // Game is now IN_PROGRESS; lobby state is no longer needed
+        // Remove the lock after the transaction commits
         lobbyLocks.remove(gameId)
-        readyPlayers.remove(gameId)
         return result
     }
 }

--- a/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
@@ -19,6 +19,7 @@ import org.machikoro.server.exception.GameFinishedException
 import org.machikoro.server.exception.GameNotFoundException
 import org.machikoro.server.exception.GameStartedException
 import org.machikoro.server.exception.LobbyFullException
+import org.machikoro.server.exception.NotAllPlayersReadyException
 import org.machikoro.server.exception.NotEnoughPlayersException
 import org.machikoro.server.exception.NotHostException
 import org.machikoro.server.exception.PlayerNotFoundException
@@ -39,6 +40,9 @@ open class LobbyService(
 
     // ConcurrentHashMap for thread-safe lock creation and removal
     private val lobbyLocks = ConcurrentHashMap<Int, Any>()
+
+    // In-memory ready state: gameId -> set of userIds who pressed ready
+    private val readyPlayers = ConcurrentHashMap<Int, MutableSet<Int>>()
 
     /**
      * Runs [block] inside an Exposed transaction.
@@ -99,10 +103,22 @@ open class LobbyService(
     }
 
     /**
-     * Returns the current lobby roster for [gameId], including usernames, ordered by turn order.
+     * Returns the current lobby roster for [gameId], enriched with in-memory ready state.
      */
     fun getLobbyRoster(gameId: Int): List<LobbyRosterPlayerDto> = runInTransaction {
-        playerDao.getLobbyRoster(gameId)
+        val ready = readyPlayers[gameId] ?: emptySet()
+        playerDao.getLobbyRoster(gameId).map { it.copy(isReady = it.userId in ready) }
+    }
+
+    /**
+     * Toggles [userId]'s ready state in [gameId] and returns the updated roster.
+     *
+     * Thread-safe via [ConcurrentHashMap.newKeySet] on the inner set.
+     */
+    fun setReadyState(gameId: Int, userId: Int, isReady: Boolean): List<LobbyRosterPlayerDto> {
+        val readySet = readyPlayers.computeIfAbsent(gameId) { ConcurrentHashMap.newKeySet() }
+        if (isReady) readySet.add(userId) else readySet.remove(userId)
+        return getLobbyRoster(gameId)
     }
 
     /**
@@ -163,6 +179,7 @@ open class LobbyService(
             gameDao.delete(game.id)
         }
         lobbyLocks.clear()
+        readyPlayers.clear()
         games.size
     }
 
@@ -231,6 +248,7 @@ open class LobbyService(
         playerDao.deleteByGameId(gameId)
         gameDao.delete(gameId)
         lobbyLocks.remove(gameId)
+        readyPlayers.remove(gameId)
     }
 
     /**
@@ -288,6 +306,14 @@ open class LobbyService(
                     )
                 }
 
+                val ready = readyPlayers[gameId] ?: emptySet()
+                val notReady = players.filter { it.userId !in ready }
+                if (notReady.isNotEmpty()) {
+                    throw NotAllPlayersReadyException(
+                        "Game $gameId: ${notReady.size} player(s) not ready"
+                    )
+                }
+
                 val shuffled = initializationService.initializeGame(gameId)
 
                 gameDao.updateStatus(gameId, GameStatus.IN_PROGRESS)
@@ -318,8 +344,9 @@ open class LobbyService(
                 )
             }
         }
-        // Game is now IN_PROGRESS; no new joins can happen, so the lock is no longer needed
+        // Game is now IN_PROGRESS; lobby state is no longer needed
         lobbyLocks.remove(gameId)
+        readyPlayers.remove(gameId)
         return result
     }
 }

--- a/src/main/kotlin/org/machikoro/server/service/PendingLobbyCreatedCache.kt
+++ b/src/main/kotlin/org/machikoro/server/service/PendingLobbyCreatedCache.kt
@@ -1,0 +1,26 @@
+package org.machikoro.server.service
+
+import org.machikoro.server.dto.WebSocketMessage
+import org.springframework.stereotype.Component
+import java.util.concurrent.ConcurrentHashMap
+
+// Guards against the STOMP SUBSCRIBE/SEND race where createLobby sends before the subscription is registered
+@Component
+class PendingLobbyCreatedCache {
+
+    // sessionId -> message waiting to be replayed on subscribe confirmation
+    private val pending = ConcurrentHashMap<String, WebSocketMessage>()
+
+    // Store a LOBBY_CREATED message keyed by the creator's STOMP session
+    fun put(sessionId: String, message: WebSocketMessage) {
+        pending[sessionId] = message
+    }
+
+    // Returns and removes the pending message atomically — null if already consumed or never stored
+    fun consume(sessionId: String): WebSocketMessage? = pending.remove(sessionId)
+
+    // Remove on disconnect to prevent unbounded growth for sessions that never subscribed
+    fun evict(sessionId: String) {
+        pending.remove(sessionId)
+    }
+}

--- a/src/test/kotlin/org/machikoro/server/controller/GameWebSocketBroadcastIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/GameWebSocketBroadcastIntegrationTest.kt
@@ -150,6 +150,8 @@ class GameWebSocketBroadcastIntegrationTest {
             ),
         )
         assertSameGameBroadcast(hostGameQueue, guestGameQueue, MessageType.LOBBY_JOINED)
+        // joinLobby also broadcasts a roster update to the topic — drain it before game.start
+        assertSameGameBroadcast(hostGameQueue, guestGameQueue, MessageType.LOBBY_ROSTER)
 
         sendJson(
             guestSession,

--- a/src/test/kotlin/org/machikoro/server/controller/LobbyWebSocketControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/LobbyWebSocketControllerTest.kt
@@ -17,7 +17,6 @@ import org.machikoro.server.dto.LobbyLeavingOutcome
 import org.machikoro.server.dto.LobbyRosterDto
 import org.machikoro.server.dto.LobbyRosterPlayerDto
 import org.machikoro.server.exception.GameNotFoundException
-import org.machikoro.server.exception.PlayerNotFoundException
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
@@ -362,33 +361,26 @@ class LobbyWebSocketControllerTest {
     }
 
     @Test
-    fun `leaveLobby throws when player is not in lobby`() {
+    fun `leaveLobby does nothing when caller is not a member of the lobby`() {
         whenever(lobbyService.leaveLobby(1, 10))
-            .thenThrow(
-                PlayerNotFoundException(
-                    "Player 10 not found in game 1"
-                )
-            )
+            .thenReturn(LobbyLeavingOutcome.NotAMember)
 
         val accessor = authenticatedAccessor(
             userId = 10,
             username = "Player1"
         )
 
-        assertThrows<PlayerNotFoundException> {
-            controller.leaveLobby(
-                WebSocketMessage(
-                    type = MessageType.JOIN,
-                    sender = "Player1",
-                    payload = mapOf("gameId" to 1)
-                ),
-                accessor,
-            )
-        }
+        controller.leaveLobby(
+            WebSocketMessage(
+                type = MessageType.JOIN,
+                sender = "Player1",
+                payload = mapOf("gameId" to 1)
+            ),
+            accessor,
+        )
 
-        verify(lobbyService)
-            .leaveLobby(1, 10)
-
+        verify(lobbyService).leaveLobby(1, 10)
+        // No topic broadcast — stale/duplicate frame must not trigger HOST_LEFT
         verify(messagingTemplate, never())
             .convertAndSend(any<String>(), any<WebSocketMessage>())
     }
@@ -593,7 +585,8 @@ class LobbyWebSocketControllerTest {
         val msgCaptor = argumentCaptor<WebSocketMessage>()
         verify(messagingTemplate).convertAndSend(any<String>(), msgCaptor.capture())
 
-        val payload = msgCaptor.firstValue.payload as LobbyRosterDto
+        val payload = msgCaptor.firstValue.payload as? LobbyRosterDto
+            ?: throw AssertionError("Payload is not a LobbyRosterDto")
         assertEquals(false, payload.players[0].isReady)
     }
 

--- a/src/test/kotlin/org/machikoro/server/controller/LobbyWebSocketControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/LobbyWebSocketControllerTest.kt
@@ -17,6 +17,8 @@ import org.machikoro.server.dto.LobbyLeavingOutcome
 import org.machikoro.server.dto.LobbyRosterDto
 import org.machikoro.server.dto.LobbyRosterPlayerDto
 import org.machikoro.server.exception.GameNotFoundException
+import org.machikoro.server.service.PendingLobbyCreatedCache
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
@@ -31,7 +33,9 @@ class LobbyWebSocketControllerTest {
 
     private val lobbyService = mock<LobbyService>()
     private val messagingTemplate = mock<SimpMessagingTemplate>()
-    private val controller = LobbyWebSocketController(lobbyService, messagingTemplate)
+    // Use a real cache instance — no external dependencies
+    private val pendingLobbyCreatedCache = PendingLobbyCreatedCache()
+    private val controller = LobbyWebSocketController(lobbyService, messagingTemplate, pendingLobbyCreatedCache)
 
     // Helper: accessor with authenticated principal and a session ID
     private fun authenticatedAccessor(userId: Int, username: String, sessionId: String = "test-session"): SimpMessageHeaderAccessor =
@@ -92,6 +96,24 @@ class LobbyWebSocketControllerTest {
         assertEquals("WAITING", payload["status"])
 
         verify(lobbyService).createLobby(10)
+    }
+
+    @Test
+    fun `createLobby stores LOBBY_CREATED in pending cache for subscribe-event replay`() {
+        whenever(lobbyService.createLobby(10)).thenReturn(game())
+
+        val accessor = authenticatedAccessor(userId = 10, username = "Player1", sessionId = "sess-42")
+
+        controller.createLobby(
+            WebSocketMessage(type = MessageType.JOIN, sender = "ignored-by-server", content = "create lobby"),
+            accessor,
+        )
+
+        // Pending entry must survive after the direct send so the subscribe-event replay path can consume it
+        val pending = pendingLobbyCreatedCache.consume("sess-42")
+        assertNotNull(pending)
+        assertEquals(MessageType.LOBBY_CREATED, pending!!.type)
+        assertEquals(1, pending.gameId)
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/controller/LobbyWebSocketControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/LobbyWebSocketControllerTest.kt
@@ -173,8 +173,8 @@ class LobbyWebSocketControllerTest {
 
         val destCaptor = argumentCaptor<String>()
         val msgCaptor = argumentCaptor<WebSocketMessage>()
-        // Expect two sends: LOBBY_ROSTER to the joiner's queue, then LOBBY_JOINED to the topic
-        verify(messagingTemplate, times(2)).convertAndSend(destCaptor.capture(), msgCaptor.capture())
+        // 3 sends: LOBBY_ROSTER to joiner's queue, LOBBY_JOINED to topic, LOBBY_ROSTER to topic
+        verify(messagingTemplate, times(3)).convertAndSend(destCaptor.capture(), msgCaptor.capture())
 
         // First send: LOBBY_ROSTER only to the joiner's session queue
         assertEquals("/queue/lobby-usersess-77", destCaptor.allValues[0])
@@ -197,8 +197,15 @@ class LobbyWebSocketControllerTest {
         assertEquals(1, joinPayload["gameId"])
         assertEquals(3, joinPayload["coins"])
 
+        // Third send: updated LOBBY_ROSTER broadcast so all lobby members stay in sync
+        assertEquals("/topic/game/1", destCaptor.allValues[2])
+        val broadcastRoster = msgCaptor.allValues[2]
+        assertEquals(MessageType.LOBBY_ROSTER, broadcastRoster.type)
+        assertEquals(LobbyRosterDto(players = roster), broadcastRoster.payload)
+
         verify(lobbyService).joinLobby("ABC1234", 20)
-        verify(lobbyService).getLobbyRoster(1)
+        // getLobbyRoster called twice: once for private send, once for topic broadcast
+        verify(lobbyService, times(2)).getLobbyRoster(1)
     }
 
     @Test
@@ -387,11 +394,13 @@ class LobbyWebSocketControllerTest {
     }
 
     @Test
-    fun `leaveLobby broadcasts LOBBY_LEFT to game topic when lobby persists`() {
+    fun `leaveLobby broadcasts LOBBY_LEFT then LOBBY_ROSTER to game topic when lobby persists`() {
+        val updatedRoster = listOf(
+            LobbyRosterPlayerDto(playerId = 2, userId = 20, username = "Player2", gameId = 1, turnOrder = 1, coins = 3),
+        )
         whenever(lobbyService.leaveLobby(1, 10))
-            .thenReturn(
-                LobbyLeavingOutcome.LobbyRemains( 10)
-            )
+            .thenReturn(LobbyLeavingOutcome.LobbyRemains(10))
+        whenever(lobbyService.getLobbyRoster(1)).thenReturn(updatedRoster)
 
         val accessor = authenticatedAccessor(
             userId = 10,
@@ -410,27 +419,22 @@ class LobbyWebSocketControllerTest {
 
         val destCaptor = argumentCaptor<String>()
         val msgCaptor = argumentCaptor<WebSocketMessage>()
+        // 2 sends: LOBBY_LEFT, then LOBBY_ROSTER so remaining members see updated ready states
+        verify(messagingTemplate, times(2)).convertAndSend(destCaptor.capture(), msgCaptor.capture())
 
-        verify(messagingTemplate)
-            .convertAndSend(
-                destCaptor.capture(),
-                msgCaptor.capture()
-            )
-
-        assertEquals(
-            "/topic/game/1",
-            destCaptor.firstValue
-        )
-
-        val msg = msgCaptor.firstValue
-        assertEquals(MessageType.LOBBY_LEFT, msg.type)
-        assertEquals("SERVER", msg.sender)
-        assertEquals(1, msg.gameId)
-
-        val payload = msg.payload as? Map<*, *>
-            ?: throw AssertionError("Payload is not a Map")
-
+        assertEquals("/topic/game/1", destCaptor.allValues[0])
+        val leftMsg = msgCaptor.allValues[0]
+        assertEquals(MessageType.LOBBY_LEFT, leftMsg.type)
+        assertEquals("SERVER", leftMsg.sender)
+        assertEquals(1, leftMsg.gameId)
+        val payload = leftMsg.payload as? Map<*, *> ?: throw AssertionError("Payload is not a Map")
         assertEquals(10, payload["userId"])
+
+        // Follow-up roster broadcast keeps remaining players in sync
+        assertEquals("/topic/game/1", destCaptor.allValues[1])
+        val rosterMsg = msgCaptor.allValues[1]
+        assertEquals(MessageType.LOBBY_ROSTER, rosterMsg.type)
+        assertEquals(LobbyRosterDto(players = updatedRoster), rosterMsg.payload)
     }
 
     @Test
@@ -478,11 +482,130 @@ class LobbyWebSocketControllerTest {
 
         assertEquals(10, payload["userId"])
     }
-    @Test
-    fun `joinLobby skips LOBBY_ROSTER when sessionId is null`() {
-        whenever(lobbyService.joinLobby("ABC1234", 20)).thenReturn(player())
+    // === toggleReady() ===
 
-        // Accessor with no sessionId — LOBBY_JOINED still broadcasts, LOBBY_ROSTER is skipped
+    @Test
+    fun `toggleReady throws when no authenticated principal is present`() {
+        val accessor = SimpMessageHeaderAccessor.create().apply { sessionId = "sess-1" }
+
+        val ex = assertThrows<CustomWebSocketException> {
+            controller.toggleReady(
+                WebSocketMessage(type = MessageType.JOIN, sender = "ghost", payload = mapOf("gameId" to 1, "isReady" to true)),
+                accessor,
+            )
+        }
+
+        assertEquals("UNAUTHENTICATED", ex.errorCode)
+        verify(lobbyService, never()).setReadyState(any(), any(), any())
+        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
+    }
+
+    @Test
+    fun `toggleReady throws when payload is not a Map`() {
+        val accessor = authenticatedAccessor(userId = 10, username = "Player1")
+
+        val ex = assertThrows<CustomWebSocketException> {
+            controller.toggleReady(
+                WebSocketMessage(type = MessageType.JOIN, sender = "Player1", payload = "not-a-map"),
+                accessor,
+            )
+        }
+
+        assertEquals("INVALID_PAYLOAD", ex.errorCode)
+        verify(lobbyService, never()).setReadyState(any(), any(), any())
+    }
+
+    @Test
+    fun `toggleReady throws when gameId is missing from payload`() {
+        val accessor = authenticatedAccessor(userId = 10, username = "Player1")
+
+        val ex = assertThrows<CustomWebSocketException> {
+            controller.toggleReady(
+                WebSocketMessage(type = MessageType.JOIN, sender = "Player1", payload = mapOf("isReady" to true)),
+                accessor,
+            )
+        }
+
+        assertEquals("MISSING_GAME_ID", ex.errorCode)
+        verify(lobbyService, never()).setReadyState(any(), any(), any())
+    }
+
+    @Test
+    fun `toggleReady throws when isReady is missing from payload`() {
+        val accessor = authenticatedAccessor(userId = 10, username = "Player1")
+
+        val ex = assertThrows<CustomWebSocketException> {
+            controller.toggleReady(
+                WebSocketMessage(type = MessageType.JOIN, sender = "Player1", payload = mapOf("gameId" to 1)),
+                accessor,
+            )
+        }
+
+        assertEquals("MISSING_IS_READY", ex.errorCode)
+        verify(lobbyService, never()).setReadyState(any(), any(), any())
+    }
+
+    @Test
+    fun `toggleReady broadcasts LOBBY_ROSTER with updated ready states to game topic`() {
+        val gameId = 1
+        val roster = listOf(
+            LobbyRosterPlayerDto(playerId = 1, userId = 10, username = "Player1", gameId = gameId, turnOrder = 0, coins = 3, isReady = true),
+            LobbyRosterPlayerDto(playerId = 2, userId = 20, username = "Player2", gameId = gameId, turnOrder = 1, coins = 3, isReady = false),
+        )
+        whenever(lobbyService.setReadyState(gameId, 10, true)).thenReturn(roster)
+
+        val accessor = authenticatedAccessor(userId = 10, username = "Player1", sessionId = "sess-ready")
+
+        controller.toggleReady(
+            WebSocketMessage(type = MessageType.JOIN, sender = "Player1", payload = mapOf("gameId" to gameId, "isReady" to true)),
+            accessor,
+        )
+
+        val destCaptor = argumentCaptor<String>()
+        val msgCaptor = argumentCaptor<WebSocketMessage>()
+        verify(messagingTemplate).convertAndSend(destCaptor.capture(), msgCaptor.capture())
+
+        // Broadcast goes to the shared game topic, not a private queue
+        assertEquals("/topic/game/$gameId", destCaptor.firstValue)
+
+        val msg = msgCaptor.firstValue
+        assertEquals(MessageType.LOBBY_ROSTER, msg.type)
+        assertEquals("SERVER", msg.sender)
+        assertEquals(gameId, msg.gameId)
+        assertEquals(LobbyRosterDto(players = roster), msg.payload)
+    }
+
+    @Test
+    fun `toggleReady broadcasts unready state when isReady is false`() {
+        val gameId = 1
+        val roster = listOf(
+            LobbyRosterPlayerDto(playerId = 1, userId = 10, username = "Player1", gameId = gameId, turnOrder = 0, coins = 3, isReady = false),
+        )
+        whenever(lobbyService.setReadyState(gameId, 10, false)).thenReturn(roster)
+
+        val accessor = authenticatedAccessor(userId = 10, username = "Player1")
+
+        controller.toggleReady(
+            WebSocketMessage(type = MessageType.JOIN, sender = "Player1", payload = mapOf("gameId" to gameId, "isReady" to false)),
+            accessor,
+        )
+
+        val msgCaptor = argumentCaptor<WebSocketMessage>()
+        verify(messagingTemplate).convertAndSend(any<String>(), msgCaptor.capture())
+
+        val payload = msgCaptor.firstValue.payload as LobbyRosterDto
+        assertEquals(false, payload.players[0].isReady)
+    }
+
+    @Test
+    fun `joinLobby skips private LOBBY_ROSTER when sessionId is null but still broadcasts to topic`() {
+        val roster = listOf(
+            LobbyRosterPlayerDto(playerId = 5, userId = 20, username = "Player2", gameId = 1, turnOrder = 1, coins = 3),
+        )
+        whenever(lobbyService.joinLobby("ABC1234", 20)).thenReturn(player())
+        whenever(lobbyService.getLobbyRoster(1)).thenReturn(roster)
+
+        // No sessionId — private LOBBY_ROSTER skipped, but LOBBY_JOINED + topic LOBBY_ROSTER still sent
         val accessor = SimpMessageHeaderAccessor.create().apply {
             user = UserPrincipal(userId = 20, username = "Player2")
         }
@@ -494,9 +617,13 @@ class LobbyWebSocketControllerTest {
 
         val destCaptor = argumentCaptor<String>()
         val msgCaptor = argumentCaptor<WebSocketMessage>()
-        verify(messagingTemplate).convertAndSend(destCaptor.capture(), msgCaptor.capture())
-        assertEquals("/topic/game/1", destCaptor.firstValue)
-        assertEquals(MessageType.LOBBY_JOINED, msgCaptor.firstValue.type)
-        verify(lobbyService, never()).getLobbyRoster(any())
+        // 2 sends to topic: LOBBY_JOINED + LOBBY_ROSTER (private LOBBY_ROSTER skipped)
+        verify(messagingTemplate, times(2)).convertAndSend(destCaptor.capture(), msgCaptor.capture())
+        assertEquals("/topic/game/1", destCaptor.allValues[0])
+        assertEquals(MessageType.LOBBY_JOINED, msgCaptor.allValues[0].type)
+        assertEquals("/topic/game/1", destCaptor.allValues[1])
+        assertEquals(MessageType.LOBBY_ROSTER, msgCaptor.allValues[1].type)
+        // getLobbyRoster called once for the topic broadcast (not for the skipped private send)
+        verify(lobbyService, times(1)).getLobbyRoster(1)
     }
 }

--- a/src/test/kotlin/org/machikoro/server/listener/WebSocketEventListenerTests.kt
+++ b/src/test/kotlin/org/machikoro/server/listener/WebSocketEventListenerTests.kt
@@ -3,6 +3,7 @@ package org.machikoro.server.listener
 import org.junit.jupiter.api.Test
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.WebSocketMessage
+import org.machikoro.server.service.PendingLobbyCreatedCache
 import org.machikoro.server.service.WebSocketConnectionTracker
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
@@ -17,13 +18,15 @@ import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.messaging.support.MessageBuilder
 import org.springframework.web.socket.CloseStatus
 import org.springframework.web.socket.messaging.SessionDisconnectEvent
+import org.springframework.web.socket.messaging.SessionSubscribeEvent
 import kotlin.test.assertEquals
 
 class WebSocketEventListenerTests {
 
     private val template = mock<SimpMessageSendingOperations>()
     private val connectionTracker = mock<WebSocketConnectionTracker>()
-    private val listener = WebSocketEventListener(template, connectionTracker)
+    private val pendingLobbyCreatedCache = mock<PendingLobbyCreatedCache>()
+    private val listener = WebSocketEventListener(template, connectionTracker, pendingLobbyCreatedCache)
 
     @Test
     fun handleWebSocketDisconnectListenerShouldPublishLeaveMessageWhenUsernameExists() {
@@ -55,6 +58,62 @@ class WebSocketEventListenerTests {
 
         // session-1 is the id passed to SessionDisconnectEvent in the helper
         verify(connectionTracker).unregister("session-1")
+    }
+
+    @Test
+    fun handleWebSocketDisconnectListenerShouldEvictPendingCacheEntry() {
+        val event = disconnectEventWithSessionAttributes(mapOf("username" to "alice"))
+
+        listener.handleWebSocketDisconnectListener(event)
+
+        // Evict prevents the pending cache from leaking entries for sessions that never subscribed
+        verify(pendingLobbyCreatedCache).evict("session-1")
+    }
+
+    @Test
+    fun handleSubscribeEventShouldReplayPendingLobbyCreatedOnUserQueueSubscription() {
+        val sessionId = "sess-42"
+        val destination = "/queue/lobby-user$sessionId"
+        val pending = WebSocketMessage(type = MessageType.LOBBY_CREATED, sender = "SERVER", content = "Lobby created", gameId = 1)
+
+        org.mockito.kotlin.whenever(pendingLobbyCreatedCache.consume(sessionId)).thenReturn(pending)
+
+        listener.handleSubscribeEvent(subscribeEvent(sessionId, destination))
+
+        val destCaptor = argumentCaptor<String>()
+        val msgCaptor = argumentCaptor<WebSocketMessage>()
+        verify(template).convertAndSend(destCaptor.capture(), msgCaptor.capture())
+        assertEquals(destination, destCaptor.firstValue)
+        assertEquals(MessageType.LOBBY_CREATED, msgCaptor.firstValue.type)
+        assertEquals(1, msgCaptor.firstValue.gameId)
+    }
+
+    @Test
+    fun handleSubscribeEventShouldDoNothingWhenNoPendingMessage() {
+        val sessionId = "sess-99"
+        org.mockito.kotlin.whenever(pendingLobbyCreatedCache.consume(sessionId)).thenReturn(null)
+
+        listener.handleSubscribeEvent(subscribeEvent(sessionId, "/queue/lobby-user$sessionId"))
+
+        // No template send — nothing pending means no replay
+        verify(template, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
+    }
+
+    @Test
+    fun handleSubscribeEventShouldIgnoreNonLobbyUserQueueDestinations() {
+        // Subscribing to a game topic must not trigger replay even if there were a pending entry
+        listener.handleSubscribeEvent(subscribeEvent("sess-5", "/topic/game/42"))
+
+        verify(pendingLobbyCreatedCache, never()).consume(any())
+        verify(template, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
+    }
+
+    private fun subscribeEvent(sessionId: String, destination: String): SessionSubscribeEvent {
+        val accessor = SimpMessageHeaderAccessor.create(SimpMessageType.SUBSCRIBE)
+        accessor.sessionId = sessionId
+        accessor.destination = destination
+        val message: Message<ByteArray> = MessageBuilder.createMessage(ByteArray(0), accessor.messageHeaders)
+        return SessionSubscribeEvent(this, message, null)
     }
 
     private fun disconnectEventWithSessionAttributes(attributes: Map<String, Any>): SessionDisconnectEvent {

--- a/src/test/kotlin/org/machikoro/server/service/GameSyncServiceIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GameSyncServiceIntegrationTest.kt
@@ -93,6 +93,9 @@ class GameSyncServiceIntegrationTest : AbstractDBSetup() {
         secondUserId = userIds.second
         firstPlayerId = playerDao.addPlayer(gameId, userIds.first).id
         secondPlayerId = playerDao.addPlayer(gameId, userIds.second).id
+        // All players must be ready before startGame can proceed
+        lobbyService.setReadyState(gameId, firstUserId, true)
+        lobbyService.setReadyState(gameId, secondUserId, true)
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/service/LobbyServiceIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/LobbyServiceIntegrationTest.kt
@@ -102,6 +102,9 @@ class LobbyServiceIntegrationTest : AbstractDBSetup() {
         secondUserId = userIds.second
         firstPlayerId = playerDao.addPlayer(gameId, userIds.first).id
         secondPlayerId = playerDao.addPlayer(gameId, userIds.second).id
+        // All players must be ready before startGame can proceed
+        lobbyService.setReadyState(gameId, firstUserId, true)
+        lobbyService.setReadyState(gameId, secondUserId, true)
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/service/LobbyServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/LobbyServiceTest.kt
@@ -27,6 +27,7 @@ import org.machikoro.server.exception.LobbyFullException
 import org.machikoro.server.exception.NotAllPlayersReadyException
 import org.machikoro.server.exception.NotEnoughPlayersException
 import org.machikoro.server.exception.NotHostException
+import org.machikoro.server.exception.PlayerNotFoundException
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -272,10 +273,18 @@ class LobbyServiceTest {
             PlayerCardModel(playerId = 2, cardType = CardType.BAKERY, quantity = 1),
         )
 
+        // setReadyState guard (x2) + startGame status check + startGame after updateStatus
         whenever(gameDao.findById(gameId))
             .thenReturn(game(gameId, GameStatus.WAITING))
+            .thenReturn(game(gameId, GameStatus.WAITING))
+            .thenReturn(game(gameId, GameStatus.WAITING))
             .thenReturn(updatedGame)
+        whenever(playerDao.findByGameIdAndUserId(gameId, 1)).thenReturn(player(1))
+        whenever(playerDao.findByGameIdAndUserId(gameId, 2)).thenReturn(player(2))
         whenever(playerDao.getPlayers(gameId)).thenReturn(players)
+        whenever(playerDao.getLobbyRoster(gameId)).thenReturn(
+            listOf(rosterEntry(1, "alice", gameId), rosterEntry(2, "bob", gameId))
+        )
         whenever(initializationService.initializeGame(gameId)).thenReturn(players)
         whenever(playerCardDao.findByPlayerIds(listOf(1, 2))).thenReturn(mapOf(1 to p1Cards, 2 to p2Cards))
         whenever(playerLandmarkDao.findByPlayerId(1)).thenReturn(emptyList())
@@ -388,17 +397,17 @@ class LobbyServiceTest {
     // === leaveLobby() ===
 
     @Test
-    fun `leaveLobby returns LobbyDeleted when player is not found (already purged or left)`() {
+    fun `leaveLobby returns NotAMember when player is not found (already purged or left)`() {
         whenever(playerDao.findByGameIdAndUserId(1, 99)).thenReturn(null)
 
         val result = lobbyService.leaveLobby(1, 99)
 
-        assertEquals(LobbyLeavingOutcome.LobbyDeleted(1), result)
+        assertEquals(LobbyLeavingOutcome.NotAMember, result)
         verify(playerDao, never()).deleteByPlayerId(any())
     }
 
     @Test
-    fun `leaveLobby returns LobbyDeleted when game is not found (already purged)`() {
+    fun `leaveLobby returns NotAMember when game is not found (already purged)`() {
         val gameId = 1
         val userId = 10
         val p = player(5).copy(gameId = gameId, userId = userId)
@@ -407,7 +416,7 @@ class LobbyServiceTest {
 
         val result = lobbyService.leaveLobby(gameId, userId)
 
-        assertEquals(LobbyLeavingOutcome.LobbyDeleted(gameId), result)
+        assertEquals(LobbyLeavingOutcome.NotAMember, result)
         verify(playerDao, never()).deleteByPlayerId(any())
     }
 
@@ -668,6 +677,8 @@ class LobbyServiceTest {
     @Test
     fun `setReadyState marks player as ready and returns roster with isReady true`() {
         val gameId = 1
+        whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.WAITING))
+        whenever(playerDao.findByGameIdAndUserId(gameId, 1)).thenReturn(player(1))
         whenever(playerDao.getLobbyRoster(gameId)).thenReturn(
             listOf(rosterEntry(1, "alice", gameId))
         )
@@ -680,6 +691,8 @@ class LobbyServiceTest {
     @Test
     fun `setReadyState marks player as not ready after toggling back`() {
         val gameId = 1
+        whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.WAITING))
+        whenever(playerDao.findByGameIdAndUserId(gameId, 1)).thenReturn(player(1))
         whenever(playerDao.getLobbyRoster(gameId)).thenReturn(
             listOf(rosterEntry(1, "alice", gameId))
         )
@@ -693,6 +706,8 @@ class LobbyServiceTest {
     @Test
     fun `setReadyState only marks the specified player as ready`() {
         val gameId = 1
+        whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.WAITING))
+        whenever(playerDao.findByGameIdAndUserId(gameId, 1)).thenReturn(player(1))
         whenever(playerDao.getLobbyRoster(gameId)).thenReturn(
             listOf(
                 rosterEntry(1, "alice", gameId),
@@ -707,11 +722,43 @@ class LobbyServiceTest {
         assertEquals(false, roster.first { it.userId == 2 }.isReady)
     }
 
+    @Test
+    fun `setReadyState throws GameNotFoundException when game does not exist`() {
+        whenever(gameDao.findById(99)).thenReturn(null)
+
+        assertThrows<GameNotFoundException> {
+            lobbyService.setReadyState(99, 1, true)
+        }
+    }
+
+    @Test
+    fun `setReadyState throws GameStartedException when game is not WAITING`() {
+        val gameId = 1
+        whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.IN_PROGRESS))
+
+        assertThrows<GameStartedException> {
+            lobbyService.setReadyState(gameId, 1, true)
+        }
+    }
+
+    @Test
+    fun `setReadyState throws PlayerNotFoundException when caller is not in the game`() {
+        val gameId = 1
+        whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.WAITING))
+        whenever(playerDao.findByGameIdAndUserId(gameId, 99)).thenReturn(null)
+
+        assertThrows<PlayerNotFoundException> {
+            lobbyService.setReadyState(gameId, 99, true)
+        }
+    }
+
     // === getLobbyRoster() — isReady enrichment ===
 
     @Test
     fun `getLobbyRoster enriches players with isReady true when they are in the ready set`() {
         val gameId = 1
+        whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.WAITING))
+        whenever(playerDao.findByGameIdAndUserId(gameId, 1)).thenReturn(player(1))
         whenever(playerDao.getLobbyRoster(gameId)).thenReturn(
             listOf(
                 rosterEntry(1, "alice", gameId),
@@ -733,6 +780,10 @@ class LobbyServiceTest {
         val gameId = 1
         whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.WAITING))
         whenever(playerDao.getPlayers(gameId)).thenReturn(listOf(player(1), player(2)))
+        // Return real (non-debug) players so the gate actually fires
+        whenever(playerDao.getLobbyRoster(gameId)).thenReturn(
+            listOf(rosterEntry(1, "alice", gameId), rosterEntry(2, "bob", gameId))
+        )
 
         assertThrows<NotAllPlayersReadyException> {
             lobbyService.startGame(gameId)
@@ -745,7 +796,12 @@ class LobbyServiceTest {
     fun `startGame throws NotAllPlayersReadyException when only one of two players is ready`() {
         val gameId = 1
         whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.WAITING))
+        whenever(playerDao.findByGameIdAndUserId(gameId, 1)).thenReturn(player(1))
         whenever(playerDao.getPlayers(gameId)).thenReturn(listOf(player(1), player(2)))
+        // Return real players so the gate fires for the unready player
+        whenever(playerDao.getLobbyRoster(gameId)).thenReturn(
+            listOf(rosterEntry(1, "alice", gameId), rosterEntry(2, "bob", gameId))
+        )
         // Only player 1 is ready — player 2 is still not
         lobbyService.setReadyState(gameId, 1, true)
 
@@ -756,6 +812,68 @@ class LobbyServiceTest {
         verify(initializationService, never()).initializeGame(any())
     }
 
+    @Test
+    fun `startGame succeeds when only debug bots are not ready`() {
+        val gameId = 1
+        val realPlayer = player(1)
+        val players = listOf(realPlayer, player(2))
+        val updatedGame = game(gameId, GameStatus.IN_PROGRESS)
+        // setReadyState guard (x1) + startGame status check + startGame after updateStatus
+        whenever(gameDao.findById(gameId))
+            .thenReturn(game(gameId, GameStatus.WAITING))
+            .thenReturn(game(gameId, GameStatus.WAITING))
+            .thenReturn(updatedGame)
+        whenever(playerDao.findByGameIdAndUserId(gameId, 1)).thenReturn(realPlayer)
+        whenever(playerDao.getPlayers(gameId)).thenReturn(players)
+        whenever(playerDao.getLobbyRoster(gameId)).thenReturn(
+            listOf(
+                rosterEntry(1, "alice", gameId),        // Real player — must be ready
+                rosterEntry(2, "debug_player2", gameId), // Debug bot — excluded from gate
+            )
+        )
+        whenever(initializationService.initializeGame(gameId)).thenReturn(players)
+        whenever(playerCardDao.findByPlayerIds(any())).thenReturn(emptyMap())
+        whenever(playerLandmarkDao.findByPlayerId(any())).thenReturn(emptyList())
+        whenever(gameMarketplaceDao.findByGameIdAsMap(gameId)).thenReturn(emptyMap())
+        // Only the real player is ready; debug bot is not — game should still start
+        lobbyService.setReadyState(gameId, 1, true)
+
+        val result = lobbyService.startGame(gameId)
+
+        assertEquals(GameStatus.IN_PROGRESS, result.game.status)
+        verify(initializationService).initializeGame(gameId)
+    }
+
+    @Test
+    fun `startGame auto-readies the host when requestingUserId is provided`() {
+        val gameId = 1
+        val hostUserId = 1
+        val otherUserId = 2
+        val players = listOf(player(hostUserId), player(otherUserId))
+        val updatedGame = game(gameId, GameStatus.IN_PROGRESS).copy(hostUserId = hostUserId)
+        // setReadyState guard (x1) + startGame status check + startGame after updateStatus
+        whenever(gameDao.findById(gameId))
+            .thenReturn(game(gameId, GameStatus.WAITING).copy(hostUserId = hostUserId))
+            .thenReturn(game(gameId, GameStatus.WAITING).copy(hostUserId = hostUserId))
+            .thenReturn(updatedGame)
+        whenever(playerDao.findByGameIdAndUserId(gameId, otherUserId)).thenReturn(player(otherUserId))
+        whenever(playerDao.getPlayers(gameId)).thenReturn(players)
+        whenever(playerDao.getLobbyRoster(gameId)).thenReturn(
+            listOf(rosterEntry(hostUserId, "alice", gameId), rosterEntry(otherUserId, "bob", gameId))
+        )
+        whenever(initializationService.initializeGame(gameId)).thenReturn(players)
+        whenever(playerCardDao.findByPlayerIds(any())).thenReturn(emptyMap())
+        whenever(playerLandmarkDao.findByPlayerId(any())).thenReturn(emptyList())
+        whenever(gameMarketplaceDao.findByGameIdAsMap(gameId)).thenReturn(emptyMap())
+        // Only the non-host player pressed ready — host is auto-readied by startGame call
+        lobbyService.setReadyState(gameId, otherUserId, true)
+
+        val result = lobbyService.startGame(gameId, hostUserId)
+
+        assertEquals(GameStatus.IN_PROGRESS, result.game.status)
+        verify(initializationService).initializeGame(gameId)
+    }
+
     // === startGame() — playerUsernames ===
 
     @Test
@@ -763,9 +881,14 @@ class LobbyServiceTest {
         val gameId = 1
         val players = listOf(player(1), player(2))
         val updatedGame = game(gameId, GameStatus.IN_PROGRESS)
+        // setReadyState guard (x2) + startGame status check + startGame after updateStatus
         whenever(gameDao.findById(gameId))
             .thenReturn(game(gameId, GameStatus.WAITING))
+            .thenReturn(game(gameId, GameStatus.WAITING))
+            .thenReturn(game(gameId, GameStatus.WAITING))
             .thenReturn(updatedGame)
+        whenever(playerDao.findByGameIdAndUserId(gameId, 1)).thenReturn(player(1))
+        whenever(playerDao.findByGameIdAndUserId(gameId, 2)).thenReturn(player(2))
         whenever(playerDao.getPlayers(gameId)).thenReturn(players)
         whenever(initializationService.initializeGame(gameId)).thenReturn(players)
         whenever(playerCardDao.findByPlayerIds(any())).thenReturn(emptyMap())

--- a/src/test/kotlin/org/machikoro/server/service/LobbyServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/LobbyServiceTest.kt
@@ -27,7 +27,6 @@ import org.machikoro.server.exception.LobbyFullException
 import org.machikoro.server.exception.NotAllPlayersReadyException
 import org.machikoro.server.exception.NotEnoughPlayersException
 import org.machikoro.server.exception.NotHostException
-import org.machikoro.server.exception.PlayerNotFoundException
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -389,16 +388,27 @@ class LobbyServiceTest {
     // === leaveLobby() ===
 
     @Test
-    fun `leaveLobby throws PlayerNotFoundException when player is not in the game`() {
-        whenever(playerDao.findByGameIdAndUserId(1, 99))
-            .thenReturn(null)
+    fun `leaveLobby returns LobbyDeleted when player is not found (already purged or left)`() {
+        whenever(playerDao.findByGameIdAndUserId(1, 99)).thenReturn(null)
 
-        assertThrows<PlayerNotFoundException> {
-            lobbyService.leaveLobby(1, 99)
-        }
+        val result = lobbyService.leaveLobby(1, 99)
 
-        verify(playerDao, never())
-            .deleteByPlayerId(any())
+        assertEquals(LobbyLeavingOutcome.LobbyDeleted(1), result)
+        verify(playerDao, never()).deleteByPlayerId(any())
+    }
+
+    @Test
+    fun `leaveLobby returns LobbyDeleted when game is not found (already purged)`() {
+        val gameId = 1
+        val userId = 10
+        val p = player(5).copy(gameId = gameId, userId = userId)
+        whenever(playerDao.findByGameIdAndUserId(gameId, userId)).thenReturn(p)
+        whenever(gameDao.findById(gameId)).thenReturn(null)
+
+        val result = lobbyService.leaveLobby(gameId, userId)
+
+        assertEquals(LobbyLeavingOutcome.LobbyDeleted(gameId), result)
+        verify(playerDao, never()).deleteByPlayerId(any())
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/service/LobbyServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/LobbyServiceTest.kt
@@ -24,6 +24,7 @@ import org.machikoro.server.exception.GameFinishedException
 import org.machikoro.server.exception.GameNotFoundException
 import org.machikoro.server.exception.GameStartedException
 import org.machikoro.server.exception.LobbyFullException
+import org.machikoro.server.exception.NotAllPlayersReadyException
 import org.machikoro.server.exception.NotEnoughPlayersException
 import org.machikoro.server.exception.NotHostException
 import org.machikoro.server.exception.PlayerNotFoundException
@@ -281,6 +282,9 @@ class LobbyServiceTest {
         whenever(playerLandmarkDao.findByPlayerId(1)).thenReturn(emptyList())
         whenever(playerLandmarkDao.findByPlayerId(2)).thenReturn(emptyList())
         whenever(gameMarketplaceDao.findByGameIdAsMap(gameId)).thenReturn(emptyMap())
+        // Mark all players ready so startGame doesn't block on NOT_ALL_PLAYERS_READY
+        lobbyService.setReadyState(gameId, 1, true)
+        lobbyService.setReadyState(gameId, 2, true)
 
         val result = lobbyService.startGame(gameId)
 
@@ -649,6 +653,99 @@ class LobbyServiceTest {
         verify(gameDao, never()).delete(any())
     }
 
+    // === setReadyState() ===
+
+    @Test
+    fun `setReadyState marks player as ready and returns roster with isReady true`() {
+        val gameId = 1
+        whenever(playerDao.getLobbyRoster(gameId)).thenReturn(
+            listOf(rosterEntry(1, "alice", gameId))
+        )
+
+        val roster = lobbyService.setReadyState(gameId, 1, true)
+
+        assertEquals(true, roster[0].isReady)
+    }
+
+    @Test
+    fun `setReadyState marks player as not ready after toggling back`() {
+        val gameId = 1
+        whenever(playerDao.getLobbyRoster(gameId)).thenReturn(
+            listOf(rosterEntry(1, "alice", gameId))
+        )
+
+        lobbyService.setReadyState(gameId, 1, true)
+        val roster = lobbyService.setReadyState(gameId, 1, false)
+
+        assertEquals(false, roster[0].isReady)
+    }
+
+    @Test
+    fun `setReadyState only marks the specified player as ready`() {
+        val gameId = 1
+        whenever(playerDao.getLobbyRoster(gameId)).thenReturn(
+            listOf(
+                rosterEntry(1, "alice", gameId),
+                rosterEntry(2, "bob", gameId),
+            )
+        )
+
+        val roster = lobbyService.setReadyState(gameId, 1, true)
+
+        // Alice (userId=1) is ready, Bob (userId=2) is not
+        assertEquals(true, roster.first { it.userId == 1 }.isReady)
+        assertEquals(false, roster.first { it.userId == 2 }.isReady)
+    }
+
+    // === getLobbyRoster() — isReady enrichment ===
+
+    @Test
+    fun `getLobbyRoster enriches players with isReady true when they are in the ready set`() {
+        val gameId = 1
+        whenever(playerDao.getLobbyRoster(gameId)).thenReturn(
+            listOf(
+                rosterEntry(1, "alice", gameId),
+                rosterEntry(2, "bob", gameId),
+            )
+        )
+        lobbyService.setReadyState(gameId, 1, true)
+
+        val roster = lobbyService.getLobbyRoster(gameId)
+
+        assertEquals(true, roster.first { it.userId == 1 }.isReady)
+        assertEquals(false, roster.first { it.userId == 2 }.isReady)
+    }
+
+    // === startGame() — NotAllPlayersReadyException ===
+
+    @Test
+    fun `startGame throws NotAllPlayersReadyException when no players are ready`() {
+        val gameId = 1
+        whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.WAITING))
+        whenever(playerDao.getPlayers(gameId)).thenReturn(listOf(player(1), player(2)))
+
+        assertThrows<NotAllPlayersReadyException> {
+            lobbyService.startGame(gameId)
+        }
+
+        verify(initializationService, never()).initializeGame(any())
+    }
+
+    @Test
+    fun `startGame throws NotAllPlayersReadyException when only one of two players is ready`() {
+        val gameId = 1
+        whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.WAITING))
+        whenever(playerDao.getPlayers(gameId)).thenReturn(listOf(player(1), player(2)))
+        // Only player 1 is ready — player 2 is still not
+        lobbyService.setReadyState(gameId, 1, true)
+
+        assertThrows<NotAllPlayersReadyException> {
+            lobbyService.startGame(gameId)
+        }
+
+        verify(initializationService, never()).initializeGame(any())
+    }
+
     // === startGame() — playerUsernames ===
 
     @Test
@@ -667,6 +764,9 @@ class LobbyServiceTest {
         whenever(playerDao.getLobbyRoster(gameId)).thenReturn(
             listOf(rosterEntry(1, "alice", gameId), rosterEntry(2, "bob", gameId))
         )
+        // Mark all players ready so startGame doesn't block on NOT_ALL_PLAYERS_READY
+        lobbyService.setReadyState(gameId, 1, true)
+        lobbyService.setReadyState(gameId, 2, true)
 
         val result = lobbyService.startGame(gameId)
 

--- a/src/test/kotlin/org/machikoro/server/service/SpringContextRestartRecoveryIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/SpringContextRestartRecoveryIntegrationTest.kt
@@ -128,7 +128,10 @@ class SpringContextRestartRecoveryIntegrationTest {
         lobbyService.addUserToLobby(sharedGameId, hostUserId)
         val gameCode = gameDao.findById(sharedGameId)!!.lobbyCode
         lobbyService.joinLobby(gameCode, guestUserId)
-        
+        // All players must be ready before startGame can proceed
+        lobbyService.setReadyState(sharedGameId, hostUserId, true)
+        lobbyService.setReadyState(sharedGameId, guestUserId, true)
+
         lobbyService.startGame(sharedGameId)
         
         val players = playerDao.getPlayers(sharedGameId)


### PR DESCRIPTION
Problem:                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 Two bugs in the lobby ready flow:                                                                                                                                                                                                                                                                                
- Toggling ready on one client had no effect on other clients — the backend had no /app/lobby.ready endpoint, so the toggle was silently dropped                                                                                                                                                                 
- The host could start the game without all players being ready — startEnabled only checked if the host was ready, not everyone                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                   
Changes:
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
- New /app/lobby.ready WebSocket endpoint — updates in-memory ready state, broadcasts LOBBY_ROSTER with isReady flags to all lobby members                                                                                                                                                                       
- LobbyRosterPlayerDto — added isReady: Boolean                                                                                                                                                                                                                                                                  
- LobbyService — in-memory readyPlayers map (gameId → set of ready userIds), setReadyState(), getLobbyRoster() enriched with ready flags, startGame() rejects with NOT_ALL_PLAYERS_READY if any player not ready                                                                                                 
- LobbyWebSocketController — broadcasts full LOBBY_ROSTER after LOBBY_JOINED and LOBBY_LEFT so ready states stay visible when lobby composition changes                                                                                                                                                          
- leaveLobby() — returns LobbyDeleted instead of throwing PlayerNotFoundException when player/game already gone (fixes crash after debug purge)