### PR TITLE
Fix: User ID implementation with Bearer Token

### DIFF
--- a/src/main/kotlin/org/machikoro/server/controller/LobbyController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/LobbyController.kt
@@ -1,7 +1,9 @@
 package org.machikoro.server.controller
 
+import org.machikoro.server.auth.UserPrincipal
 import org.machikoro.server.service.LobbyService
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -13,15 +15,15 @@ class LobbyController(private val lobbyService: LobbyService) {
 
     /**
      * HTTP convenience endpoint for starting a game.
-     * The [requestingUserId] must match the game's hostUserId.
+     * Caller must be the lobby host — identity is taken from the Bearer token, not a param.
      * The primary start path is the WebSocket handler [GameController.startGame].
      */
     @PostMapping("/{gameId}/start")
     fun startGame(
         @PathVariable gameId: Int,
-        @org.springframework.web.bind.annotation.RequestParam requestingUserId: Int,
+        @AuthenticationPrincipal principal: UserPrincipal,
     ): ResponseEntity<Any> {
-        val state = lobbyService.startGame(gameId, requestingUserId)
+        val state = lobbyService.startGame(gameId, principal.userId)
         return ResponseEntity.ok(state)
     }
 }

--- a/src/test/kotlin/org/machikoro/server/controller/LobbyControllerTests.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/LobbyControllerTests.kt
@@ -3,10 +3,12 @@ package org.machikoro.server.controller
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.machikoro.server.auth.UserPrincipal
 import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.enums.TurnPhase
 import org.machikoro.server.domain.models.GameModel
 import org.machikoro.server.dto.GameStateDto
+import org.machikoro.server.exception.NotHostException
 import org.machikoro.server.service.LobbyService
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
@@ -19,11 +21,15 @@ class LobbyControllerTests {
     private val lobbyService = mock<LobbyService>()
     private val controller = LobbyController(lobbyService)
 
+    // Host user ID used across tests
+    private val hostUserId = 10
+    private val hostPrincipal = UserPrincipal(userId = hostUserId, username = "host")
+
     private fun gameStateDto(gameId: Int) = GameStateDto(
         game = GameModel(
             id = gameId,
             status = GameStatus.IN_PROGRESS,
-            hostUserId = 10,
+            hostUserId = hostUserId,
             lobbyCode = "ABC123",
             maxPlayers = 4,
             currentTurnIndex = 0,
@@ -43,22 +49,33 @@ class LobbyControllerTests {
     @Test
     fun `startGame returns ok when service succeeds`() {
         val gameId = 1
-        val requestingUserId = 10
-        whenever(lobbyService.startGame(eq(gameId), eq(requestingUserId))).thenReturn(gameStateDto(gameId))
+        whenever(lobbyService.startGame(eq(gameId), eq(hostUserId))).thenReturn(gameStateDto(gameId))
 
-        val response = controller.startGame(gameId, requestingUserId)
+        val response = controller.startGame(gameId, hostPrincipal)
         assertEquals(HttpStatus.OK, response.statusCode)
     }
 
     @Test
     fun `startGame propagates exception for centralized handling`() {
         val gameId = 1
-        val requestingUserId = 10
         whenever(lobbyService.startGame(eq(gameId), any())).thenThrow(RuntimeException("test error"))
 
         val exception = assertThrows<RuntimeException> {
-            controller.startGame(gameId, requestingUserId)
+            controller.startGame(gameId, hostPrincipal)
         }
         assertEquals("test error", exception.message)
+    }
+
+    @Test
+    fun `non-host cannot start game even if they know the host user ID`() {
+        val gameId = 1
+        // Non-host principal — identity comes from token, not a forgeable param
+        val nonHostPrincipal = UserPrincipal(userId = 99, username = "attacker")
+        whenever(lobbyService.startGame(eq(gameId), eq(99)))
+            .thenThrow(NotHostException("User 99 is not the host of game $gameId"))
+
+        assertThrows<NotHostException> {
+            controller.startGame(gameId, nonHostPrincipal)
+        }
     }
 }

--- a/src/test/kotlin/org/machikoro/server/controller/RestErrorHandlingRegressionTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/RestErrorHandlingRegressionTest.kt
@@ -90,29 +90,32 @@ class RestErrorHandlingRegressionTest {
     }
 
     @Test
+    @WithUserPrincipal(userId = 1)
     fun `lobby start returns structured not-found error`() {
         whenever(lobbyService.startGame(gameId = 404, requestingUserId = 1))
             .thenThrow(GameNotFoundException("Game 404 not found"))
 
-        mockMvc.perform(post("/lobby/{gameId}/start", 404).param("requestingUserId", "1"))
+        mockMvc.perform(post("/lobby/{gameId}/start", 404))
             .expectApiError(status().isNotFound, "GAME_NOT_FOUND", "Game 404 not found")
     }
 
     @Test
+    @WithUserPrincipal(userId = 1)
     fun `lobby start returns structured invalid game-state error`() {
         whenever(lobbyService.startGame(gameId = 7, requestingUserId = 1))
             .thenThrow(GameStartedException("Game 7 has already started"))
 
-        mockMvc.perform(post("/lobby/{gameId}/start", 7).param("requestingUserId", "1"))
+        mockMvc.perform(post("/lobby/{gameId}/start", 7))
             .expectApiError(status().isBadRequest, "GAME_STARTED", "Game 7 has already started")
     }
 
     @Test
+    @WithUserPrincipal(userId = 1)
     fun `unexpected REST exception returns generic error without internal details`() {
         whenever(lobbyService.startGame(gameId = 500, requestingUserId = 1))
             .thenThrow(IllegalStateException("jdbc:postgresql://prod.internal password=secret"))
 
-        mockMvc.perform(post("/lobby/{gameId}/start", 500).param("requestingUserId", "1"))
+        mockMvc.perform(post("/lobby/{gameId}/start", 500))
             .expectApiError(
                 status().isInternalServerError,
                 "INTERNAL_ERROR",

--- a/src/test/kotlin/org/machikoro/server/controller/WithUserPrincipal.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/WithUserPrincipal.kt
@@ -1,0 +1,25 @@
+package org.machikoro.server.controller
+
+import org.machikoro.server.auth.UserPrincipal
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.test.context.support.WithSecurityContext
+import org.springframework.security.test.context.support.WithSecurityContextFactory
+
+// Injects a UserPrincipal into SecurityContextHolder for @WebMvcTest without filters
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@WithSecurityContext(factory = WithUserPrincipalFactory::class)
+annotation class WithUserPrincipal(val userId: Int = 1, val username: String = "testuser")
+
+class WithUserPrincipalFactory : WithSecurityContextFactory<WithUserPrincipal> {
+    override fun createSecurityContext(annotation: WithUserPrincipal) =
+        SecurityContextHolder.createEmptyContext().apply {
+            authentication = UsernamePasswordAuthenticationToken(
+                UserPrincipal(userId = annotation.userId, username = annotation.username),
+                null,
+                listOf(SimpleGrantedAuthority("ROLE_USER")),
+            )
+        }
+}


### PR DESCRIPTION
Changes:

LobbyController.kt — replaced @RequestParam requestingUserId: Int with @AuthenticationPrincipal principal: UserPrincipal. User ID now comes from the Bearer token (placed by TokenAuthFilter), not from a caller-supplied param.

LobbyControllerTests.kt — updated existing tests to pass UserPrincipal directly, added non-host cannot start game even if they know the host user ID which verifies the IDOR is closed: the controller always passes principal.userId to the service, so a non-host gets the NotHostException regardless of what they send. 