### PR TITLE
378 align server state and realtime events with client reconnect and dice safeguards

### DIFF
--- a/src/main/kotlin/org/machikoro/server/controller/GameController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/GameController.kt
@@ -193,10 +193,10 @@ class GameController(
                     gameId = gameId,
                 )
             )
-        } catch (e: GameStartedException) {
+        } catch (_: GameStartedException) {
             // Already initialized — idempotent, only runs once per game
             logger.debug("enterGameScreen: game $gameId already in progress, skipping initialization")
-        } catch (e: NotHostException) {
+        } catch (_: NotHostException) {
             // Non-host entered screen — host will trigger initialization when they enter
             logger.debug("enterGameScreen: userId=${principal.userId} is not host of game $gameId, skipping")
         }
@@ -265,7 +265,7 @@ class GameController(
         when (val result = gamePhaseService.endTurn(request.gameId)) {
             is EndTurnOutcome.Continue -> {
                 logger.info("Ended turn for game ${request.gameId}, new phase ${result.nextPhase}")
-                broadcastPhase(request.gameId, "TURN_ENDED")
+                broadcastTurnEnded(request.gameId)
             }
             is EndTurnOutcome.Won -> {
                 logger.info("Game ${request.gameId} finished, winner=${result.winnerId}")
@@ -448,11 +448,10 @@ class GameController(
     }
 
     /**
-     * Broadcasts the new turn phase and the active player's user ID to all
-     * subscribers of the game topic. The [activePlayerId] identifies the user
-     * whose turn it is so clients can compare it against their own user ID.
+     * Broadcasts the new turn phase and active player's user ID to all
+     * subscribers of the game topic.
      */
-    private fun broadcastPhase(gameId: Int, event: String) {
+    private fun broadcastTurnEnded(gameId: Int) {
         val state = gameSyncService.buildSnapshot(gameId)
         messagingTemplate.convertAndSend(
             "/topic/game/$gameId",
@@ -461,7 +460,7 @@ class GameController(
                 sender = "server",
                 payload = buildGameActionPayload(
                     state = state,
-                    event = event,
+                    event = "TURN_ENDED",
                 ),
                 gameId = gameId,
             ),

--- a/src/main/kotlin/org/machikoro/server/controller/GameController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/GameController.kt
@@ -330,6 +330,7 @@ class GameController(
                         "total" to result.total,
                         "completed" to result.completed,
                         "extraTurnGranted" to result.extraTurnGranted,
+                        "roundNumber" to state.game.roundNumber,
                         "timestamp" to System.currentTimeMillis(),
                         "state" to state,
                     ),
@@ -349,6 +350,7 @@ class GameController(
                         "total" to result.total,
                         "completed" to result.completed,
                         "extraTurnGranted" to result.extraTurnGranted,
+                        "roundNumber" to state.game.roundNumber,
                     ),
                     gameId = request.gameId,
                 )

--- a/src/main/kotlin/org/machikoro/server/controller/GameController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/GameController.kt
@@ -330,6 +330,8 @@ class GameController(
                         "total" to result.total,
                         "completed" to result.completed,
                         "extraTurnGranted" to result.extraTurnGranted,
+                        // Keep round metadata top-level so clients do not need
+                        // to inspect the nested state to complete dice UI.
                         "roundNumber" to state.game.roundNumber,
                         "timestamp" to System.currentTimeMillis(),
                         "state" to state,
@@ -350,6 +352,8 @@ class GameController(
                         "total" to result.total,
                         "completed" to result.completed,
                         "extraTurnGranted" to result.extraTurnGranted,
+                        // Mirrors the ROLL_DICE frame for clients that consume
+                        // only GAME_ACTION updates.
                         "roundNumber" to state.game.roundNumber,
                     ),
                     gameId = request.gameId,

--- a/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
@@ -11,6 +11,7 @@ import org.machikoro.server.dto.WebSocketMessage
 import org.machikoro.server.exception.CustomWebSocketException
 import org.machikoro.server.exception.GameNotFoundException
 import org.machikoro.server.service.LobbyService
+import org.machikoro.server.service.WebSocketConnectionTracker
 import org.slf4j.LoggerFactory
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.handler.annotation.Payload
@@ -22,6 +23,7 @@ import org.springframework.stereotype.Controller
 class LobbyWebSocketController(
     private val lobbyService: LobbyService,
     private val messagingTemplate: SimpMessagingTemplate,
+    private val connectionTracker: WebSocketConnectionTracker,
 ) {
     private val logger = LoggerFactory.getLogger(LobbyWebSocketController::class.java)
 
@@ -64,6 +66,7 @@ class LobbyWebSocketController(
         logger.info("User '{}' requested lobby creation", principal.username)
 
         val lobby = lobbyService.createLobby(principal.userId)
+        connectionTracker.register(sessionId, principal.userId, lobby.id)
 
         // Deliver only to the creator — avoids auto-joining unrelated clients
         messagingTemplate.convertAndSend(
@@ -154,6 +157,8 @@ class LobbyWebSocketController(
         val roster = lobbyService.getLobbyRoster(player.gameId)
 
         if (sessionId != null) {
+            connectionTracker.register(sessionId, principal.userId, player.gameId)
+
             // Tell the joiner they successfully joined — client navigates to LobbyScreen on this event
             messagingTemplate.convertAndSend(
                 "/queue/lobby-user$sessionId",

--- a/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
@@ -66,6 +66,8 @@ class LobbyWebSocketController(
         logger.info("User '{}' requested lobby creation", principal.username)
 
         val lobby = lobbyService.createLobby(principal.userId)
+        // Membership is established here, so later game actions can identify
+        // the user without relying on a stale chat.addUser gameId payload.
         connectionTracker.register(sessionId, principal.userId, lobby.id)
 
         // Deliver only to the creator — avoids auto-joining unrelated clients
@@ -157,6 +159,8 @@ class LobbyWebSocketController(
         val roster = lobbyService.getLobbyRoster(player.gameId)
 
         if (sessionId != null) {
+            // Joining establishes membership; register the session here instead
+            // of waiting for a separate chat.addUser frame with client state.
             connectionTracker.register(sessionId, principal.userId, player.gameId)
 
             // Tell the joiner they successfully joined — client navigates to LobbyScreen on this event

--- a/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
@@ -2,6 +2,7 @@ package org.machikoro.server.controller
 
 import io.github.springwolf.core.asyncapi.annotations.AsyncListener
 import io.github.springwolf.core.asyncapi.annotations.AsyncOperation
+import org.machikoro.server.auth.UserPrincipal
 import org.machikoro.server.auth.userPrincipal
 import org.machikoro.server.dto.LobbyLeavingOutcome
 import org.machikoro.server.dto.LobbyRosterDto
@@ -256,7 +257,7 @@ class LobbyWebSocketController(
                 sender = "SERVER",
                 content = "Lobby roster updated",
                 gameId = gameId,
-                payload = org.machikoro.server.dto.LobbyRosterDto(players = roster),
+                payload = LobbyRosterDto(players = roster),
             )
         )
     }

--- a/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/LobbyWebSocketController.kt
@@ -32,8 +32,8 @@ class LobbyWebSocketController(
      * Handles lobby creation via WebSocket.
      *
      * Client sends a message to /app/lobby.create.
-     * Server creates a new lobby and delivers LOBBY_CREATED only to the creator
-     * via /queue/lobby-user{sessionId} — not a global broadcast.
+     * Server creates a new lobby and delivers LOBBY_CREATED plus the host's
+     * LOBBY_JOINED/LOBBY_ROSTER only to the creator via /queue/lobby-user{sessionId}.
      *
      * Identity is read from the [UserPrincipal] that [org.machikoro.server.auth.StompAuthChannelInterceptor]
      * attaches at CONNECT time — [WebSocketMessage.sender] is ignored to prevent
@@ -70,6 +70,8 @@ class LobbyWebSocketController(
         // Membership is established here, so later game actions can identify
         // the user without relying on a stale chat.addUser gameId payload.
         connectionTracker.register(sessionId, principal.userId, lobby.id)
+        val roster = lobbyService.getLobbyRoster(lobby.id)
+        val hostRosterEntry = roster.firstOrNull { it.userId == principal.userId }
 
         // Deliver only to the creator — avoids auto-joining unrelated clients
         messagingTemplate.convertAndSend(
@@ -84,6 +86,38 @@ class LobbyWebSocketController(
                     "hostUserId" to lobby.hostUserId,
                     "status" to lobby.status.name
                 )
+            )
+        )
+
+        // The merged client navigates to Lobby only after the server confirms
+        // membership with LOBBY_JOINED; LOBBY_CREATED only supplies the code.
+        if (hostRosterEntry != null) {
+            messagingTemplate.convertAndSend(
+                "/queue/lobby-user$sessionId",
+                WebSocketMessage(
+                    type = MessageType.LOBBY_JOINED,
+                    sender = "SERVER",
+                    content = "You joined the lobby",
+                    gameId = lobby.id,
+                    payload = mapOf(
+                        "playerId" to hostRosterEntry.playerId,
+                        "userId" to hostRosterEntry.userId,
+                        "username" to principal.username,
+                        "gameId" to lobby.id,
+                        "coins" to hostRosterEntry.coins,
+                    )
+                )
+            )
+        }
+
+        messagingTemplate.convertAndSend(
+            "/queue/lobby-user$sessionId",
+            WebSocketMessage(
+                type = MessageType.LOBBY_ROSTER,
+                sender = "SERVER",
+                content = "Lobby roster",
+                gameId = lobby.id,
+                payload = LobbyRosterDto(players = roster),
             )
         )
     }

--- a/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
@@ -89,7 +89,7 @@ class WebSocketController(
         // Trust only server-side mapping for reconnect. A client-provided
         // gameId can be stale and must not recreate old lobby membership.
         val mappedInProgressGameId = gameSyncService.findActiveInProgressGameId(principal.userId)
-        var gameIdToJoin = mappedInProgressGameId
+        var gameIdToJoin = mappedInProgressGameId ?: lobbyService.findWaitingLobbyIdForUser(principal.userId)
 
         if (gameIdToJoin != null) {
             try {

--- a/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
@@ -86,10 +86,12 @@ class WebSocketController(
         // without trusting whatever the client put in the message payload.
         headerAccessor.sessionAttributes?.put("username", principal.username)
 
+        val sessionId = headerAccessor.sessionId
+
         // Trust only server-side mapping for reconnect. A client-provided
         // gameId can be stale and must not recreate old lobby membership.
         val mappedInProgressGameId = gameSyncService.findActiveInProgressGameId(principal.userId)
-        var gameIdToJoin = mappedInProgressGameId ?: lobbyService.findWaitingLobbyIdForUser(principal.userId)
+        var gameIdToJoin = mappedInProgressGameId
 
         if (gameIdToJoin != null) {
             try {
@@ -108,7 +110,6 @@ class WebSocketController(
                 gameIdToJoin = remappedInProgressGameId
             }
 
-            val sessionId = headerAccessor.sessionId
             if (sessionId != null) {
                 connectionTracker.register(sessionId, principal.userId, gameIdToJoin)
             }
@@ -121,6 +122,17 @@ class WebSocketController(
                     userId = principal.userId,
                     gameId = syncGameId,
                 )
+            }
+        } else if (sessionId != null) {
+            // No in-progress game, but the user may still hold a server-owned
+            // WAITING lobby membership — e.g. a host whose STOMP session dropped
+            // and reconnected under a new session id, or after a backend restart.
+            // Re-register the fresh session against that server-resolved waiting
+            // membership (never the client-supplied gameId) so later game actions
+            // such as game.start can still resolve the requesting user.
+            val waitingGameId = lobbyService.findWaitingLobbyIdForUser(principal.userId)
+            if (waitingGameId != null) {
+                connectionTracker.register(sessionId, principal.userId, waitingGameId)
             }
         }
 

--- a/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
@@ -85,9 +85,10 @@ class WebSocketController(
         // without trusting whatever the client put in the message payload.
         headerAccessor.sessionAttributes?.put("username", principal.username)
 
-        // Prefer server-side mapping to an active game when a player reconnects.
+        // Trust only server-side mapping for reconnect. A client-provided
+        // gameId can be stale and must not recreate old lobby membership.
         val mappedInProgressGameId = gameSyncService.findActiveInProgressGameId(principal.userId)
-        var gameIdToJoin = mappedInProgressGameId ?: message.gameId
+        var gameIdToJoin = mappedInProgressGameId
 
         if (gameIdToJoin != null) {
             try {

--- a/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/WebSocketController.kt
@@ -4,6 +4,7 @@ import io.github.springwolf.core.asyncapi.annotations.AsyncListener
 import io.github.springwolf.core.asyncapi.annotations.AsyncOperation
 import io.micrometer.core.instrument.Metrics
 import io.micrometer.core.instrument.Timer
+import org.machikoro.server.auth.UserPrincipal
 import org.machikoro.server.auth.userPrincipal
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.SyncGameRequest

--- a/src/main/kotlin/org/machikoro/server/dao/PlayerDao.kt
+++ b/src/main/kotlin/org/machikoro/server/dao/PlayerDao.kt
@@ -126,6 +126,9 @@ class PlayerDao {
             ?.value
     }
 
+    /**
+     * Returns every waiting lobby membership for logout cleanup.
+     */
     fun findWaitingGameIdsByUserId(userId: Int): List<Int> = transaction {
         Players.join(
             Games,
@@ -137,6 +140,10 @@ class PlayerDao {
             .map { it[Players.gameId].value }
     }
 
+    /**
+     * Returns the newest waiting lobby membership so duplicate create requests
+     * can behave as idempotent retries.
+     */
     fun findWaitingMembershipByUserId(userId: Int): PlayerGameMembership? = transaction {
         Players.join(
             Games,

--- a/src/main/kotlin/org/machikoro/server/dao/PlayerDao.kt
+++ b/src/main/kotlin/org/machikoro/server/dao/PlayerDao.kt
@@ -126,6 +126,35 @@ class PlayerDao {
             ?.value
     }
 
+    fun findWaitingGameIdsByUserId(userId: Int): List<Int> = transaction {
+        Players.join(
+            Games,
+            JoinType.INNER,
+            additionalConstraint = { Players.gameId eq Games.id }
+        )
+            .selectAll()
+            .where { (Players.userId eq userId) and (Games.status eq GameStatus.WAITING) }
+            .map { it[Players.gameId].value }
+    }
+
+    fun findWaitingMembershipByUserId(userId: Int): PlayerGameMembership? = transaction {
+        Players.join(
+            Games,
+            JoinType.INNER,
+            additionalConstraint = { Players.gameId eq Games.id }
+        )
+            .selectAll()
+            .where { (Players.userId eq userId) and (Games.status eq GameStatus.WAITING) }
+            .orderBy(Games.id to SortOrder.DESC)
+            .firstOrNull()
+            ?.let { row ->
+                PlayerGameMembership(
+                    player = row.toModel(),
+                    game = row.toGameModel(),
+                )
+            }
+    }
+
     /**
      * Returns the newest valid membership for a reconnect/login decision.
      *

--- a/src/main/kotlin/org/machikoro/server/service/AuthService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/AuthService.kt
@@ -15,6 +15,7 @@ import java.util.UUID
 class AuthService(
     private val userDao: UserDao,
     private val passwordEncoder: PasswordEncoder,
+    private val lobbyService: LobbyService,
 ) {
     private val logger = LoggerFactory.getLogger(AuthService::class.java)
 
@@ -78,6 +79,7 @@ class AuthService(
     @Transactional
     fun logout(sessionToken: String) {
         val user = userDao.findBySessionToken(sessionToken) ?: return
+        lobbyService.leaveWaitingLobbiesForUser(user.id)
         userDao.updateSessionToken(user.id, null)
         logger.info("Cleared session for user '{}'", user.username)
     }

--- a/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
@@ -26,7 +26,7 @@ import org.springframework.stereotype.Service
 import java.util.concurrent.ConcurrentHashMap
 
 @Service
-open class LobbyService(
+class LobbyService(
     private val gameDao: GameDao,
     private val playerDao: PlayerDao,
     private val gameMarketplaceDao: GameMarketplaceDao,
@@ -50,7 +50,7 @@ open class LobbyService(
      * [LobbyService] and override this to `block()` directly, bypassing the
      * Exposed transaction machinery that requires a real database connection.
      */
-    protected open fun <T> runInTransaction(block: () -> T): T = transaction { block() }
+    protected fun <T> runInTransaction(block: () -> T): T = transaction { block() }
 
     companion object {
         // Machi Koro base game requires at least 2 players.

--- a/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
@@ -63,6 +63,8 @@ open class LobbyService(
      * Creates a new lobby owned by [hostUserId] and returns the persisted
      * [GameModel]. The host is registered on the game record and immediately
      * added to the player roster so membership is server-owned from creation.
+     * Duplicate create requests from the same waiting member are treated as
+     * idempotent retries and return the existing lobby.
      *
      * Wrapped in a single transaction so the create + re-fetch pair is atomic.
      */
@@ -231,6 +233,10 @@ open class LobbyService(
         LobbyLeavingOutcome.LobbyRemains(userId)
     }
 
+    /**
+     * Logout cleanup only removes waiting lobby memberships. In-progress games
+     * remain reconnectable, which keeps legitimate resume flows intact.
+     */
     fun leaveWaitingLobbiesForUser(userId: Int) {
         playerDao.findWaitingGameIdsByUserId(userId)
             .forEach { gameId ->

--- a/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
@@ -113,6 +113,9 @@ class LobbyService(
         playerDao.getLobbyRoster(gameId).map { it.copy(isReady = it.userId in ready) }
     }
 
+    fun findWaitingLobbyIdForUser(userId: Int): Int? =
+        playerDao.findWaitingMembershipByUserId(userId)?.game?.id
+
     /**
      * Flips the ready state for [userId] in [gameId].
      *

--- a/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/LobbyService.kt
@@ -61,14 +61,16 @@ open class LobbyService(
 
     /**
      * Creates a new lobby owned by [hostUserId] and returns the persisted
-     * [GameModel]. The host is registered on the game record but is NOT
-     * automatically added to the player roster — callers go through
-     * [addUserToLobby] for that, the same as any other joining player.
+     * [GameModel]. The host is registered on the game record and immediately
+     * added to the player roster so membership is server-owned from creation.
      *
      * Wrapped in a single transaction so the create + re-fetch pair is atomic.
      */
     fun createLobby(hostUserId: Int): GameModel = runInTransaction {
+        playerDao.findWaitingMembershipByUserId(hostUserId)?.let { return@runInTransaction it.game }
+
         val gameId = gameDao.create(hostUserId)
+        playerDao.addPlayer(gameId, hostUserId)
         gameDao.findById(gameId)
             ?: throw GameNotFoundException("Game $gameId not found after creation")
     }
@@ -227,6 +229,13 @@ open class LobbyService(
         }
 
         LobbyLeavingOutcome.LobbyRemains(userId)
+    }
+
+    fun leaveWaitingLobbiesForUser(userId: Int) {
+        playerDao.findWaitingGameIdsByUserId(userId)
+            .forEach { gameId ->
+                runCatching { leaveLobby(gameId, userId) }
+            }
     }
 
 

--- a/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
@@ -87,8 +87,9 @@ class GameControllerTest {
         gameId: Int,
         turnPhase: TurnPhase = defaultGame.turnPhase,
         activePlayerId: Int? = 1,
+        roundNumber: Int = defaultGame.roundNumber,
     ) = GameStateDto(
-        game = defaultGame.copy(id = gameId, turnPhase = turnPhase),
+        game = defaultGame.copy(id = gameId, turnPhase = turnPhase, roundNumber = roundNumber),
         players = listOf(
             PlayerModel(id = 1, gameId = gameId, userId = 1, turnOrder = 0, coins = 3, lastSeenAt = null),
             PlayerModel(id = 2, gameId = gameId, userId = 2, turnOrder = 1, coins = 3, lastSeenAt = null),
@@ -649,6 +650,7 @@ class GameControllerTest {
         assertEquals(listOf(3, 4), payload["result"])
         assertEquals(7, payload["total"])
         assertEquals(true, payload["completed"])
+        assertEquals(1, payload["roundNumber"])
         assert(payload["timestamp"] is Long)
         assertEquals(snapshot, payload["state"])
         assertEquals(gameId, message.gameId)
@@ -666,6 +668,7 @@ class GameControllerTest {
         assertEquals(listOf(3, 4), actionPayload["result"])
         assertEquals(7, actionPayload["total"])
         assertEquals(true, actionPayload["completed"])
+        assertEquals(1, actionPayload["roundNumber"])
         assertEquals(snapshot, actionPayload["state"])
         verify(diceService).rollDice(request, activePlayer.id)
         verify(gameStateGuard, never()).ensureSenderOwnsPlayer(any(), any(), any())
@@ -958,6 +961,38 @@ class GameControllerTest {
         @Suppress("UNCHECKED_CAST")
         val actionPayload = actionMessage.payload as Map<String, Any?>
         assertEquals(false, actionPayload["extraTurnGranted"])
+    }
+
+    @Test
+    fun `rollDice broadcasts completed result shape for round 4`() {
+        val gameId = 1
+        val activePlayer = PlayerModel(id = 9, gameId = gameId, userId = alice.userId, turnOrder = 0, coins = 3, lastSeenAt = null)
+        val request = RollDiceRequest(gameId = gameId)
+        val response = RollDiceResponse(result = listOf(4), total = 4)
+        val snapshot = gameStateDto(gameId, turnPhase = TurnPhase.RESOLVE_EFFECTS, roundNumber = 4)
+
+        whenever(gameStateGuard.ensureSenderIsActivePlayer(gameId, alice)).thenReturn(activePlayer)
+        whenever(diceService.rollDice(request, activePlayer.id)).thenReturn(response)
+        whenever(gameSyncService.buildSnapshot(gameId)).thenReturn(snapshot)
+
+        controller.rollDice(request, authedAccessor())
+
+        val captor = argumentCaptor<WebSocketMessage>()
+        verify(messagingTemplate, times(2)).convertAndSend(eq("/topic/game/$gameId"), captor.capture())
+
+        @Suppress("UNCHECKED_CAST")
+        val rollPayload = captor.firstValue.payload as Map<String, Any?>
+        assertEquals("DICE_ROLLED", rollPayload["event"])
+        assertEquals(true, rollPayload["completed"])
+        assertEquals("RESOLVE_EFFECTS", rollPayload["turnPhase"])
+        assertEquals(4, rollPayload["roundNumber"])
+
+        @Suppress("UNCHECKED_CAST")
+        val actionPayload = captor.secondValue.payload as Map<String, Any?>
+        assertEquals("DICE_ROLLED", actionPayload["event"])
+        assertEquals(true, actionPayload["completed"])
+        assertEquals("RESOLVE_EFFECTS", actionPayload["turnPhase"])
+        assertEquals(4, actionPayload["roundNumber"])
     }
     fun `rerollDice throws UNAUTHENTICATED when accessor has no principal`() {
         assertUnauthenticated { controller.rerollDice(RollDiceRequest(gameId = 42, playerId = 1), it) }

--- a/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
@@ -994,6 +994,7 @@ class GameControllerTest {
         assertEquals("RESOLVE_EFFECTS", actionPayload["turnPhase"])
         assertEquals(4, actionPayload["roundNumber"])
     }
+    @Test
     fun `rerollDice throws UNAUTHENTICATED when accessor has no principal`() {
         assertUnauthenticated { controller.rerollDice(RollDiceRequest(gameId = 42, playerId = 1), it) }
         verify(diceService, never()).rerollDice(any(), any())

--- a/src/test/kotlin/org/machikoro/server/controller/LobbyWebSocketControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/LobbyWebSocketControllerTest.kt
@@ -68,8 +68,12 @@ class LobbyWebSocketControllerTest {
     )
 
     @Test
-    fun `createLobby sends LOBBY_CREATED only to the creator's session queue`() {
+    fun `createLobby sends created joined and roster messages to creator session queue`() {
+        val roster = listOf(
+            LobbyRosterPlayerDto(playerId = 1, userId = 10, username = "Player1", gameId = 1, turnOrder = 0, coins = 3),
+        )
         whenever(lobbyService.createLobby(10)).thenReturn(game())
+        whenever(lobbyService.getLobbyRoster(1)).thenReturn(roster)
 
         val accessor = authenticatedAccessor(userId = 10, username = "Player1", sessionId = "sess-42")
 
@@ -80,23 +84,45 @@ class LobbyWebSocketControllerTest {
 
         val destCaptor = argumentCaptor<String>()
         val msgCaptor = argumentCaptor<WebSocketMessage>()
-        verify(messagingTemplate).convertAndSend(destCaptor.capture(), msgCaptor.capture())
+        verify(messagingTemplate, times(3)).convertAndSend(destCaptor.capture(), msgCaptor.capture())
 
-        // Must go to creator's session queue, not a global topic
-        assertEquals("/queue/lobby-user${"sess-42"}", destCaptor.firstValue)
+        destCaptor.allValues.forEach { destination ->
+            // Must go to creator's session queue, not a global topic
+            assertEquals("/queue/lobby-usersess-42", destination)
+        }
 
-        val msg = msgCaptor.firstValue
-        assertEquals(MessageType.LOBBY_CREATED, msg.type)
-        assertEquals("SERVER", msg.sender)
-        assertEquals("Lobby created", msg.content)
-        assertEquals(1, msg.gameId)
+        val createdMsg = msgCaptor.allValues[0]
+        assertEquals(MessageType.LOBBY_CREATED, createdMsg.type)
+        assertEquals("SERVER", createdMsg.sender)
+        assertEquals("Lobby created", createdMsg.content)
+        assertEquals(1, createdMsg.gameId)
 
-        val payload = msg.payload as? Map<*, *> ?: throw AssertionError("Payload is not a Map")
+        val payload = createdMsg.payload as? Map<*, *> ?: throw AssertionError("Payload is not a Map")
         assertEquals("ABC1234", payload["lobbyCode"])
         assertEquals(10, payload["hostUserId"])
         assertEquals("WAITING", payload["status"])
 
+        val joinedMsg = msgCaptor.allValues[1]
+        assertEquals(MessageType.LOBBY_JOINED, joinedMsg.type)
+        assertEquals("SERVER", joinedMsg.sender)
+        assertEquals("You joined the lobby", joinedMsg.content)
+        assertEquals(1, joinedMsg.gameId)
+        val joinedPayload = joinedMsg.payload as? Map<*, *> ?: throw AssertionError("Payload is not a Map")
+        assertEquals(1, joinedPayload["playerId"])
+        assertEquals(10, joinedPayload["userId"])
+        assertEquals("Player1", joinedPayload["username"])
+        assertEquals(1, joinedPayload["gameId"])
+        assertEquals(3, joinedPayload["coins"])
+
+        val rosterMsg = msgCaptor.allValues[2]
+        assertEquals(MessageType.LOBBY_ROSTER, rosterMsg.type)
+        assertEquals("SERVER", rosterMsg.sender)
+        assertEquals("Lobby roster", rosterMsg.content)
+        assertEquals(1, rosterMsg.gameId)
+        assertEquals(LobbyRosterDto(players = roster), rosterMsg.payload)
+
         verify(lobbyService).createLobby(10)
+        verify(lobbyService).getLobbyRoster(1)
         verify(connectionTracker).register("sess-42", 10, 1)
     }
 
@@ -137,7 +163,11 @@ class LobbyWebSocketControllerTest {
 
     @Test
     fun `createLobby uses principal from session attributes when header user is missing`() {
+        val roster = listOf(
+            LobbyRosterPlayerDto(playerId = 1, userId = 10, username = "Player1", gameId = 1, turnOrder = 0, coins = 3),
+        )
         whenever(lobbyService.createLobby(10)).thenReturn(game())
+        whenever(lobbyService.getLobbyRoster(1)).thenReturn(roster)
 
         val accessor = SimpMessageHeaderAccessor.create().apply {
             sessionId = "sess-99"
@@ -153,13 +183,16 @@ class LobbyWebSocketControllerTest {
 
         val destCaptor = argumentCaptor<String>()
         val msgCaptor = argumentCaptor<WebSocketMessage>()
-        verify(messagingTemplate).convertAndSend(destCaptor.capture(), msgCaptor.capture())
+        verify(messagingTemplate, times(3)).convertAndSend(destCaptor.capture(), msgCaptor.capture())
 
         assertEquals("/queue/lobby-usersess-99", destCaptor.firstValue)
         assertEquals(MessageType.LOBBY_CREATED, msgCaptor.firstValue.type)
         assertEquals("ABC1234", (msgCaptor.firstValue.payload as? Map<*, *>)?.get("lobbyCode"))
+        assertEquals(MessageType.LOBBY_JOINED, msgCaptor.allValues[1].type)
+        assertEquals(MessageType.LOBBY_ROSTER, msgCaptor.allValues[2].type)
 
         verify(lobbyService).createLobby(10)
+        verify(lobbyService).getLobbyRoster(1)
         verify(connectionTracker).register("sess-99", 10, 1)
     }
 

--- a/src/test/kotlin/org/machikoro/server/controller/LobbyWebSocketControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/LobbyWebSocketControllerTest.kt
@@ -11,6 +11,7 @@ import org.machikoro.server.dto.WebSocketErrorDto
 import org.machikoro.server.dto.WebSocketMessage
 import org.machikoro.server.exception.CustomWebSocketException
 import org.machikoro.server.service.LobbyService
+import org.machikoro.server.service.WebSocketConnectionTracker
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.machikoro.server.domain.models.PlayerModel
@@ -33,7 +34,8 @@ class LobbyWebSocketControllerTest {
 
     private val lobbyService = mock<LobbyService>()
     private val messagingTemplate = mock<SimpMessagingTemplate>()
-    private val controller = LobbyWebSocketController(lobbyService, messagingTemplate)
+    private val connectionTracker = mock<WebSocketConnectionTracker>()
+    private val controller = LobbyWebSocketController(lobbyService, messagingTemplate, connectionTracker)
 
     // Helper: accessor with authenticated principal and a session ID
     private fun authenticatedAccessor(userId: Int, username: String, sessionId: String = "test-session"): SimpMessageHeaderAccessor =
@@ -95,6 +97,7 @@ class LobbyWebSocketControllerTest {
         assertEquals("WAITING", payload["status"])
 
         verify(lobbyService).createLobby(10)
+        verify(connectionTracker).register("sess-42", 10, 1)
     }
 
     @Test
@@ -112,6 +115,7 @@ class LobbyWebSocketControllerTest {
         )
 
         verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
+        verify(connectionTracker, never()).register(any(), any(), any())
     }
 
     @Test
@@ -128,6 +132,7 @@ class LobbyWebSocketControllerTest {
         assertEquals("UNAUTHENTICATED", ex.errorCode)
         verify(lobbyService, never()).createLobby(any())
         verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
+        verify(connectionTracker, never()).register(any(), any(), any())
     }
 
     @Test
@@ -155,6 +160,7 @@ class LobbyWebSocketControllerTest {
         assertEquals("ABC1234", (msgCaptor.firstValue.payload as? Map<*, *>)?.get("lobbyCode"))
 
         verify(lobbyService).createLobby(10)
+        verify(connectionTracker).register("sess-99", 10, 1)
     }
 
     @Test
@@ -209,6 +215,7 @@ class LobbyWebSocketControllerTest {
 
         verify(lobbyService).joinLobby("ABC1234", 20)
         verify(lobbyService).getLobbyRoster(1)
+        verify(connectionTracker).register("sess-77", 20, 1)
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/controller/WebSocketControllerTests.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/WebSocketControllerTests.kt
@@ -50,6 +50,7 @@ class WebSocketControllerTests {
     @BeforeEach
     fun setup() {
         whenever(gameSyncService.findActiveInProgressGameId(any())).thenReturn(null)
+        whenever(lobbyService.findWaitingLobbyIdForUser(any())).thenReturn(null)
     }
 
     @Test
@@ -112,6 +113,19 @@ class WebSocketControllerTests {
 
         verify(lobbyService, never()).addUserToLobby(any(), any())
         verify(connectionTracker, never()).register(any(), any(), any())
+    }
+
+    @Test
+    fun `addUser registers reconnecting user for server-resolved waiting lobby`() {
+        whenever(lobbyService.findWaitingLobbyIdForUser(10)).thenReturn(7)
+        val accessor = authenticatedAccessor(userId = 10, username = "dave", sessionId = "session-new")
+        val message = WebSocketMessage(type = MessageType.JOIN, sender = "dave", gameId = 999)
+
+        controller.addUser(message, accessor)
+
+        verify(lobbyService).addUserToLobby(7, 10)
+        verify(connectionTracker).register("session-new", 10, 7)
+        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/controller/WebSocketControllerTests.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/WebSocketControllerTests.kt
@@ -102,7 +102,7 @@ class WebSocketControllerTests {
     }
 
     @Test
-    fun `addUser calls addUserToLobby and registers session when user and gameId are present`() {
+    fun `addUser ignores stale client gameId when no active server game exists`() {
         val gameId = 1
         val accessor = authenticatedAccessor(userId = 10, username = "dave", sessionId = "session-abc")
 
@@ -110,8 +110,8 @@ class WebSocketControllerTests {
 
         controller.addUser(message, accessor)
 
-        verify(lobbyService).addUserToLobby(gameId, 10)
-        verify(connectionTracker).register("session-abc", 10, gameId)
+        verify(lobbyService, never()).addUserToLobby(any(), any())
+        verify(connectionTracker, never()).register(any(), any(), any())
     }
 
     @Test
@@ -129,6 +129,7 @@ class WebSocketControllerTests {
     @Test
     fun `addUser does not register session when sessionId is null`() {
         val message = WebSocketMessage(type = MessageType.JOIN, sender = "frank", gameId = 2)
+        whenever(gameSyncService.findActiveInProgressGameId(7)).thenReturn(2)
         // accessor without sessionId set → sessionId is null
         val accessor = SimpMessageHeaderAccessor.create().apply {
             sessionAttributes = mutableMapOf()
@@ -169,12 +170,12 @@ class WebSocketControllerTests {
 
     @Test
     fun `addUser handles transition race by re-mapping user and syncing state`() {
-        whenever(gameSyncService.findActiveInProgressGameId(12)).thenReturn(null, 3, 3)
+        whenever(gameSyncService.findActiveInProgressGameId(12)).thenReturn(3, 3, 3)
         whenever(lobbyService.addUserToLobby(3, 12)).thenThrow(GameStartedException("already started"))
         whenever(gameSyncService.buildSnapshot(3)).thenReturn(mock<GameStateDto>())
 
         val accessor = authenticatedAccessor(userId = 12, username = "harry", sessionId = "session-race")
-        val message = WebSocketMessage(type = MessageType.JOIN, sender = "harry", gameId = 3)
+        val message = WebSocketMessage(type = MessageType.JOIN, sender = "harry", gameId = 999)
 
         controller.addUser(message, accessor)
 

--- a/src/test/kotlin/org/machikoro/server/controller/WebSocketControllerTests.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/WebSocketControllerTests.kt
@@ -50,6 +50,8 @@ class WebSocketControllerTests {
     @BeforeEach
     fun setup() {
         whenever(gameSyncService.findActiveInProgressGameId(any())).thenReturn(null)
+        // Default: no waiting lobby membership. Mockito otherwise returns 0 for a
+        // boxed Int return, which would spuriously trigger reconnect registration.
         whenever(lobbyService.findWaitingLobbyIdForUser(any())).thenReturn(null)
     }
 
@@ -116,16 +118,38 @@ class WebSocketControllerTests {
     }
 
     @Test
-    fun `addUser registers reconnecting user for server-resolved waiting lobby`() {
-        whenever(lobbyService.findWaitingLobbyIdForUser(10)).thenReturn(7)
+    fun `addUser re-registers session against server-resolved waiting lobby on reconnect`() {
+        // Host reconnects under a new session id: no in-progress game, but a
+        // WAITING lobby membership is still owned server-side. The new session
+        // must be re-registered so a later game.start can resolve the host.
+        whenever(gameSyncService.findActiveInProgressGameId(10)).thenReturn(null)
+        whenever(lobbyService.findWaitingLobbyIdForUser(10)).thenReturn(42)
         val accessor = authenticatedAccessor(userId = 10, username = "dave", sessionId = "session-new")
+
+        // Client-supplied gameId is stale and must be ignored entirely.
         val message = WebSocketMessage(type = MessageType.JOIN, sender = "dave", gameId = 999)
 
         controller.addUser(message, accessor)
 
-        verify(lobbyService).addUserToLobby(7, 10)
-        verify(connectionTracker).register("session-new", 10, 7)
-        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
+        // No lobby join — the user is already a member — just session re-registration.
+        verify(lobbyService, never()).addUserToLobby(any(), any())
+        verify(connectionTracker).register("session-new", 10, 42)
+    }
+
+    @Test
+    fun `addUser does not register waiting lobby when sessionId is null`() {
+        whenever(gameSyncService.findActiveInProgressGameId(7)).thenReturn(null)
+        whenever(lobbyService.findWaitingLobbyIdForUser(7)).thenReturn(42)
+        val accessor = SimpMessageHeaderAccessor.create().apply {
+            sessionAttributes = mutableMapOf()
+            user = UserPrincipal(userId = 7, username = "frank")
+        }
+
+        val message = WebSocketMessage(type = MessageType.JOIN, sender = "frank", gameId = 42)
+
+        controller.addUser(message, accessor)
+
+        verify(connectionTracker, never()).register(any(), any(), any())
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/dao/PlayerDaoTest.kt
+++ b/src/test/kotlin/org/machikoro/server/dao/PlayerDaoTest.kt
@@ -208,6 +208,48 @@ class PlayerDaoTest : AbstractDBSetup() {
     }
 
     @Test
+    fun `findWaitingGameIdsByUserId returns only waiting memberships`() {
+        val waitingGameId = gameDao.create(userId)
+        val activeGameId = gameDao.create(userId)
+        val finishedGameId = gameDao.create(userId)
+
+        playerDao.addPlayer(waitingGameId, userId)
+        playerDao.addPlayer(activeGameId, userId)
+        playerDao.addPlayer(finishedGameId, userId)
+        gameDao.updateStatus(activeGameId, GameStatus.IN_PROGRESS)
+        gameDao.updateStatus(finishedGameId, GameStatus.FINISHED)
+
+        assertEquals(listOf(waitingGameId), playerDao.findWaitingGameIdsByUserId(userId))
+    }
+
+    @Test
+    fun `findWaitingMembershipByUserId returns newest waiting membership`() {
+        val olderWaitingGameId = gameDao.create(userId)
+        val newerWaitingGameId = gameDao.create(userId)
+        val activeGameId = gameDao.create(userId)
+        playerDao.addPlayer(olderWaitingGameId, userId)
+        val expectedPlayer = playerDao.addPlayer(newerWaitingGameId, userId)
+        playerDao.addPlayer(activeGameId, userId)
+        gameDao.updateStatus(activeGameId, GameStatus.IN_PROGRESS)
+
+        val membership = playerDao.findWaitingMembershipByUserId(userId)
+
+        assertNotNull(membership)
+        assertEquals(newerWaitingGameId, membership!!.game.id)
+        assertEquals(expectedPlayer.id, membership.player.id)
+        assertEquals(GameStatus.WAITING, membership.game.status)
+    }
+
+    @Test
+    fun `findWaitingMembershipByUserId returns null when user has no waiting lobby`() {
+        val activeGameId = gameDao.create(userId)
+        playerDao.addPlayer(activeGameId, userId)
+        gameDao.updateStatus(activeGameId, GameStatus.IN_PROGRESS)
+
+        assertNull(playerDao.findWaitingMembershipByUserId(userId))
+    }
+
+    @Test
     fun `findCurrentMembershipByUserId prefers newest in-progress game over waiting lobby`() {
         val waitingGameId = gameDao.create(userId)
         val activeGameId = gameDao.create(userId)

--- a/src/test/kotlin/org/machikoro/server/service/AuthServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/AuthServiceTest.kt
@@ -22,8 +22,9 @@ class AuthServiceTest {
 
     private val userDao = mock<UserDao>()
     private val passwordEncoder = mock<PasswordEncoder>()
+    private val lobbyService = mock<LobbyService>()
 
-    private val service = AuthService(userDao, passwordEncoder)
+    private val service = AuthService(userDao, passwordEncoder, lobbyService)
 
     @Test
     fun `register persists user with hashed password and returns id and username`() {
@@ -170,6 +171,7 @@ class AuthServiceTest {
 
         service.logout(token)
 
+        verify(lobbyService).leaveWaitingLobbiesForUser(7)
         verify(userDao).updateSessionToken(eq(7), isNull())
     }
 
@@ -179,6 +181,7 @@ class AuthServiceTest {
 
         service.logout("stale")
 
+        verify(lobbyService, never()).leaveWaitingLobbiesForUser(any())
         verify(userDao, never()).updateSessionToken(any(), any())
     }
 

--- a/src/test/kotlin/org/machikoro/server/service/LobbyServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/LobbyServiceTest.kt
@@ -85,6 +85,7 @@ class LobbyServiceTest {
     private fun player(id: Int) =
         PlayerModel(id = id, gameId = 1, userId = id, turnOrder = 0, coins = 3, lastSeenAt = null)
 
+    @Suppress("SameParameterValue")
     private fun rosterEntry(playerId: Int, username: String, gameId: Int = 1) =
         LobbyRosterPlayerDto(playerId = playerId, userId = playerId, username = username, gameId = gameId, turnOrder = playerId - 1, coins = 3)
 

--- a/src/test/kotlin/org/machikoro/server/service/LobbyServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/LobbyServiceTest.kt
@@ -372,6 +372,23 @@ class LobbyServiceTest {
     }
 
     @Test
+    fun `findWaitingLobbyIdForUser returns waiting membership game id`() {
+        val userId = 10
+        val waitingGame = game(7, GameStatus.WAITING)
+        whenever(playerDao.findWaitingMembershipByUserId(userId))
+            .thenReturn(PlayerDao.PlayerGameMembership(player(userId), waitingGame))
+
+        assertEquals(7, lobbyService.findWaitingLobbyIdForUser(userId))
+    }
+
+    @Test
+    fun `findWaitingLobbyIdForUser returns null when user has no waiting membership`() {
+        whenever(playerDao.findWaitingMembershipByUserId(10)).thenReturn(null)
+
+        assertEquals(null, lobbyService.findWaitingLobbyIdForUser(10))
+    }
+
+    @Test
     fun `startGame throws NotEnoughPlayersException with no players`() {
         val gameId = 1
         whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.WAITING))

--- a/src/test/kotlin/org/machikoro/server/service/LobbyServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/LobbyServiceTest.kt
@@ -187,7 +187,22 @@ class LobbyServiceTest {
 
         kotlin.test.assertEquals(expected, result)
         verify(gameDao).create(eq(hostUserId), any(), any())
+        verify(playerDao).addPlayer(gameId, hostUserId)
         verify(gameDao).findById(gameId)
+    }
+
+    @Test
+    fun `createLobby returns existing waiting lobby for duplicate create`() {
+        val hostUserId = 7
+        val existingGame = game(42, GameStatus.WAITING).copy(hostUserId = hostUserId)
+        whenever(playerDao.findWaitingMembershipByUserId(hostUserId))
+            .thenReturn(PlayerDao.PlayerGameMembership(player(hostUserId), existingGame))
+
+        val result = lobbyService.createLobby(hostUserId)
+
+        assertEquals(existingGame, result)
+        verify(gameDao, never()).create(any(), any(), any())
+        verify(playerDao, never()).addPlayer(any(), any())
     }
 
     @Test
@@ -648,6 +663,25 @@ class LobbyServiceTest {
         assertEquals(0, count)
         verify(playerDao, never()).deleteByGameId(any())
         verify(gameDao, never()).delete(any())
+    }
+
+    @Test
+    fun `leaveWaitingLobbiesForUser leaves every waiting lobby membership`() {
+        val userId = 10
+        whenever(playerDao.findWaitingGameIdsByUserId(userId)).thenReturn(listOf(1, 2))
+        whenever(playerDao.findByGameIdAndUserId(1, userId))
+            .thenReturn(player(5).copy(gameId = 1, userId = userId))
+        whenever(playerDao.findByGameIdAndUserId(2, userId))
+            .thenReturn(player(6).copy(gameId = 2, userId = userId))
+        whenever(gameDao.findById(1)).thenReturn(game(1, GameStatus.WAITING).copy(hostUserId = 99))
+        whenever(gameDao.findById(2)).thenReturn(game(2, GameStatus.WAITING).copy(hostUserId = userId))
+        whenever(playerDao.getLobbyRoster(1)).thenReturn(listOf(rosterEntry(20, "bob", 1)))
+
+        lobbyService.leaveWaitingLobbiesForUser(userId)
+
+        verify(playerDao).deleteByPlayerId(5)
+        verify(playerDao).deleteByGameId(2)
+        verify(gameDao).delete(2)
     }
 
     // === toggleReady() ===


### PR DESCRIPTION
## Summary

This PR aligns server-side lobby/reconnect and dice event behavior with the client safeguards from Client [#175](https://github.com/SE2-Machi-Koro/Client/pull/342).

### Reconnect and stale state

- `/app/chat.addUser` no longer treats the client-provided `gameId` as a fallback source of truth.
- Reconnect handling now only joins/syncs a game when the server can resolve an active in-progress membership for the authenticated user.
- This prevents stale navigation snapshots or old client payloads from recreating misleading lobby/game membership.

### Lobby membership

- `lobby.create` now creates real host membership immediately.
- The host is added to the lobby roster at creation time instead of relying on a later join/addUser flow.
- `lobby.create` is idempotent when the user already has a waiting lobby, returning the existing waiting lobby instead of creating duplicates.
- `lobby.join` continues to use the existing add-user path, preserving duplicate join behavior for existing members.

### WebSocket session tracking

- `lobby.create` and `lobby.join` now register the authenticated session with the connection tracker.
- This keeps later game actions, such as `game.start`, tied to server-established membership instead of stale client-supplied state.

### Logout cleanup

- Logout now clears the user’s waiting lobby memberships through the existing lobby leave cleanup path.
- In-progress game membership is preserved so legitimate reconnects still work.

### Dice completion events

- Dice roll completion broadcasts now include `roundNumber` alongside the completed result shape.
- This keeps later-round dice events, including round 4, explicit and stable for clients.