### PR TITLE
Fix: Ready Sync in Lobby

### DIFF
--- a/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
@@ -186,6 +186,60 @@ class LobbyWebSocketController(
     }
 
     /**
+     * Handles a player's ready-state toggle in the lobby.
+     *
+     * Client sends a message to `/app/lobby.ready` with `gameId` and `isReady`
+     * in the payload. Server updates the in-memory ready set and broadcasts
+     * the full updated roster to `/topic/game/{gameId}` so every client
+     * re-renders with accurate per-player ready state.
+     */
+    @MessageMapping("/lobby.ready")
+    fun toggleReady(
+        @Payload message: WebSocketMessage,
+        headerAccessor: SimpMessageHeaderAccessor,
+    ) {
+        val principal = headerAccessor.userPrincipal()
+            ?: throw CustomWebSocketException(
+                errorCode = "UNAUTHENTICATED",
+                message = "Authenticated principal not found",
+            )
+
+        val payload = message.payload as? Map<*, *>
+            ?: throw CustomWebSocketException(
+                errorCode = "INVALID_PAYLOAD",
+                message = "lobby.ready payload must contain gameId and isReady",
+            )
+
+        val gameId = (payload["gameId"] as? Number)?.toInt()
+            ?: throw CustomWebSocketException(
+                errorCode = "MISSING_GAME_ID",
+                message = "gameId is missing or not a number",
+            )
+
+        val isReady = payload["isReady"] as? Boolean
+            ?: throw CustomWebSocketException(
+                errorCode = "MISSING_IS_READY",
+                message = "isReady is missing or not a boolean",
+            )
+
+        logger.info("User '{}' toggled ready to {} in game {}", principal.username, isReady, gameId)
+
+        lobbyService.toggleReady(gameId, principal.userId, isReady)
+
+        val roster = lobbyService.getLobbyRoster(gameId)
+        messagingTemplate.convertAndSend(
+            "/topic/game/$gameId",
+            WebSocketMessage(
+                type = MessageType.LOBBY_ROSTER,
+                sender = "SERVER",
+                content = "Lobby roster updated",
+                gameId = gameId,
+                payload = org.machikoro.server.dto.LobbyRosterDto(players = roster),
+            )
+        )
+    }
+
+    /**
      * Handles a player leaving a lobby via WebSocket.
      *
      * Client sends a message to `/app/lobby.leave` with the `gameId`

--- a/src/main/kotlin/org/machikoro/server/dto/LobbyRosterDto.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/LobbyRosterDto.kt
@@ -11,4 +11,5 @@ data class LobbyRosterPlayerDto(
     val gameId: Int,
     val turnOrder: Int,
     val coins: Int,
+    val isReady: Boolean = false,
 )

--- a/src/main/kotlin/org/machikoro/server/service/DebugService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/DebugService.kt
@@ -70,6 +70,8 @@ class DebugService(
             val creds = ensureUser(username)
             try {
                 val player = lobbyService.addUserToLobby(game.id, creds.userId)
+                // Dummies are always ready so the host can start immediately
+                lobbyService.toggleReady(game.id, creds.userId, true)
                 // Broadcast to per-lobby topic, matching the real join path
                 messagingTemplate.convertAndSend(
                     "/topic/game/${player.gameId}",
@@ -84,6 +86,8 @@ class DebugService(
                             "username" to username,
                             "gameId" to player.gameId,
                             "coins" to player.coins,
+                            // Dummies are always pre-marked ready
+                            "isReady" to true,
                         )
                     )
                 )

--- a/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
@@ -37,8 +37,11 @@ open class LobbyService(
     private val landmarkDao: LandmarkDao,
 ) {
 
-    // ConcurrentHashMap for thread-safe lock creation and removal
+    // Per-lobby synchronization locks
     private val lobbyLocks = ConcurrentHashMap<Int, Any>()
+
+    // Tracks which userIds have toggled ready per gameId — cleared when lobby is deleted
+    private val readyPlayers = ConcurrentHashMap<Int, MutableSet<Int>>()
 
     /**
      * Runs [block] inside an Exposed transaction.
@@ -99,10 +102,26 @@ open class LobbyService(
     }
 
     /**
-     * Returns the current lobby roster for [gameId], including usernames, ordered by turn order.
+     * Returns the current lobby roster for [gameId] with per-player ready state merged in.
      */
     fun getLobbyRoster(gameId: Int): List<LobbyRosterPlayerDto> = runInTransaction {
-        playerDao.getLobbyRoster(gameId)
+        val ready = readyPlayers[gameId] ?: emptySet()
+        playerDao.getLobbyRoster(gameId).map { it.copy(isReady = it.userId in ready) }
+    }
+
+    /**
+     * Flips the ready state for [userId] in [gameId].
+     *
+     * @throws GameNotFoundException if no game with [gameId] exists.
+     * @throws PlayerNotFoundException if [userId] is not part of the lobby.
+     */
+    fun toggleReady(gameId: Int, userId: Int, isReady: Boolean) {
+        gameDao.findById(gameId) ?: throw GameNotFoundException("Game $gameId not found")
+        playerDao.findByGameIdAndUserId(gameId, userId)
+            ?: throw PlayerNotFoundException("Player $userId not found in game $gameId")
+
+        val readySet = readyPlayers.computeIfAbsent(gameId) { ConcurrentHashMap.newKeySet() }
+        if (isReady) readySet.add(userId) else readySet.remove(userId)
     }
 
     /**
@@ -163,6 +182,7 @@ open class LobbyService(
             gameDao.delete(game.id)
         }
         lobbyLocks.clear()
+        readyPlayers.clear()
         games.size
     }
 
@@ -231,6 +251,7 @@ open class LobbyService(
         playerDao.deleteByGameId(gameId)
         gameDao.delete(gameId)
         lobbyLocks.remove(gameId)
+        readyPlayers.remove(gameId)
     }
 
     /**

--- a/src/test/kotlin/org/machikoro/server/controller/LobbyWebSocketControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/LobbyWebSocketControllerTest.kt
@@ -481,6 +481,142 @@ class LobbyWebSocketControllerTest {
 
         assertEquals(10, payload["userId"])
     }
+    // === toggleReady() ===
+
+    @Test
+    fun `toggleReady broadcasts updated LOBBY_ROSTER to game topic`() {
+        val gameId = 1
+        val userId = 20
+        val roster = listOf(
+            LobbyRosterPlayerDto(playerId = 5, userId = userId, username = "Player2", gameId = gameId, turnOrder = 1, coins = 3, isReady = true),
+        )
+        whenever(lobbyService.getLobbyRoster(gameId)).thenReturn(roster)
+
+        val accessor = authenticatedAccessor(userId = userId, username = "Player2")
+
+        controller.toggleReady(
+            WebSocketMessage(type = MessageType.LOBBY_ROSTER, sender = "android-client",
+                payload = mapOf("gameId" to gameId, "isReady" to true)),
+            accessor,
+        )
+
+        verify(lobbyService).toggleReady(gameId, userId, true)
+
+        val destCaptor = argumentCaptor<String>()
+        val msgCaptor = argumentCaptor<WebSocketMessage>()
+        verify(messagingTemplate).convertAndSend(destCaptor.capture(), msgCaptor.capture())
+
+        assertEquals("/topic/game/$gameId", destCaptor.firstValue)
+        val msg = msgCaptor.firstValue
+        assertEquals(MessageType.LOBBY_ROSTER, msg.type)
+        assertEquals("SERVER", msg.sender)
+        assertEquals(gameId, msg.gameId)
+        assertEquals(LobbyRosterDto(players = roster), msg.payload)
+    }
+
+    @Test
+    fun `toggleReady throws when no authenticated principal is present`() {
+        val accessor = SimpMessageHeaderAccessor.create().apply { sessionId = "sess-1" }
+
+        val ex = assertThrows<CustomWebSocketException> {
+            controller.toggleReady(
+                WebSocketMessage(type = MessageType.LOBBY_ROSTER, sender = "ghost",
+                    payload = mapOf("gameId" to 1, "isReady" to true)),
+                accessor,
+            )
+        }
+
+        assertEquals("UNAUTHENTICATED", ex.errorCode)
+        verify(lobbyService, never()).toggleReady(any(), any(), any())
+        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
+    }
+
+    @Test
+    fun `toggleReady throws when payload is not a Map`() {
+        val accessor = authenticatedAccessor(userId = 20, username = "Player2")
+
+        val ex = assertThrows<CustomWebSocketException> {
+            controller.toggleReady(
+                WebSocketMessage(type = MessageType.LOBBY_ROSTER, sender = "Player2",
+                    payload = "not-a-map"),
+                accessor,
+            )
+        }
+
+        assertEquals("INVALID_PAYLOAD", ex.errorCode)
+        verify(lobbyService, never()).toggleReady(any(), any(), any())
+    }
+
+    @Test
+    fun `toggleReady throws when gameId is missing from payload`() {
+        val accessor = authenticatedAccessor(userId = 20, username = "Player2")
+
+        val ex = assertThrows<CustomWebSocketException> {
+            controller.toggleReady(
+                WebSocketMessage(type = MessageType.LOBBY_ROSTER, sender = "Player2",
+                    payload = mapOf("isReady" to true)),
+                accessor,
+            )
+        }
+
+        assertEquals("MISSING_GAME_ID", ex.errorCode)
+        verify(lobbyService, never()).toggleReady(any(), any(), any())
+    }
+
+    @Test
+    fun `toggleReady throws when isReady is missing from payload`() {
+        val accessor = authenticatedAccessor(userId = 20, username = "Player2")
+
+        val ex = assertThrows<CustomWebSocketException> {
+            controller.toggleReady(
+                WebSocketMessage(type = MessageType.LOBBY_ROSTER, sender = "Player2",
+                    payload = mapOf("gameId" to 1)),
+                accessor,
+            )
+        }
+
+        assertEquals("MISSING_IS_READY", ex.errorCode)
+        verify(lobbyService, never()).toggleReady(any(), any(), any())
+    }
+
+    @Test
+    fun `toggleReady propagates GameNotFoundException from service`() {
+        whenever(lobbyService.toggleReady(99, 20, true))
+            .thenThrow(GameNotFoundException("Game 99 not found"))
+
+        val accessor = authenticatedAccessor(userId = 20, username = "Player2")
+
+        assertThrows<GameNotFoundException> {
+            controller.toggleReady(
+                WebSocketMessage(type = MessageType.LOBBY_ROSTER, sender = "Player2",
+                    payload = mapOf("gameId" to 99, "isReady" to true)),
+                accessor,
+            )
+        }
+
+        verify(lobbyService).toggleReady(99, 20, true)
+        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
+    }
+
+    @Test
+    fun `toggleReady propagates PlayerNotFoundException from service`() {
+        whenever(lobbyService.toggleReady(1, 20, true))
+            .thenThrow(PlayerNotFoundException("Player 20 not found in game 1"))
+
+        val accessor = authenticatedAccessor(userId = 20, username = "Player2")
+
+        assertThrows<PlayerNotFoundException> {
+            controller.toggleReady(
+                WebSocketMessage(type = MessageType.LOBBY_ROSTER, sender = "Player2",
+                    payload = mapOf("gameId" to 1, "isReady" to true)),
+                accessor,
+            )
+        }
+
+        verify(lobbyService).toggleReady(1, 20, true)
+        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
+    }
+
     @Test
     fun `joinLobby skips LOBBY_ROSTER when sessionId is null`() {
         whenever(lobbyService.joinLobby("ABC1234", 20)).thenReturn(player())

--- a/src/test/kotlin/org/machikoro/server/service/LobbyServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/LobbyServiceTest.kt
@@ -649,6 +649,118 @@ class LobbyServiceTest {
         verify(gameDao, never()).delete(any())
     }
 
+    // === toggleReady() ===
+
+    @Test
+    fun `toggleReady throws GameNotFoundException when game does not exist`() {
+        whenever(gameDao.findById(99)).thenReturn(null)
+
+        assertThrows<GameNotFoundException> {
+            lobbyService.toggleReady(99, 10, true)
+        }
+
+        verify(playerDao, never()).findByGameIdAndUserId(any(), any())
+    }
+
+    @Test
+    fun `toggleReady throws PlayerNotFoundException when player is not in the game`() {
+        val gameId = 1
+        whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.WAITING))
+        whenever(playerDao.findByGameIdAndUserId(gameId, 99)).thenReturn(null)
+
+        assertThrows<PlayerNotFoundException> {
+            lobbyService.toggleReady(gameId, 99, true)
+        }
+    }
+
+    @Test
+    fun `toggleReady marks player ready and getLobbyRoster reflects it`() {
+        val gameId = 1
+        val userId = 10
+        whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.WAITING))
+        whenever(playerDao.findByGameIdAndUserId(gameId, userId))
+            .thenReturn(player(userId).copy(gameId = gameId, userId = userId))
+        whenever(playerDao.getLobbyRoster(gameId))
+            .thenReturn(listOf(rosterEntry(userId, "alice", gameId)))
+
+        lobbyService.toggleReady(gameId, userId, true)
+
+        assertEquals(true, lobbyService.getLobbyRoster(gameId).single().isReady)
+    }
+
+    @Test
+    fun `toggleReady marks player not ready after toggling back`() {
+        val gameId = 1
+        val userId = 10
+        whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.WAITING))
+        whenever(playerDao.findByGameIdAndUserId(gameId, userId))
+            .thenReturn(player(userId).copy(gameId = gameId, userId = userId))
+        whenever(playerDao.getLobbyRoster(gameId))
+            .thenReturn(listOf(rosterEntry(userId, "alice", gameId)))
+
+        lobbyService.toggleReady(gameId, userId, true)
+        lobbyService.toggleReady(gameId, userId, false)
+
+        assertEquals(false, lobbyService.getLobbyRoster(gameId).single().isReady)
+    }
+
+    @Test
+    fun `getLobbyRoster returns isReady true only for players in the ready set`() {
+        val gameId = 1
+        val readyUserId = 10
+        val notReadyUserId = 20
+        whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.WAITING))
+        whenever(playerDao.findByGameIdAndUserId(gameId, readyUserId))
+            .thenReturn(player(readyUserId).copy(gameId = gameId, userId = readyUserId))
+        whenever(playerDao.getLobbyRoster(gameId)).thenReturn(listOf(
+            rosterEntry(readyUserId, "alice", gameId),
+            rosterEntry(notReadyUserId, "bob", gameId),
+        ))
+
+        lobbyService.toggleReady(gameId, readyUserId, true)
+        val roster = lobbyService.getLobbyRoster(gameId)
+
+        assertEquals(true, roster.find { it.userId == readyUserId }!!.isReady)
+        assertEquals(false, roster.find { it.userId == notReadyUserId }!!.isReady)
+    }
+
+    @Test
+    fun `leaveLobby clears ready state when lobby is deleted`() {
+        val gameId = 1
+        val userId = 10
+        whenever(gameDao.findById(gameId))
+            .thenReturn(game(gameId, GameStatus.WAITING).copy(hostUserId = userId))
+        whenever(playerDao.findByGameIdAndUserId(gameId, userId))
+            .thenReturn(player(5).copy(gameId = gameId, userId = userId))
+        whenever(playerDao.getLobbyRoster(gameId))
+            .thenReturn(listOf(rosterEntry(userId, "alice", gameId)))
+
+        lobbyService.toggleReady(gameId, userId, true)
+        assertEquals(true, lobbyService.getLobbyRoster(gameId).single().isReady)
+
+        // Host leaves → lobby deleted → ready state must be gone
+        lobbyService.leaveLobby(gameId, userId)
+        assertEquals(false, lobbyService.getLobbyRoster(gameId).single().isReady)
+    }
+
+    @Test
+    fun `purgeAllGames clears all ready state`() {
+        val gameId = 1
+        val userId = 10
+        whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.WAITING))
+        whenever(playerDao.findByGameIdAndUserId(gameId, userId))
+            .thenReturn(player(userId).copy(gameId = gameId, userId = userId))
+        whenever(playerDao.getLobbyRoster(gameId))
+            .thenReturn(listOf(rosterEntry(userId, "alice", gameId)))
+        whenever(gameDao.findAll()).thenReturn(listOf(game(gameId, GameStatus.WAITING)))
+
+        lobbyService.toggleReady(gameId, userId, true)
+        assertEquals(true, lobbyService.getLobbyRoster(gameId).single().isReady)
+
+        lobbyService.purgeAllGames()
+        assertEquals(false, lobbyService.getLobbyRoster(gameId).single().isReady)
+    }
+
     // === startGame() — playerUsernames ===
 
     @Test


### PR DESCRIPTION
This PR fixes the ready synchronization in the lobby screen between multiple clients, by introducing an isReady property in the LobbyRosterDTO, a new concurrentHashmap (readyPlayers) and a new REST endpoint. 
The whole thing gets saved in memory, instead of using a flag in the database for the time being. This should be sufficient though.