### PR TITLE
test(error-handling): add Sprint 3 server error regression coverage

### DIFF
--- a/src/test/kotlin/org/machikoro/server/config/DockerHealthcheckConfigTest.kt
+++ b/src/test/kotlin/org/machikoro/server/config/DockerHealthcheckConfigTest.kt
@@ -3,6 +3,7 @@ package org.machikoro.server.config
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.nio.file.Files
@@ -15,15 +16,81 @@ class DockerHealthcheckConfigTest {
 
     @Test
     fun `backend compose service exposes actuator health through docker healthcheck`() {
-        val backend = composeService("backend")
+        val backend = composeService("compose.yaml", "backend")
         val healthcheck = backend.path("healthcheck")
-        val testCommand = healthcheck.path("test").map(JsonNode::asText)
 
-        assertEquals(listOf("CMD-SHELL", "curl -fsS http://localhost:8080/actuator/health || exit 1"), testCommand)
+        assertEquals(listOf("CMD-SHELL", "curl -fsS http://localhost:8080/actuator/health || exit 1"), healthcheck.testCommand())
         assertEquals("15s", healthcheck.path("interval").asText())
         assertEquals("5s", healthcheck.path("timeout").asText())
         assertEquals(5, healthcheck.path("retries").asInt())
         assertEquals("60s", healthcheck.path("start_period").asText())
+    }
+
+    @Test
+    fun `postgres compose service exposes pg_isready healthcheck`() {
+        val postgres = composeService("compose.yaml", "postgres")
+        val healthcheck = postgres.path("healthcheck")
+
+        assertEquals(listOf("CMD-SHELL", "pg_isready -U ${'$'}{DB_USERNAME} -d ${'$'}{DB_NAME:-machikoro}"), healthcheck.testCommand())
+        assertEquals("5s", healthcheck.path("interval").asText())
+        assertEquals("5s", healthcheck.path("timeout").asText())
+        assertEquals(5, healthcheck.path("retries").asInt())
+        assertEquals("30s", healthcheck.path("start_period").asText())
+    }
+
+    @Test
+    fun `backend waits for postgres to be healthy before starting`() {
+        val backend = composeService("compose.yaml", "backend")
+
+        assertEquals("service_healthy", backend.path("depends_on").path("postgres").path("condition").asText())
+    }
+
+    @Test
+    fun `backend production compose uses internal postgres connection settings`() {
+        val environment = composeService("compose.yaml", "backend").environment()
+
+        assertTrue(environment.contains("DB_HOST=postgres"))
+        assertTrue(environment.contains("DB_PORT=5432"))
+        assertTrue(environment.contains("SERVER_PORT=8080"))
+        assertTrue(environment.contains("SPRING_DOCKER_COMPOSE_ENABLED=false"))
+    }
+
+    @Test
+    fun `postgres production compose uses required database environment settings`() {
+        val environment = composeService("compose.yaml", "postgres").environment()
+
+        assertTrue(environment.contains("POSTGRES_DB=${'$'}{DB_NAME:-machikoro}"))
+        assertTrue(environment.contains("POSTGRES_PASSWORD=${'$'}{DB_PASSWORD}"))
+        assertTrue(environment.contains("POSTGRES_USER=${'$'}{DB_USERNAME}"))
+    }
+
+    @Test
+    fun `production compose keeps postgres private while dev compose exposes it locally`() {
+        val productionPostgres = composeService("compose.yaml", "postgres")
+        val devPostgres = composeService("compose-dev.yaml", "postgres")
+
+        assertFalse(productionPostgres.has("ports"))
+        assertEquals(listOf("${'$'}{DB_PORT:-5432}:5432"), devPostgres.path("ports").map(JsonNode::asText))
+    }
+
+    @Test
+    fun `compose files preserve postgres data through named volumes`() {
+        listOf("compose.yaml", "compose-dev.yaml").forEach { composeFile ->
+            val compose = compose(composeFile)
+
+            assertEquals(listOf("postgres_data:/var/lib/postgresql"), compose.path("services").path("postgres").path("volumes").map(JsonNode::asText))
+            assertTrue(compose.path("volumes").has("postgres_data"))
+        }
+    }
+
+    @Test
+    fun `development pgadmin depends on postgres and uses persistent storage`() {
+        val pgAdmin = composeService("compose-dev.yaml", "pgAdmin")
+
+        assertEquals(listOf("postgres"), pgAdmin.path("depends_on").map(JsonNode::asText))
+        assertEquals(listOf("pgadmin_data:/var/lib/pgadmin"), pgAdmin.path("volumes").map(JsonNode::asText))
+        assertEquals(listOf("5050:80"), pgAdmin.path("ports").map(JsonNode::asText))
+        assertTrue(compose("compose-dev.yaml").path("volumes").has("pgadmin_data"))
     }
 
     @Test
@@ -34,8 +101,15 @@ class DockerHealthcheckConfigTest {
         assertTrue(dockerfile.contains("apt-get install -y --no-install-recommends curl"))
     }
 
-    private fun composeService(name: String): JsonNode {
-        val compose = yamlMapper.readTree(projectRoot.resolve("compose.yaml").toFile())
-        return compose.path("services").path(name)
-    }
+    private fun composeService(composeFile: String, name: String): JsonNode =
+        compose(composeFile).path("services").path(name)
+
+    private fun compose(composeFile: String): JsonNode =
+        yamlMapper.readTree(projectRoot.resolve(composeFile).toFile())
+
+    private fun JsonNode.testCommand(): List<String> =
+        path("test").map(JsonNode::asText)
+
+    private fun JsonNode.environment(): List<String> =
+        path("environment").map(JsonNode::asText)
 }

