### PR TITLE
Cheating accusations (server): silent cheat tracking, adjudication & coin penalty (#361)

### DIFF
--- a/src/main/kotlin/org/machikoro/server/controller/GameController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/GameController.kt
@@ -375,15 +375,19 @@ class GameController(
         )
         logger.info(
             "Accusation in game {} by player {} against {} -> {}",
-            request.gameId, outcome.accuserPlayerId, outcome.accusedPlayerId, outcome.outcome,
+            request.gameId, outcome.accuserPlayerId, outcome.accusedPlayerId,
+            if (outcome.caught) "CAUGHT" else "WRONG",
         )
         broadcastAccusationResult(request.gameId, outcome)
     }
 
     /**
-     * Broadcasts an ACCUSATION_RESULT to the game topic with the outcome, the
-     * involved player IDs (PlayerModel.id), and a fresh state snapshot so coin
-     * totals update for everyone.
+     * Broadcasts an ACCUSATION_RESULT to the game topic. The payload keys
+     * `{accuserPlayerId, accusedPlayerId, caught, penalizedPlayerId,
+     * penaltyCoins}` are the wire contract agreed in issue #361 / Client#280 —
+     * keep them in lockstep with the client parser (see the #353 post-mortem).
+     * `state` carries the usual fresh snapshot so coin totals update for
+     * everyone.
      */
     private fun broadcastAccusationResult(gameId: Int, outcome: AccusationOutcome) {
         val state = gameSyncService.buildSnapshot(gameId)
@@ -393,10 +397,11 @@ class GameController(
                 type = MessageType.ACCUSATION_RESULT,
                 sender = "server",
                 payload = linkedMapOf<String, Any?>(
-                    "outcome" to outcome.outcome.name,
                     "accuserPlayerId" to outcome.accuserPlayerId,
                     "accusedPlayerId" to outcome.accusedPlayerId,
+                    "caught" to outcome.caught,
                     "penalizedPlayerId" to outcome.penalizedPlayerId,
+                    "penaltyCoins" to outcome.penaltyCoins,
                     "state" to state,
                 ),
                 gameId = gameId,

--- a/src/main/kotlin/org/machikoro/server/controller/GameController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/GameController.kt
@@ -2,6 +2,8 @@ package org.machikoro.server.controller
 
 import org.machikoro.server.auth.requireUserPrincipal
 import org.machikoro.server.domain.models.PlayerModel
+import org.machikoro.server.dto.AccusationOutcome
+import org.machikoro.server.dto.AccuseRequest
 import org.machikoro.server.dto.AdvancePhaseRequest
 import org.machikoro.server.dto.EndTurnOutcome
 import org.machikoro.server.dto.EndTurnRequest
@@ -9,6 +11,7 @@ import org.machikoro.server.dto.EnterGameScreenRequest
 import org.machikoro.server.dto.GameStateDto
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.PurchaseRequest
+import org.machikoro.server.dto.ReportCheatRequest
 import org.machikoro.server.dto.RollDiceRequest
 import org.machikoro.server.dto.StartGameRequest
 import org.machikoro.server.dto.WebSocketErrorDto
@@ -16,6 +19,7 @@ import org.machikoro.server.dto.WebSocketMessage
 import org.machikoro.server.exception.CustomWebSocketException
 import org.machikoro.server.exception.GameStartedException
 import org.machikoro.server.exception.NotHostException
+import org.machikoro.server.service.AccusationService
 import org.machikoro.server.service.DiceService
 import org.machikoro.server.service.GameEndBroadcaster
 import org.machikoro.server.service.GamePhaseService
@@ -45,6 +49,7 @@ class GameController(
     private val gameStateGuard: GameStateGuard,
     private val gameSyncService: GameSyncService,
     private val gameEndBroadcaster: GameEndBroadcaster,
+    private val accusationService: AccusationService,
 ) {
     private val logger = LoggerFactory.getLogger(GameController::class.java)
 
@@ -349,6 +354,71 @@ class GameController(
                 error = WebSocketErrorDto.internal(mapOf("event" to "ROLL_FAILED")),
             )
         }
+    }
+
+    /**
+     * Records that the active player used the Insider Trading cheat this game
+     * (issue #361). Silent — no broadcast; only the server learns, so other
+     * players must still guess. Sent to /app/game.reportCheat.
+     */
+    @MessageMapping("/game.reportCheat")
+    @AsyncListener(operation = AsyncOperation(
+        channelName = "/game.reportCheat",
+        description = "Silent self-report that the active player used the Insider Trading cheat.",
+        payloadType = ReportCheatRequest::class,
+    ))
+    fun reportCheat(@Payload request: ReportCheatRequest, headerAccessor: SimpMessageHeaderAccessor) {
+        accusationService.reportCheat(request.gameId, headerAccessor.requireUserPrincipal())
+    }
+
+    /**
+     * One player accuses another of cheating (issue #361). The server adjudicates
+     * (caught vs. wrong), penalizes, and broadcasts the outcome plus a fresh state
+     * snapshot so everyone sees the new coin totals. Invalid accusations throw and
+     * are delivered privately to the accuser via the global exception handler.
+     * Sent to /app/game.accuse.
+     */
+    @MessageMapping("/game.accuse")
+    @AsyncListener(operation = AsyncOperation(
+        channelName = "/game.accuse",
+        description = "Accuse another player of cheating. The caught cheater or wrong accuser is penalized; the result is broadcast to the game topic.",
+        payloadType = AccuseRequest::class,
+    ))
+    fun accuse(@Payload request: AccuseRequest, headerAccessor: SimpMessageHeaderAccessor) {
+        val outcome = accusationService.accuse(
+            gameId = request.gameId,
+            accuser = headerAccessor.requireUserPrincipal(),
+            accusedPlayerId = request.accusedPlayerId,
+        )
+        logger.info(
+            "Accusation in game {} by player {} against {} -> {}",
+            request.gameId, outcome.accuserPlayerId, outcome.accusedPlayerId, outcome.outcome,
+        )
+        broadcastAccusationResult(request.gameId, outcome)
+    }
+
+    /**
+     * Broadcasts an ACCUSATION_RESULT to the game topic with the outcome, the
+     * involved player IDs (PlayerModel.id), and a fresh state snapshot so coin
+     * totals update for everyone.
+     */
+    private fun broadcastAccusationResult(gameId: Int, outcome: AccusationOutcome) {
+        val state = gameSyncService.buildSnapshot(gameId)
+        messagingTemplate.convertAndSend(
+            "/topic/game/$gameId",
+            WebSocketMessage(
+                type = MessageType.ACCUSATION_RESULT,
+                sender = "server",
+                payload = linkedMapOf<String, Any?>(
+                    "outcome" to outcome.outcome.name,
+                    "accuserPlayerId" to outcome.accuserPlayerId,
+                    "accusedPlayerId" to outcome.accusedPlayerId,
+                    "penalizedPlayerId" to outcome.penalizedPlayerId,
+                    "state" to state,
+                ),
+                gameId = gameId,
+            ),
+        )
     }
 
     /**

--- a/src/main/kotlin/org/machikoro/server/dao/CheatFlagDao.kt
+++ b/src/main/kotlin/org/machikoro/server/dao/CheatFlagDao.kt
@@ -1,0 +1,42 @@
+package org.machikoro.server.dao
+
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.insertIgnore
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.machikoro.server.database.CheatFlags
+import org.springframework.stereotype.Repository
+
+/**
+ * Persists which players have an outstanding (uncaught) Insider Trading cheat
+ * (issue #361). A row present means "this player cheated and has not been caught
+ * yet". Durable in Postgres so a cheat reported before a restart stays catchable.
+ */
+@Repository
+class CheatFlagDao {
+
+    /**
+     * Marks [playerId] as having an outstanding cheat. Idempotent — reporting the
+     * cheat twice keeps a single row, so a player who cheats repeatedly without
+     * being caught is still "caught at most once" per consume.
+     */
+    fun setOutstanding(playerId: Int): Unit = transaction {
+        CheatFlags.insertIgnore { it[CheatFlags.playerId] = playerId }
+    }
+
+    /**
+     * Atomically consumes [playerId]'s outstanding cheat. Returns the number of
+     * rows removed (1 if there was an outstanding cheat, 0 otherwise). The count
+     * makes adjudication race-safe: only the accusation whose delete affected a
+     * row counts as a catch, so two accusers cannot double-penalize one cheater.
+     */
+    fun consume(playerId: Int): Int = transaction {
+        CheatFlags.deleteWhere { CheatFlags.playerId eq playerId }
+    }
+
+    /** Test/diagnostic helper: whether [playerId] currently has an outstanding cheat. */
+    fun hasOutstanding(playerId: Int): Boolean = transaction {
+        CheatFlags.selectAll().where { CheatFlags.playerId eq playerId }.count() > 0
+    }
+}

--- a/src/main/kotlin/org/machikoro/server/database/Tables.kt
+++ b/src/main/kotlin/org/machikoro/server/database/Tables.kt
@@ -158,3 +158,14 @@ object GameMarketplace : Table("game_marketplace") {
 
     override val primaryKey = PrimaryKey(gameId, cardId)
 }
+
+/**
+ * Outstanding (uncaught) Insider Trading cheats per player (issue #361).
+ * A row present = that player cheated and has not been caught yet.
+ * Removing a player removes their flag automatically.
+ */
+object CheatFlags : Table("cheat_flags") {
+    val playerId = reference("player_id", Players, onDelete = ReferenceOption.CASCADE)
+
+    override val primaryKey = PrimaryKey(playerId)
+}

--- a/src/main/kotlin/org/machikoro/server/dto/AccusationOutcome.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/AccusationOutcome.kt
@@ -1,22 +1,20 @@
 package org.machikoro.server.dto
 
-/** Result of adjudicating a cheating accusation (issue #361). */
-enum class AccusationOutcomeType {
-    /** The accused had an outstanding cheat — the cheater is penalized. */
-    CAUGHT,
-
-    /** The accused had no outstanding cheat — the accuser loses their bet. */
-    WRONG,
-}
-
 /**
  * Outcome of an accusation, returned by `AccusationService.accuse` and used to
- * build the broadcast `ACCUSATION_RESULT` payload. All IDs are `PlayerModel.id`
- * (player IDs), not user IDs.
+ * build the broadcast `ACCUSATION_RESULT` payload. The field names form the
+ * client/server wire contract agreed in issue #361 / Client#280 — keep them in
+ * lockstep with the client parser. All IDs are `PlayerModel.id` (player IDs),
+ * not user IDs.
+ *
+ * [penaltyCoins] is the number of coins actually deducted from
+ * [penalizedPlayerId] — it may be less than the nominal penalty when the
+ * balance is clamped at 0.
  */
 data class AccusationOutcome(
-    val outcome: AccusationOutcomeType,
     val accuserPlayerId: Int,
     val accusedPlayerId: Int,
+    val caught: Boolean,
     val penalizedPlayerId: Int,
+    val penaltyCoins: Int,
 )

--- a/src/main/kotlin/org/machikoro/server/dto/AccusationOutcome.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/AccusationOutcome.kt
@@ -1,0 +1,22 @@
+package org.machikoro.server.dto
+
+/** Result of adjudicating a cheating accusation (issue #361). */
+enum class AccusationOutcomeType {
+    /** The accused had an outstanding cheat — the cheater is penalized. */
+    CAUGHT,
+
+    /** The accused had no outstanding cheat — the accuser loses their bet. */
+    WRONG,
+}
+
+/**
+ * Outcome of an accusation, returned by `AccusationService.accuse` and used to
+ * build the broadcast `ACCUSATION_RESULT` payload. All IDs are `PlayerModel.id`
+ * (player IDs), not user IDs.
+ */
+data class AccusationOutcome(
+    val outcome: AccusationOutcomeType,
+    val accuserPlayerId: Int,
+    val accusedPlayerId: Int,
+    val penalizedPlayerId: Int,
+)

--- a/src/main/kotlin/org/machikoro/server/dto/AccuseRequest.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/AccuseRequest.kt
@@ -1,0 +1,11 @@
+package org.machikoro.server.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Accuse another player of cheating — sent to /app/game.accuse")
+data class AccuseRequest(
+    @Schema(description = "ID of the game", example = "1")
+    val gameId: Int,
+    @Schema(description = "PlayerModel.id of the accused player", example = "2")
+    val accusedPlayerId: Int,
+)

--- a/src/main/kotlin/org/machikoro/server/dto/ChatMessage.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/ChatMessage.kt
@@ -19,6 +19,7 @@ enum class MessageType {
     LOBBY_LEFT,
     ERROR,
     ROLL_DICE,
+    ACCUSATION_RESULT,
 }
 
 @Schema(description = "Message broadcast to all clients via WebSocket")

--- a/src/main/kotlin/org/machikoro/server/dto/ReportCheatRequest.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/ReportCheatRequest.kt
@@ -1,0 +1,9 @@
+package org.machikoro.server.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Silent self-report that the active player used the Insider Trading cheat — sent to /app/game.reportCheat")
+data class ReportCheatRequest(
+    @Schema(description = "ID of the game the cheat was used in", example = "1")
+    val gameId: Int,
+)

--- a/src/main/kotlin/org/machikoro/server/service/AccusationService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/AccusationService.kt
@@ -1,0 +1,105 @@
+package org.machikoro.server.service
+
+import org.machikoro.server.auth.UserPrincipal
+import org.machikoro.server.dao.CheatFlagDao
+import org.machikoro.server.dao.PlayerDao
+import org.machikoro.server.dto.AccusationOutcome
+import org.machikoro.server.dto.AccusationOutcomeType
+import org.machikoro.server.exception.CustomWebSocketException
+import org.springframework.stereotype.Service
+
+/**
+ * Adjudicates the cheating-accusation mechanic (issue #361). The server is the
+ * sole authority: it silently records cheat usage (self-reported by the active
+ * player's client) and, when another player accuses, decides caught vs. wrong
+ * and applies the coin penalty.
+ *
+ * No explicit rate limit: a wrong accusation costs the accuser a coin, so spam
+ * accusing is self-punishing.
+ */
+@Service
+class AccusationService(
+    private val gameStateGuard: GameStateGuard,
+    private val playerDao: PlayerDao,
+    private val cheatFlagDao: CheatFlagDao,
+    private val gameTransactionRunner: GameTransactionRunner,
+) {
+
+    /**
+     * Records that the active player used the Insider Trading cheat this game.
+     * Only the active player on their own turn may report — enforced via
+     * [GameStateGuard.ensureSenderIsActivePlayer] so a client can only ever
+     * incriminate itself (no framing). Silent: no broadcast.
+     */
+    fun reportCheat(gameId: Int, reporter: UserPrincipal) {
+        val active = gameStateGuard.ensureSenderIsActivePlayer(gameId, reporter)
+        cheatFlagDao.setOutstanding(active.id)
+    }
+
+    /**
+     * [accuser] accuses player [accusedPlayerId] of cheating. Caught (accused had
+     * an outstanding cheat) → cheater loses [CHEATER_PENALTY]; wrong → accuser
+     * loses [WRONG_ACCUSER_PENALTY]. Coins are clamped at 0 (the economy never
+     * goes negative). Runs in a single transaction so the flag-consume and coin
+     * change are atomic; the consume's affected-row count makes concurrent
+     * accusations against the same cheater race-safe.
+     *
+     * @throws CustomWebSocketException `INVALID_ACCUSATION` for self-accusation or
+     *   a non-member accuser/accused; `GAME_FINISHED` / `GAME_NOT_STARTED` when
+     *   the game is not in progress.
+     */
+    fun accuse(gameId: Int, accuser: UserPrincipal, accusedPlayerId: Int): AccusationOutcome =
+        gameTransactionRunner.inTransaction {
+            gameStateGuard.ensureGameIsRunning(gameId)
+
+            val accuserPlayer = playerDao.findByGameIdAndUserId(gameId, accuser.userId)
+                ?: throw CustomWebSocketException(
+                    INVALID_ACCUSATION,
+                    "You are not a player in game $gameId",
+                )
+
+            val accused = playerDao.findById(accusedPlayerId)
+            if (accused == null || accused.gameId != gameId) {
+                throw CustomWebSocketException(
+                    INVALID_ACCUSATION,
+                    "Player $accusedPlayerId is not in game $gameId",
+                )
+            }
+            if (accused.id == accuserPlayer.id) {
+                throw CustomWebSocketException(
+                    INVALID_ACCUSATION,
+                    "You cannot accuse yourself",
+                )
+            }
+
+            val caught = cheatFlagDao.consume(accused.id) > 0
+            if (caught) {
+                playerDao.updateCoins(accused.id, maxOf(0, accused.coins - CHEATER_PENALTY))
+                AccusationOutcome(
+                    outcome = AccusationOutcomeType.CAUGHT,
+                    accuserPlayerId = accuserPlayer.id,
+                    accusedPlayerId = accused.id,
+                    penalizedPlayerId = accused.id,
+                )
+            } else {
+                playerDao.updateCoins(accuserPlayer.id, maxOf(0, accuserPlayer.coins - WRONG_ACCUSER_PENALTY))
+                AccusationOutcome(
+                    outcome = AccusationOutcomeType.WRONG,
+                    accuserPlayerId = accuserPlayer.id,
+                    accusedPlayerId = accused.id,
+                    penalizedPlayerId = accuserPlayer.id,
+                )
+            }
+        }
+
+    companion object {
+        /** Stable error code returned for a rejected accusation. */
+        private const val INVALID_ACCUSATION = "INVALID_ACCUSATION"
+
+        /** Coins a caught cheater loses. */
+        const val CHEATER_PENALTY = 2
+
+        /** Coins a wrong accuser loses (the lost bet). */
+        const val WRONG_ACCUSER_PENALTY = 1
+    }
+}

--- a/src/main/kotlin/org/machikoro/server/service/AccusationService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/AccusationService.kt
@@ -4,9 +4,9 @@ import org.machikoro.server.auth.UserPrincipal
 import org.machikoro.server.dao.CheatFlagDao
 import org.machikoro.server.dao.PlayerDao
 import org.machikoro.server.dto.AccusationOutcome
-import org.machikoro.server.dto.AccusationOutcomeType
 import org.machikoro.server.exception.CustomWebSocketException
 import org.springframework.stereotype.Service
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Adjudicates the cheating-accusation mechanic (issue #361). The server is the
@@ -14,8 +14,9 @@ import org.springframework.stereotype.Service
  * player's client) and, when another player accuses, decides caught vs. wrong
  * and applies the coin penalty.
  *
- * No explicit rate limit: a wrong accusation costs the accuser a coin, so spam
- * accusing is self-punishing.
+ * Each accuser may accuse at most once per turn (anti-spam guardrail from
+ * issue #361); further attempts in the same turn are rejected with
+ * `INVALID_ACCUSATION`.
  */
 @Service
 class AccusationService(
@@ -24,6 +25,23 @@ class AccusationService(
     private val cheatFlagDao: CheatFlagDao,
     private val gameTransactionRunner: GameTransactionRunner,
 ) {
+
+    /**
+     * Last turn — (roundNumber, currentTurnIndex) — in which each accuser
+     * (keyed by PlayerModel.id) made a *successful* accusation. Kept in memory
+     * on purpose (issue #361 sanctions this): losing it on restart merely
+     * re-opens at most one extra accusation for the in-flight turn. Entries are
+     * a few bytes per player that ever accused, so no cleanup is needed.
+     *
+     * Only read inside the accuse transaction and only written after it
+     * commits: the Exposed runner retries the whole lambda on transient
+     * SQLExceptions and rolls it back on failure, so an in-transaction write
+     * would burn the turn's slot on a rollback and reject its own retry.
+     */
+    private val lastAccusationTurn = ConcurrentHashMap<Int, Pair<Int, Int>>()
+
+    /** Accuser userIds with an accuse call in flight — closes the double-submit race. */
+    private val inFlightAccusers = ConcurrentHashMap.newKeySet<Int>()
 
     /**
      * Records that the active player used the Insider Trading cheat this game.
@@ -40,57 +58,91 @@ class AccusationService(
      * [accuser] accuses player [accusedPlayerId] of cheating. Caught (accused had
      * an outstanding cheat) → cheater loses [CHEATER_PENALTY]; wrong → accuser
      * loses [WRONG_ACCUSER_PENALTY]. Coins are clamped at 0 (the economy never
-     * goes negative). Runs in a single transaction so the flag-consume and coin
-     * change are atomic; the consume's affected-row count makes concurrent
-     * accusations against the same cheater race-safe.
+     * goes negative) and the outcome reports the coins actually deducted. Runs in
+     * a single transaction so the flag-consume and coin change are atomic; the
+     * consume's affected-row count makes concurrent accusations against the same
+     * cheater race-safe.
      *
-     * @throws CustomWebSocketException `INVALID_ACCUSATION` for self-accusation or
-     *   a non-member accuser/accused; `GAME_FINISHED` / `GAME_NOT_STARTED` when
-     *   the game is not in progress.
+     * @throws CustomWebSocketException `INVALID_ACCUSATION` for self-accusation,
+     *   a non-member accuser/accused, or a second accusation by the same accuser
+     *   in the same turn; `GAME_FINISHED` / `GAME_NOT_STARTED` when the game is
+     *   not in progress.
      */
-    fun accuse(gameId: Int, accuser: UserPrincipal, accusedPlayerId: Int): AccusationOutcome =
-        gameTransactionRunner.inTransaction {
-            gameStateGuard.ensureGameIsRunning(gameId)
-
-            val accuserPlayer = playerDao.findByGameIdAndUserId(gameId, accuser.userId)
-                ?: throw CustomWebSocketException(
-                    INVALID_ACCUSATION,
-                    "You are not a player in game $gameId",
-                )
-
-            val accused = playerDao.findById(accusedPlayerId)
-            if (accused == null || accused.gameId != gameId) {
-                throw CustomWebSocketException(
-                    INVALID_ACCUSATION,
-                    "Player $accusedPlayerId is not in game $gameId",
-                )
-            }
-            if (accused.id == accuserPlayer.id) {
-                throw CustomWebSocketException(
-                    INVALID_ACCUSATION,
-                    "You cannot accuse yourself",
-                )
-            }
-
-            val caught = cheatFlagDao.consume(accused.id) > 0
-            if (caught) {
-                playerDao.updateCoins(accused.id, maxOf(0, accused.coins - CHEATER_PENALTY))
-                AccusationOutcome(
-                    outcome = AccusationOutcomeType.CAUGHT,
-                    accuserPlayerId = accuserPlayer.id,
-                    accusedPlayerId = accused.id,
-                    penalizedPlayerId = accused.id,
-                )
-            } else {
-                playerDao.updateCoins(accuserPlayer.id, maxOf(0, accuserPlayer.coins - WRONG_ACCUSER_PENALTY))
-                AccusationOutcome(
-                    outcome = AccusationOutcomeType.WRONG,
-                    accuserPlayerId = accuserPlayer.id,
-                    accusedPlayerId = accused.id,
-                    penalizedPlayerId = accuserPlayer.id,
-                )
-            }
+    fun accuse(gameId: Int, accuser: UserPrincipal, accusedPlayerId: Int): AccusationOutcome {
+        if (!inFlightAccusers.add(accuser.userId)) {
+            throw CustomWebSocketException(
+                INVALID_ACCUSATION,
+                "Your previous accusation is still being processed",
+            )
         }
+        try {
+            var claim: Pair<Int, Pair<Int, Int>>? = null
+            val outcome = gameTransactionRunner.inTransaction {
+                val game = gameStateGuard.ensureGameIsRunning(gameId)
+
+                val accuserPlayer = playerDao.findByGameIdAndUserId(gameId, accuser.userId)
+                    ?: throw CustomWebSocketException(
+                        INVALID_ACCUSATION,
+                        "You are not a player in game $gameId",
+                    )
+
+                val accused = playerDao.findById(accusedPlayerId)
+                if (accused == null || accused.gameId != gameId) {
+                    throw CustomWebSocketException(
+                        INVALID_ACCUSATION,
+                        "Player $accusedPlayerId is not in game $gameId",
+                    )
+                }
+                if (accused.id == accuserPlayer.id) {
+                    throw CustomWebSocketException(
+                        INVALID_ACCUSATION,
+                        "You cannot accuse yourself",
+                    )
+                }
+
+                // One accusation per accuser per turn (issue #361 anti-spam
+                // guardrail). Read-only here — the slot is claimed only after
+                // the transaction commits, so a rollback (or an Exposed retry
+                // of this lambda) never burns the turn's slot. The in-flight
+                // guard above keeps concurrent same-accuser calls out.
+                val turnKey = game.roundNumber to game.currentTurnIndex
+                if (lastAccusationTurn[accuserPlayer.id] == turnKey) {
+                    throw CustomWebSocketException(
+                        INVALID_ACCUSATION,
+                        "You can only accuse once per turn",
+                    )
+                }
+                claim = accuserPlayer.id to turnKey
+
+                val caught = cheatFlagDao.consume(accused.id) > 0
+                if (caught) {
+                    val newCoins = maxOf(0, accused.coins - CHEATER_PENALTY)
+                    playerDao.updateCoins(accused.id, newCoins)
+                    AccusationOutcome(
+                        accuserPlayerId = accuserPlayer.id,
+                        accusedPlayerId = accused.id,
+                        caught = true,
+                        penalizedPlayerId = accused.id,
+                        penaltyCoins = accused.coins - newCoins,
+                    )
+                } else {
+                    val newCoins = maxOf(0, accuserPlayer.coins - WRONG_ACCUSER_PENALTY)
+                    playerDao.updateCoins(accuserPlayer.id, newCoins)
+                    AccusationOutcome(
+                        accuserPlayerId = accuserPlayer.id,
+                        accusedPlayerId = accused.id,
+                        caught = false,
+                        penalizedPlayerId = accuserPlayer.id,
+                        penaltyCoins = accuserPlayer.coins - newCoins,
+                    )
+                }
+            }
+            claim?.let { (playerId, turnKey) -> lastAccusationTurn[playerId] = turnKey }
+            return outcome
+        } finally {
+            inFlightAccusers.remove(accuser.userId)
+        }
+    }
 
     companion object {
         /** Stable error code returned for a rejected accusation. */

--- a/src/main/resources/db/migration/V3__add_cheat_flags.sql
+++ b/src/main/resources/db/migration/V3__add_cheat_flags.sql
@@ -1,0 +1,8 @@
+-- Tracks an outstanding (uncaught) Insider Trading cheat per player (issue #361).
+-- Row present = that player has cheated and has not yet been caught.
+-- Reporting is idempotent (one row per player); a successful accusation deletes the row.
+-- ON DELETE CASCADE so flags are removed automatically when a player/game is deleted.
+CREATE TABLE cheat_flags
+(
+    player_id INT NOT NULL PRIMARY KEY REFERENCES players (id) ON DELETE CASCADE
+);

--- a/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
@@ -12,7 +12,6 @@ import org.machikoro.server.dto.EndTurnOutcome
 import org.machikoro.server.domain.models.GameModel
 import org.machikoro.server.domain.models.PlayerModel
 import org.machikoro.server.dto.AccusationOutcome
-import org.machikoro.server.dto.AccusationOutcomeType
 import org.machikoro.server.dto.AccuseRequest
 import org.machikoro.server.dto.AdvancePhaseRequest
 import org.machikoro.server.dto.EndTurnRequest
@@ -127,14 +126,15 @@ class GameControllerTest {
     }
 
     @Test
-    fun `accuse broadcasts ACCUSATION_RESULT with outcome and state`() {
+    fun `accuse broadcasts ACCUSATION_RESULT with the contract payload and state`() {
         val gameId = 1
         whenever(accusationService.accuse(gameId, alice, 2)).thenReturn(
             AccusationOutcome(
-                outcome = AccusationOutcomeType.CAUGHT,
                 accuserPlayerId = 1,
                 accusedPlayerId = 2,
+                caught = true,
                 penalizedPlayerId = 2,
+                penaltyCoins = 2,
             )
         )
         whenever(gameSyncService.buildSnapshot(gameId)).thenReturn(gameStateDto(gameId))
@@ -148,10 +148,13 @@ class GameControllerTest {
         assertEquals(gameId, message.gameId)
         @Suppress("UNCHECKED_CAST")
         val payload = message.payload as Map<String, Any?>
-        assertEquals("CAUGHT", payload["outcome"])
+        // Contract keys agreed in issue #361 / Client#280 — keep in lockstep
+        // with the client parser.
         assertEquals(1, payload["accuserPlayerId"])
         assertEquals(2, payload["accusedPlayerId"])
+        assertEquals(true, payload["caught"])
         assertEquals(2, payload["penalizedPlayerId"])
+        assertEquals(2, payload["penaltyCoins"])
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
@@ -11,6 +11,9 @@ import org.machikoro.server.domain.enums.TurnPhase
 import org.machikoro.server.dto.EndTurnOutcome
 import org.machikoro.server.domain.models.GameModel
 import org.machikoro.server.domain.models.PlayerModel
+import org.machikoro.server.dto.AccusationOutcome
+import org.machikoro.server.dto.AccusationOutcomeType
+import org.machikoro.server.dto.AccuseRequest
 import org.machikoro.server.dto.AdvancePhaseRequest
 import org.machikoro.server.dto.EndTurnRequest
 import org.machikoro.server.dto.EnterGameScreenRequest
@@ -18,6 +21,7 @@ import org.machikoro.server.dto.GameStateDto
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.PurchaseRequest
 import org.machikoro.server.dto.PurchaseType
+import org.machikoro.server.dto.ReportCheatRequest
 import org.machikoro.server.dto.RollDiceRequest
 import org.machikoro.server.dto.RollDiceResponse
 import org.machikoro.server.dto.StartGameRequest
@@ -27,6 +31,7 @@ import org.machikoro.server.exception.CustomWebSocketException
 import org.machikoro.server.exception.GameFinishedException
 import org.machikoro.server.exception.GameStartedException
 import org.machikoro.server.exception.NotHostException
+import org.machikoro.server.service.AccusationService
 import org.machikoro.server.service.DiceService
 import org.machikoro.server.service.GameEndBroadcaster
 import org.machikoro.server.service.GamePhaseService
@@ -43,6 +48,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.messaging.simp.SimpMessagingTemplate
@@ -58,10 +64,12 @@ class GameControllerTest {
     private val gameStateGuard = mock<GameStateGuard>()
     private val gameSyncService = mock<GameSyncService>()
     private val gameEndBroadcaster = mock<GameEndBroadcaster>()
+    private val accusationService = mock<AccusationService>()
     private val controller = GameController(
         gamePhaseService, messagingTemplate,
         purchaseService, diceService, lobbyService, connectionTracker,
         gameStateGuard, gameSyncService, gameEndBroadcaster,
+        accusationService,
     )
 
     private val alice = UserPrincipal(userId = 1, username = "alice")
@@ -98,6 +106,73 @@ class GameControllerTest {
         accessor.sessionId = sessionId
         accessor.sessionAttributes = mutableMapOf()
         return accessor
+    }
+
+    // ── reportCheat / accuse (#361) ─────────────────────────────────────────────
+
+    @Test
+    fun `reportCheat delegates to AccusationService and does not broadcast`() {
+        controller.reportCheat(ReportCheatRequest(1), authedAccessor())
+
+        verify(accusationService).reportCheat(1, alice)
+        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
+    }
+
+    @Test
+    fun `reportCheat throws UNAUTHENTICATED without a principal`() {
+        val ex = assertThrows<CustomWebSocketException> {
+            controller.reportCheat(ReportCheatRequest(1), SimpMessageHeaderAccessor.create())
+        }
+        assertEquals("UNAUTHENTICATED", ex.errorCode)
+        verifyNoInteractions(accusationService)
+    }
+
+    @Test
+    fun `accuse broadcasts ACCUSATION_RESULT with outcome and state`() {
+        val gameId = 1
+        whenever(accusationService.accuse(gameId, alice, 2)).thenReturn(
+            AccusationOutcome(
+                outcome = AccusationOutcomeType.CAUGHT,
+                accuserPlayerId = 1,
+                accusedPlayerId = 2,
+                penalizedPlayerId = 2,
+            )
+        )
+        whenever(gameSyncService.buildSnapshot(gameId)).thenReturn(gameStateDto(gameId))
+
+        controller.accuse(AccuseRequest(gameId, 2), authedAccessor())
+
+        val captor = argumentCaptor<WebSocketMessage>()
+        verify(messagingTemplate).convertAndSend(eq("/topic/game/$gameId"), captor.capture())
+        val message = captor.firstValue
+        assertEquals(MessageType.ACCUSATION_RESULT, message.type)
+        assertEquals(gameId, message.gameId)
+        @Suppress("UNCHECKED_CAST")
+        val payload = message.payload as Map<String, Any?>
+        assertEquals("CAUGHT", payload["outcome"])
+        assertEquals(1, payload["accuserPlayerId"])
+        assertEquals(2, payload["accusedPlayerId"])
+        assertEquals(2, payload["penalizedPlayerId"])
+    }
+
+    @Test
+    fun `accuse propagates rejection and does not broadcast`() {
+        whenever(accusationService.accuse(any(), any(), any()))
+            .thenThrow(CustomWebSocketException("INVALID_ACCUSATION", "You cannot accuse yourself"))
+
+        val ex = assertThrows<CustomWebSocketException> {
+            controller.accuse(AccuseRequest(1, 1), authedAccessor())
+        }
+        assertEquals("INVALID_ACCUSATION", ex.errorCode)
+        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
+    }
+
+    @Test
+    fun `accuse throws UNAUTHENTICATED without a principal`() {
+        assertThrows<CustomWebSocketException> {
+            controller.accuse(AccuseRequest(1, 2), SimpMessageHeaderAccessor.create())
+        }
+        verifyNoInteractions(accusationService)
     }
 
     // ── startGame ─────────────────────────────────────────────────────────────

--- a/src/test/kotlin/org/machikoro/server/controller/GameWebSocketBroadcastIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/GameWebSocketBroadcastIntegrationTest.kt
@@ -21,6 +21,7 @@ import org.machikoro.server.dto.PurchaseType
 import org.machikoro.server.dto.RollDiceResponse
 import org.machikoro.server.dto.WebSocketMessage
 import org.machikoro.server.exception.CustomWebSocketException
+import org.machikoro.server.service.AccusationService
 import org.machikoro.server.service.DiceService
 import org.machikoro.server.service.GamePhaseService
 import org.machikoro.server.service.GameStateGuard
@@ -103,6 +104,11 @@ class GameWebSocketBroadcastIntegrationTest {
 
     @MockitoBean
     private lateinit var earningsService: EarningsService
+
+    // GameController now depends on AccusationService (#361); mock it so the
+    // DataSource-excluded context still loads.
+    @MockitoBean
+    private lateinit var accusationService: AccusationService
 
     @AfterEach
     fun disconnectSessions() {

--- a/src/test/kotlin/org/machikoro/server/dao/CheatFlagDaoTest.kt
+++ b/src/test/kotlin/org/machikoro/server/dao/CheatFlagDaoTest.kt
@@ -1,0 +1,76 @@
+package org.machikoro.server.dao
+
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.deleteAll
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.insertAndGetId
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.machikoro.server.database.AbstractDBSetup
+import org.machikoro.server.database.CheatFlags
+import org.machikoro.server.database.Games
+import org.machikoro.server.database.Players
+import org.machikoro.server.database.Users
+import org.springframework.beans.factory.annotation.Autowired
+import kotlin.test.Test
+
+class CheatFlagDaoTest : AbstractDBSetup() {
+
+    @Autowired
+    private lateinit var cheatFlagDao: CheatFlagDao
+
+    private var playerId = 0
+
+    @BeforeEach
+    fun setupData() {
+        transaction {
+            CheatFlags.deleteAll()
+            Players.deleteAll()
+            Games.deleteAll()
+            Users.deleteAll()
+
+            val userId = Users.insertAndGetId { it[username] = "cheater" }.value
+            val gameId = Games.insertAndGetId {
+                it[hostUserId] = userId
+                it[lobbyCode] = "ABC1234"
+            }.value
+            playerId = Players.insertAndGetId {
+                it[Players.gameId] = gameId
+                it[Players.userId] = userId
+                it[turnOrder] = 0
+            }.value
+        }
+    }
+
+    @Test
+    fun `setOutstanding then hasOutstanding is true`() {
+        cheatFlagDao.setOutstanding(playerId)
+        assertTrue(cheatFlagDao.hasOutstanding(playerId))
+    }
+
+    @Test
+    fun `setOutstanding is idempotent and consume removes the single row`() {
+        cheatFlagDao.setOutstanding(playerId)
+        cheatFlagDao.setOutstanding(playerId)
+
+        assertEquals(1, cheatFlagDao.consume(playerId))
+        assertFalse(cheatFlagDao.hasOutstanding(playerId))
+    }
+
+    @Test
+    fun `consume returns 0 when there is no outstanding cheat`() {
+        assertEquals(0, cheatFlagDao.consume(playerId))
+    }
+
+    @Test
+    fun `flag is removed via cascade when the player is deleted`() {
+        cheatFlagDao.setOutstanding(playerId)
+
+        transaction { Players.deleteWhere { Players.id eq playerId } }
+
+        assertFalse(cheatFlagDao.hasOutstanding(playerId))
+    }
+}

--- a/src/test/kotlin/org/machikoro/server/dto/ChatMessageTests.kt
+++ b/src/test/kotlin/org/machikoro/server/dto/ChatMessageTests.kt
@@ -24,7 +24,8 @@ class ChatMessageTests {
             "GAME_END",
             "LOBBY_LEFT",
             "ERROR",
-            "ROLL_DICE"
+            "ROLL_DICE",
+            "ACCUSATION_RESULT"
         )
         val actual = MessageType.entries.map { it.name }.toSet()
 

--- a/src/test/kotlin/org/machikoro/server/service/AccusationServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/AccusationServiceTest.kt
@@ -1,0 +1,175 @@
+package org.machikoro.server.service
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.machikoro.server.auth.UserPrincipal
+import org.machikoro.server.dao.CheatFlagDao
+import org.machikoro.server.dao.PlayerDao
+import org.machikoro.server.domain.models.PlayerModel
+import org.machikoro.server.dto.AccusationOutcomeType
+import org.machikoro.server.exception.CustomWebSocketException
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class AccusationServiceTest {
+
+    private val gameStateGuard = mock<GameStateGuard>()
+    private val playerDao = mock<PlayerDao>()
+    private val cheatFlagDao = mock<CheatFlagDao>()
+
+    // Fake runner that simply executes the lambda (the real one wraps it in an
+    // Exposed transaction). This keeps the service unit-testable without a DB.
+    private val transactionRunner = object : GameTransactionRunner {
+        override fun <T> inTransaction(action: () -> T): T = action()
+    }
+
+    private val service = AccusationService(gameStateGuard, playerDao, cheatFlagDao, transactionRunner)
+
+    private val accuser = UserPrincipal(userId = 1, username = "alice")
+
+    private fun player(id: Int, userId: Int, coins: Int, gameId: Int = GAME) =
+        PlayerModel(id = id, gameId = gameId, userId = userId, turnOrder = 0, coins = coins, lastSeenAt = null)
+
+    // ── reportCheat ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `reportCheat flags the active player`() {
+        whenever(gameStateGuard.ensureSenderIsActivePlayer(GAME, accuser)).thenReturn(player(10, 1, 3))
+
+        service.reportCheat(GAME, accuser)
+
+        verify(cheatFlagDao).setOutstanding(10)
+    }
+
+    @Test
+    fun `reportCheat propagates guard rejection and sets no flag`() {
+        whenever(gameStateGuard.ensureSenderIsActivePlayer(GAME, accuser))
+            .thenThrow(CustomWebSocketException("NOT_YOUR_TURN", "It is not your turn"))
+
+        assertThrows<CustomWebSocketException> { service.reportCheat(GAME, accuser) }
+        verify(cheatFlagDao, never()).setOutstanding(any())
+    }
+
+    // ── accuse: caught ────────────────────────────────────────────────────────
+
+    @Test
+    fun `accuse caught deducts 2 from cheater and consumes the flag`() {
+        whenever(playerDao.findByGameIdAndUserId(GAME, 1)).thenReturn(player(10, 1, 5))
+        whenever(playerDao.findById(20)).thenReturn(player(20, 2, 4))
+        whenever(cheatFlagDao.consume(20)).thenReturn(1)
+
+        val outcome = service.accuse(GAME, accuser, 20)
+
+        assertEquals(AccusationOutcomeType.CAUGHT, outcome.outcome)
+        assertEquals(20, outcome.penalizedPlayerId)
+        assertEquals(10, outcome.accuserPlayerId) // accuser's PlayerModel.id, not userId
+        verify(cheatFlagDao).consume(20)
+        verify(playerDao).updateCoins(20, 2) // 4 - 2
+        verify(playerDao, never()).updateCoins(eq(10), any())
+    }
+
+    @Test
+    fun `accuse caught clamps cheater coins at 0`() {
+        whenever(playerDao.findByGameIdAndUserId(GAME, 1)).thenReturn(player(10, 1, 5))
+        whenever(playerDao.findById(20)).thenReturn(player(20, 2, 1))
+        whenever(cheatFlagDao.consume(20)).thenReturn(1)
+
+        val outcome = service.accuse(GAME, accuser, 20)
+
+        assertEquals(AccusationOutcomeType.CAUGHT, outcome.outcome)
+        verify(playerDao).updateCoins(20, 0) // max(0, 1 - 2)
+    }
+
+    // ── accuse: wrong ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `accuse wrong deducts 1 from accuser and leaves the accused untouched`() {
+        whenever(playerDao.findByGameIdAndUserId(GAME, 1)).thenReturn(player(10, 1, 5))
+        whenever(playerDao.findById(20)).thenReturn(player(20, 2, 4))
+        whenever(cheatFlagDao.consume(20)).thenReturn(0)
+
+        val outcome = service.accuse(GAME, accuser, 20)
+
+        assertEquals(AccusationOutcomeType.WRONG, outcome.outcome)
+        assertEquals(10, outcome.penalizedPlayerId)
+        verify(playerDao).updateCoins(10, 4) // 5 - 1
+        verify(playerDao, never()).updateCoins(eq(20), any())
+    }
+
+    @Test
+    fun `accuse wrong clamps accuser coins at 0`() {
+        whenever(playerDao.findByGameIdAndUserId(GAME, 1)).thenReturn(player(10, 1, 0))
+        whenever(playerDao.findById(20)).thenReturn(player(20, 2, 3))
+        whenever(cheatFlagDao.consume(20)).thenReturn(0)
+
+        service.accuse(GAME, accuser, 20)
+
+        verify(playerDao).updateCoins(10, 0) // max(0, 0 - 1)
+    }
+
+    // ── accuse: validation ────────────────────────────────────────────────────
+
+    @Test
+    fun `accuse self is rejected with INVALID_ACCUSATION`() {
+        val me = player(10, 1, 5)
+        whenever(playerDao.findByGameIdAndUserId(GAME, 1)).thenReturn(me)
+        whenever(playerDao.findById(10)).thenReturn(me)
+
+        val ex = assertThrows<CustomWebSocketException> { service.accuse(GAME, accuser, 10) }
+
+        assertEquals("INVALID_ACCUSATION", ex.errorCode)
+        verify(cheatFlagDao, never()).consume(any())
+        verify(playerDao, never()).updateCoins(any(), any())
+    }
+
+    @Test
+    fun `accuse by a non-member is rejected`() {
+        whenever(playerDao.findByGameIdAndUserId(GAME, 1)).thenReturn(null)
+
+        val ex = assertThrows<CustomWebSocketException> { service.accuse(GAME, accuser, 20) }
+
+        assertEquals("INVALID_ACCUSATION", ex.errorCode)
+        verify(playerDao, never()).updateCoins(any(), any())
+    }
+
+    @Test
+    fun `accuse of a non-existent player is rejected`() {
+        whenever(playerDao.findByGameIdAndUserId(GAME, 1)).thenReturn(player(10, 1, 5))
+        whenever(playerDao.findById(20)).thenReturn(null)
+
+        val ex = assertThrows<CustomWebSocketException> { service.accuse(GAME, accuser, 20) }
+
+        assertEquals("INVALID_ACCUSATION", ex.errorCode)
+    }
+
+    @Test
+    fun `accuse of a player in another game is rejected`() {
+        whenever(playerDao.findByGameIdAndUserId(GAME, 1)).thenReturn(player(10, 1, 5))
+        whenever(playerDao.findById(20)).thenReturn(player(20, 2, 4, gameId = 999))
+
+        val ex = assertThrows<CustomWebSocketException> { service.accuse(GAME, accuser, 20) }
+
+        assertEquals("INVALID_ACCUSATION", ex.errorCode)
+        verify(cheatFlagDao, never()).consume(any())
+    }
+
+    @Test
+    fun `accuse rejects when the game is not running`() {
+        whenever(gameStateGuard.ensureGameIsRunning(GAME))
+            .thenThrow(CustomWebSocketException("GAME_FINISHED", "Game $GAME has already ended"))
+
+        val ex = assertThrows<CustomWebSocketException> { service.accuse(GAME, accuser, 20) }
+
+        assertEquals("GAME_FINISHED", ex.errorCode)
+        verify(playerDao, never()).updateCoins(any(), any())
+    }
+
+    private companion object {
+        const val GAME = 7
+    }
+}

--- a/src/test/kotlin/org/machikoro/server/service/AccusationServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/AccusationServiceTest.kt
@@ -1,18 +1,23 @@
 package org.machikoro.server.service
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.machikoro.server.auth.UserPrincipal
 import org.machikoro.server.dao.CheatFlagDao
 import org.machikoro.server.dao.PlayerDao
+import org.machikoro.server.domain.enums.GameStatus
+import org.machikoro.server.domain.enums.TurnPhase
+import org.machikoro.server.domain.models.GameModel
 import org.machikoro.server.domain.models.PlayerModel
-import org.machikoro.server.dto.AccusationOutcomeType
 import org.machikoro.server.exception.CustomWebSocketException
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -32,8 +37,28 @@ class AccusationServiceTest {
 
     private val accuser = UserPrincipal(userId = 1, username = "alice")
 
+    init {
+        // The service reads roundNumber/currentTurnIndex from the running game
+        // for the one-accusation-per-turn guardrail. Individual tests re-stub
+        // to advance the turn or to make the guard throw.
+        whenever(gameStateGuard.ensureGameIsRunning(GAME)).thenReturn(game())
+    }
+
     private fun player(id: Int, userId: Int, coins: Int, gameId: Int = GAME) =
         PlayerModel(id = id, gameId = gameId, userId = userId, turnOrder = 0, coins = coins, lastSeenAt = null)
+
+    private fun game(roundNumber: Int = 1, currentTurnIndex: Int = 0) = GameModel(
+        id = GAME,
+        status = GameStatus.IN_PROGRESS,
+        hostUserId = 1,
+        lobbyCode = "ABC1234",
+        maxPlayers = 4,
+        currentTurnIndex = currentTurnIndex,
+        turnPhase = TurnPhase.ROLL_DICE,
+        lastDiceRoll = null,
+        roundNumber = roundNumber,
+        hasPurchasedThisTurn = false,
+    )
 
     // ── reportCheat ───────────────────────────────────────────────────────────
 
@@ -65,23 +90,25 @@ class AccusationServiceTest {
 
         val outcome = service.accuse(GAME, accuser, 20)
 
-        assertEquals(AccusationOutcomeType.CAUGHT, outcome.outcome)
+        assertTrue(outcome.caught)
         assertEquals(20, outcome.penalizedPlayerId)
         assertEquals(10, outcome.accuserPlayerId) // accuser's PlayerModel.id, not userId
+        assertEquals(2, outcome.penaltyCoins)
         verify(cheatFlagDao).consume(20)
         verify(playerDao).updateCoins(20, 2) // 4 - 2
         verify(playerDao, never()).updateCoins(eq(10), any())
     }
 
     @Test
-    fun `accuse caught clamps cheater coins at 0`() {
+    fun `accuse caught clamps cheater coins at 0 and reports actual deduction`() {
         whenever(playerDao.findByGameIdAndUserId(GAME, 1)).thenReturn(player(10, 1, 5))
         whenever(playerDao.findById(20)).thenReturn(player(20, 2, 1))
         whenever(cheatFlagDao.consume(20)).thenReturn(1)
 
         val outcome = service.accuse(GAME, accuser, 20)
 
-        assertEquals(AccusationOutcomeType.CAUGHT, outcome.outcome)
+        assertTrue(outcome.caught)
+        assertEquals(1, outcome.penaltyCoins) // only 1 coin existed to take
         verify(playerDao).updateCoins(20, 0) // max(0, 1 - 2)
     }
 
@@ -95,21 +122,116 @@ class AccusationServiceTest {
 
         val outcome = service.accuse(GAME, accuser, 20)
 
-        assertEquals(AccusationOutcomeType.WRONG, outcome.outcome)
+        assertFalse(outcome.caught)
         assertEquals(10, outcome.penalizedPlayerId)
+        assertEquals(1, outcome.penaltyCoins)
         verify(playerDao).updateCoins(10, 4) // 5 - 1
         verify(playerDao, never()).updateCoins(eq(20), any())
     }
 
     @Test
-    fun `accuse wrong clamps accuser coins at 0`() {
+    fun `accuse wrong clamps accuser coins at 0 and reports zero deduction`() {
         whenever(playerDao.findByGameIdAndUserId(GAME, 1)).thenReturn(player(10, 1, 0))
         whenever(playerDao.findById(20)).thenReturn(player(20, 2, 3))
         whenever(cheatFlagDao.consume(20)).thenReturn(0)
 
+        val outcome = service.accuse(GAME, accuser, 20)
+
+        assertEquals(0, outcome.penaltyCoins) // nothing left to take
+        verify(playerDao).updateCoins(10, 0) // max(0, 0 - 1)
+    }
+
+    // ── accuse: one per accuser per turn ──────────────────────────────────────
+
+    @Test
+    fun `second accusation by the same accuser in the same turn is rejected`() {
+        whenever(playerDao.findByGameIdAndUserId(GAME, 1)).thenReturn(player(10, 1, 5))
+        whenever(playerDao.findById(20)).thenReturn(player(20, 2, 4))
+        whenever(cheatFlagDao.consume(20)).thenReturn(0)
+
+        service.accuse(GAME, accuser, 20)
+        val ex = assertThrows<CustomWebSocketException> { service.accuse(GAME, accuser, 20) }
+
+        assertEquals("INVALID_ACCUSATION", ex.errorCode)
+        // Only the first accusation adjudicated and penalized.
+        verify(cheatFlagDao, times(1)).consume(any())
+        verify(playerDao, times(1)).updateCoins(any(), any())
+    }
+
+    @Test
+    fun `accusation is allowed again when the turn advances`() {
+        whenever(playerDao.findByGameIdAndUserId(GAME, 1)).thenReturn(player(10, 1, 5))
+        whenever(playerDao.findById(20)).thenReturn(player(20, 2, 4))
+        whenever(cheatFlagDao.consume(20)).thenReturn(0)
+
+        service.accuse(GAME, accuser, 20)
+        whenever(gameStateGuard.ensureGameIsRunning(GAME)).thenReturn(game(currentTurnIndex = 1))
         service.accuse(GAME, accuser, 20)
 
-        verify(playerDao).updateCoins(10, 0) // max(0, 0 - 1)
+        verify(playerDao, times(2)).updateCoins(any(), any())
+    }
+
+    @Test
+    fun `accusation is allowed again in a new round`() {
+        whenever(playerDao.findByGameIdAndUserId(GAME, 1)).thenReturn(player(10, 1, 5))
+        whenever(playerDao.findById(20)).thenReturn(player(20, 2, 4))
+        whenever(cheatFlagDao.consume(20)).thenReturn(0)
+
+        service.accuse(GAME, accuser, 20)
+        whenever(gameStateGuard.ensureGameIsRunning(GAME)).thenReturn(game(roundNumber = 2))
+        service.accuse(GAME, accuser, 20)
+
+        verify(playerDao, times(2)).updateCoins(any(), any())
+    }
+
+    @Test
+    fun `different accusers may each accuse once in the same turn`() {
+        val otherAccuser = UserPrincipal(userId = 3, username = "carol")
+        whenever(playerDao.findByGameIdAndUserId(GAME, 1)).thenReturn(player(10, 1, 5))
+        whenever(playerDao.findByGameIdAndUserId(GAME, 3)).thenReturn(player(30, 3, 5))
+        whenever(playerDao.findById(20)).thenReturn(player(20, 2, 4))
+        whenever(cheatFlagDao.consume(20)).thenReturn(0)
+
+        service.accuse(GAME, accuser, 20)
+        service.accuse(GAME, otherAccuser, 20)
+
+        verify(playerDao).updateCoins(10, 4)
+        verify(playerDao).updateCoins(30, 4)
+    }
+
+    @Test
+    fun `failed adjudication does not consume the turn slot`() {
+        whenever(playerDao.findByGameIdAndUserId(GAME, 1)).thenReturn(player(10, 1, 5))
+        whenever(playerDao.findById(20)).thenReturn(player(20, 2, 4))
+        whenever(cheatFlagDao.consume(20)).thenReturn(0)
+        // First adjudication dies mid-transaction (e.g. transient DB failure);
+        // the rolled-back attempt must not burn the turn's single slot.
+        whenever(playerDao.updateCoins(10, 4))
+            .thenThrow(RuntimeException("transient DB failure"))
+            .then { }
+
+        assertThrows<RuntimeException> { service.accuse(GAME, accuser, 20) }
+        val outcome = service.accuse(GAME, accuser, 20) // same turn — must still be allowed
+
+        assertFalse(outcome.caught)
+        verify(playerDao, times(2)).updateCoins(10, 4)
+    }
+
+    @Test
+    fun `rejected accusation does not consume the turn slot`() {
+        val me = player(10, 1, 5)
+        whenever(playerDao.findByGameIdAndUserId(GAME, 1)).thenReturn(me)
+        whenever(playerDao.findById(10)).thenReturn(me)
+        whenever(playerDao.findById(20)).thenReturn(player(20, 2, 4))
+        whenever(cheatFlagDao.consume(20)).thenReturn(0)
+
+        // Self-accusation is rejected, then a valid accusation in the same turn
+        // must still be allowed.
+        assertThrows<CustomWebSocketException> { service.accuse(GAME, accuser, 10) }
+        val outcome = service.accuse(GAME, accuser, 20)
+
+        assertFalse(outcome.caught)
+        verify(playerDao, times(1)).updateCoins(any(), any())
     }
 
     // ── accuse: validation ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Server side of the **cheating-accusations** feature (#361). A player can accuse another player of using the **Insider Trading** cheat (SE2-Machi-Koro/Client#203); the server is the authority that knows who actually cheated and applies a coin penalty. The cheat stays invisible to other players — they have to *bet* on it.

Client half: **SE2-Machi-Koro/Client#280** (in progress).

## Design (locked decisions)

- **Whole-game detection.** A cheat use stays catchable until a successful catch consumes it; cheat again → catchable again.
- **Two-way bet.** Caught cheater loses **2** coins; wrong accuser loses **1**. Penalties go to the bank, **clamped at 0** (the economy never creates coins or goes negative).
- **No rate limit** — the wrong-accusation coin cost self-limits spam (kept simple).

## Flow

1. **Silent self-report** — client sends `/app/game.reportCheat {gameId}` when the active player uses the cheat. Server records an *outstanding cheat* for that player (`cheat_flags` table). Not broadcast.
2. **Accuse** — client sends `/app/game.accuse {gameId, accusedPlayerId}`; accuser derived from the authenticated WS session.
3. **Adjudicate (authoritative, single transaction)** — a **consume-decides** delete: `CheatFlagDao.consume` returns the affected-row count, so two accusers can't double-penalize one cheater. Caught → cheater −2; wrong → accuser −1; coins re-read in-transaction and clamped.
4. **Broadcast** — `ACCUSATION_RESULT` to `/topic/game/{gameId}` with the outcome, the involved `PlayerModel.id`s, and a fresh state snapshot so everyone sees the new coin totals.

## Guardrails

- Only while `IN_PROGRESS`; accuser & accused must be players in the game; **can't accuse yourself**.
- `reportCheat` accepted only from the active player on their turn (so a client can only self-incriminate — no framing).
- Invalid accusations → `CustomWebSocketException("INVALID_ACCUSATION")` → private `/queue/errors`.

## Implementation

- New `cheat_flags` table via **Flyway `V3__add_cheat_flags.sql`** (FK→players `ON DELETE CASCADE`) + Exposed `CheatFlags` + `CheatFlagDao`.
- `AccusationService` (adjudication/penalty) wired into `GameController` (`/game.reportCheat`, `/game.accuse` + `ACCUSATION_RESULT` broadcast).
- DTOs `ReportCheatRequest`, `AccuseRequest`, `AccusationOutcome`; new `MessageType.ACCUSATION_RESULT`.

## Testing

- ✅ `./gradlew check` green locally against **real Postgres (Testcontainers)** — all tests + the JaCoCo coverage gate.
- **Unit** (`AccusationServiceTest`): caught / wrong / clamp-at-0 / self / non-member / game-not-running / consume-race.
- **DAO** (`CheatFlagDaoTest`): idempotent set, consume row-count, `ON DELETE CASCADE`.
- **Controller** (`GameControllerTest`): handlers delegate, broadcast `ACCUSATION_RESULT`, error propagation, unauthenticated.
- Adversarial multi-agent review: no high/medium issues; one low (absolute-value coin RMW) left **consistent with the existing economy** (`PurchaseService`/`EarningsServiceImpl` do the same) and noted for a future repo-wide fix.

> Live end-to-end via the app is covered by the client half (#280); the accusation can't be triggered through the UI until that lands.

## Known limitation

Detection trusts the (honest) client to self-report cheat usage — a modified client could cheat without reporting. Acceptable: the cheat itself is client-side.

Refs #361