--- a/src/test/kotlin/org/machikoro/server/config/DockerHealthcheckConfigTest.kt
+++ b/src/test/kotlin/org/machikoro/server/config/DockerHealthcheckConfigTest.kt
@@ -1,0 +1,41 @@
+package org.machikoro.server.config
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+
+class DockerHealthcheckConfigTest {
+
+    private val yamlMapper = YAMLMapper()
+    private val projectRoot: Path = Path.of("").toAbsolutePath()
+
+    @Test
+    fun `backend compose service exposes actuator health through docker healthcheck`() {
+        val backend = composeService("backend")
+        val healthcheck = backend.path("healthcheck")
+        val testCommand = healthcheck.path("test").map(JsonNode::asText)
+
+        assertEquals(listOf("CMD-SHELL", "curl -fsS http://localhost:8080/actuator/health || exit 1"), testCommand)
+        assertEquals("15s", healthcheck.path("interval").asText())
+        assertEquals("5s", healthcheck.path("timeout").asText())
+        assertEquals(5, healthcheck.path("retries").asInt())
+        assertEquals("60s", healthcheck.path("start_period").asText())
+    }
+
+    @Test
+    fun `backend docker image installs curl required by compose healthcheck`() {
+        val dockerfile = Files.readString(projectRoot.resolve("Dockerfile"))
+
+        assertTrue(dockerfile.contains("FROM eclipse-temurin:21.0.6_7-jre-jammy AS runtime-base"))
+        assertTrue(dockerfile.contains("apt-get install -y --no-install-recommends curl"))
+    }
+
+    private fun composeService(name: String): JsonNode {
+        val compose = yamlMapper.readTree(projectRoot.resolve("compose.yaml").toFile())
+        return compose.path("services").path(name)
+    }
+}

--- a/src/test/kotlin/org/machikoro/server/controller/EarningsControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/EarningsControllerTest.kt
@@ -28,7 +28,6 @@ import org.mockito.kotlin.whenever
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 
 class EarningsControllerTest {
 
@@ -139,26 +138,6 @@ class EarningsControllerTest {
         val payload = captor.firstValue.payload as WebSocketErrorDto
         assertEquals("EFFECTS_ALREADY_RESOLVED", payload.code)
         assertEquals("EFFECTS_FAILED", payload.context["event"])
-    }
-
-    @Test
-    fun `resolveEffects broadcasts internal error when service fails unexpectedly`() {
-        val request = ResolveEffectsRequest(gameId = 1)
-        doThrow(IllegalStateException("jdbc:postgresql://prod.internal password=secret"))
-            .whenever(earningsService).resolveEffects(1)
-
-        controller.resolveEffects(request, authedAccessor())
-
-        val captor = argumentCaptor<WebSocketMessage>()
-        verify(messagingTemplate).convertAndSend(eq("/topic/game/1"), captor.capture())
-        val message = captor.firstValue
-        assertEquals(MessageType.ERROR, message.type)
-        val payload = message.payload as WebSocketErrorDto
-        assertEquals("INTERNAL_ERROR", payload.code)
-        assertEquals("Unexpected error while processing WebSocket message", payload.message)
-        assertEquals("EFFECTS_FAILED", payload.context["event"])
-        assertFalse(payload.message.contains("prod.internal"))
-        assertFalse(payload.message.contains("password=secret"))
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/controller/EarningsControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/EarningsControllerTest.kt
@@ -28,6 +28,7 @@ import org.mockito.kotlin.whenever
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 class EarningsControllerTest {
 
@@ -123,6 +124,26 @@ class EarningsControllerTest {
         val payload = captor.firstValue.payload as WebSocketErrorDto
         assertEquals("EFFECTS_ALREADY_RESOLVED", payload.code)
         assertEquals("EFFECTS_FAILED", payload.context["event"])
+    }
+
+    @Test
+    fun `resolveEffects broadcasts internal error when service fails unexpectedly`() {
+        val request = ResolveEffectsRequest(gameId = 1)
+        doThrow(IllegalStateException("jdbc:postgresql://prod.internal password=secret"))
+            .whenever(earningsService).resolveEffects(1)
+
+        controller.resolveEffects(request, authedAccessor())
+
+        val captor = argumentCaptor<WebSocketMessage>()
+        verify(messagingTemplate).convertAndSend(eq("/topic/game/1"), captor.capture())
+        val message = captor.firstValue
+        assertEquals(MessageType.ERROR, message.type)
+        val payload = message.payload as WebSocketErrorDto
+        assertEquals("INTERNAL_ERROR", payload.code)
+        assertEquals("Unexpected error while processing WebSocket message", payload.message)
+        assertEquals("EFFECTS_FAILED", payload.context["event"])
+        assertFalse(payload.message.contains("prod.internal"))
+        assertFalse(payload.message.contains("password=secret"))
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/controller/RestErrorHandlingRegressionTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/RestErrorHandlingRegressionTest.kt
@@ -1,0 +1,142 @@
+package org.machikoro.server.controller
+
+import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.not
+import org.junit.jupiter.api.Test
+import org.machikoro.server.dao.UserDao
+import org.machikoro.server.exception.GameNotFoundException
+import org.machikoro.server.exception.GameStartedException
+import org.machikoro.server.exception.InvalidCredentialsException
+import org.machikoro.server.exception.InvalidSessionTokenException
+import org.machikoro.server.exception.NotAdminException
+import org.machikoro.server.service.AuthService
+import org.machikoro.server.service.DebugService
+import org.machikoro.server.service.GameEndBroadcaster
+import org.machikoro.server.service.GamePhaseService
+import org.machikoro.server.service.GameSyncService
+import org.machikoro.server.service.LobbyService
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.ResultMatcher
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(controllers = [AuthController::class, LobbyController::class, DebugController::class])
+@AutoConfigureMockMvc(addFilters = false)
+@TestPropertySource(properties = ["debug.enabled=true"])
+class RestErrorHandlingRegressionTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    private lateinit var authService: AuthService
+
+    @MockitoBean
+    private lateinit var gameSyncService: GameSyncService
+
+    @MockitoBean
+    private lateinit var lobbyService: LobbyService
+
+    @MockitoBean
+    private lateinit var debugService: DebugService
+
+    @MockitoBean
+    private lateinit var gameEndBroadcaster: GameEndBroadcaster
+
+    @MockitoBean
+    private lateinit var gamePhaseService: GamePhaseService
+
+    @MockitoBean
+    private lateinit var userDao: UserDao
+
+    @Test
+    fun `login failure returns structured credentials error without account details`() {
+        whenever(authService.login("alice", "wrong-password"))
+            .thenThrow(InvalidCredentialsException("Invalid username or password"))
+
+        postJson("/auth/login", """{"username":"alice","password":"wrong-password"}""")
+            .expectApiError(status().isUnauthorized, "INVALID_CREDENTIALS", "Invalid username or password")
+            .andExpect(content().string(not(containsString("wrong-password"))))
+    }
+
+    @Test
+    fun `missing debug session returns structured unauthenticated error`() {
+        whenever(debugService.validateAdmin(isNull()))
+            .thenThrow(InvalidSessionTokenException("Missing Authorization header"))
+
+        mockMvc.perform(post("/debug/seed"))
+            .expectApiError(status().isUnauthorized, "UNAUTHENTICATED", "Missing Authorization header")
+    }
+
+    @Test
+    fun `non-admin debug session returns structured forbidden error`() {
+        whenever(debugService.validateAdmin(eq("Bearer user-token")))
+            .thenThrow(NotAdminException("Admin access required"))
+
+        mockMvc.perform(post("/debug/seed").header("Authorization", "Bearer user-token"))
+            .expectApiError(status().isForbidden, "NOT_ADMIN", "Admin access required")
+    }
+
+    @Test
+    fun `lobby start returns structured not-found error`() {
+        whenever(lobbyService.startGame(gameId = 404, requestingUserId = 1))
+            .thenThrow(GameNotFoundException("Game 404 not found"))
+
+        mockMvc.perform(post("/lobby/{gameId}/start", 404).param("requestingUserId", "1"))
+            .expectApiError(status().isNotFound, "GAME_NOT_FOUND", "Game 404 not found")
+    }
+
+    @Test
+    fun `lobby start returns structured invalid game-state error`() {
+        whenever(lobbyService.startGame(gameId = 7, requestingUserId = 1))
+            .thenThrow(GameStartedException("Game 7 has already started"))
+
+        mockMvc.perform(post("/lobby/{gameId}/start", 7).param("requestingUserId", "1"))
+            .expectApiError(status().isBadRequest, "GAME_STARTED", "Game 7 has already started")
+    }
+
+    @Test
+    fun `unexpected REST exception returns generic error without internal details`() {
+        whenever(lobbyService.startGame(gameId = 500, requestingUserId = 1))
+            .thenThrow(IllegalStateException("jdbc:postgresql://prod.internal password=secret"))
+
+        mockMvc.perform(post("/lobby/{gameId}/start", 500).param("requestingUserId", "1"))
+            .expectApiError(
+                status().isInternalServerError,
+                "INTERNAL_ERROR",
+                "Unexpected error while processing request",
+            )
+            .andExpect(content().string(not(containsString("prod.internal"))))
+            .andExpect(content().string(not(containsString("password=secret"))))
+    }
+
+    private fun postJson(path: String, body: String): ResultActions =
+        mockMvc.perform(
+            post(path)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body),
+        )
+
+    private fun ResultActions.expectApiError(
+        statusMatcher: ResultMatcher,
+        code: String,
+        message: String,
+    ): ResultActions =
+        andExpect(statusMatcher)
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.code").value(code))
+            .andExpect(jsonPath("$.message").value(message))
+            .andExpect(jsonPath("$.timestamp").isNumber)
+}

--- a/src/test/kotlin/org/machikoro/server/handler/GlobalWebSocketExceptionHandlerTests.kt
+++ b/src/test/kotlin/org/machikoro/server/handler/GlobalWebSocketExceptionHandlerTests.kt
@@ -1,6 +1,7 @@
 package org.machikoro.server.handler
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.machikoro.server.exception.CustomWebSocketException
@@ -27,7 +28,7 @@ class GlobalWebSocketExceptionHandlerTests {
 
     @Test
     fun handleGenericExceptionShouldReturnInternalErrorPayload() {
-        val exception = IllegalStateException("boom")
+        val exception = IllegalStateException("jdbc:postgresql://prod.internal password=secret")
 
         val start = System.currentTimeMillis()
         val response = handler.handleGenericException(exception)
@@ -35,6 +36,8 @@ class GlobalWebSocketExceptionHandlerTests {
 
         assertEquals("INTERNAL_ERROR", response.code)
         assertEquals("Unexpected error while processing WebSocket message", response.message)
+        assertFalse(response.message.contains("prod.internal"))
+        assertFalse(response.message.contains("password=secret"))
         assertTrue(response.timestamp in start..end)
     }
 }


### PR DESCRIPTION
## Summary

Adds focused regression coverage for the centralized server error-handling contract introduced for Sprint 3.

This PR verifies that REST and WebSocket error paths continue to return structured, client-safe payloads instead of plain strings or ad-hoc responses. It also adds static Docker/Compose configuration checks for deployment health and service wiring, without running Docker smoke tests.

## Sprint 3 Requirement

This work is required for Sprint 3 to lock down backend error behavior and deployment health configuration before further gameplay, client integration, and deployment work depends on it.

## Coverage Added

- REST boundary tests for authentication, session, authorization, not-found, invalid game-state, and unexpected exception paths.
- WebSocket handler regression checks for generic internal errors.
- Assertions that sensitive internal details are not exposed in client-facing error payloads.
- Static Docker/Compose checks for backend `/actuator/health`.
- Static Docker/Compose checks for Postgres `pg_isready`.
- Verification that backend startup depends on Postgres `service_healthy`.
- Verification that production Compose keeps Postgres private while development Compose exposes it locally.
- Verification that named volumes persist Postgres and pgAdmin data.
- Verification that the runtime Docker image installs `curl` for health checks.

## Validation

- `./gradlew test --tests org.machikoro.server.config.DockerHealthcheckConfigTest`
- `./gradlew build`

Closes #351  
Closes #347
```