### PR TITLE
docs: align server docs and CI with Railway deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,9 @@
 # Server Configuration
 SERVER_PORT=8080
 
-# Public host port published by the production compose stack on the AAU
-# shared server. Each group gets its own assigned port (group 6 = 53210).
+# Host port published by the local Docker Compose stack. Production now runs
+# on Railway, which injects its own PORT/domain, so this only matters for local
+# and the legacy AAU deployment (group 6 used 53210).
 PUBLIC_PORT=53210
 
 # Comma-separated list of allowed Origins for WebSocket / CORS.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,10 @@ jobs:
           name: server-test-reports
           path: build/reports/tests/
 
-  # Deployment is handled by doco-cd on every push to `main`.
-  # doco-cd clones the repo to
-  #   /var/lib/docker/volumes/doco-cd-setup_data/_data/github.com/<org>/<repo>/
-  # on the AAU shared server and runs `docker compose up -d` against
-  # `compose.yaml`. Production secrets live in a server-side `.env` placed
-  # next to `compose.yaml` (chmod 600). For debugging / rollback use SSH:
-  #   ssh grp-6@se2-demo.aau.at -p 53200
+  # Deployment is handled by Railway (https://railway.app). On every push to
+  # `main` the `docker-publish.yml` workflow pushes a new image to GHCR
+  # (ghcr.io/se2-machi-koro/server:latest); Railway watches that image
+  # (pull_policy: always) and automatically redeploys the backend service.
+  # Production env vars (DB_*, WEBSOCKET_ALLOWED_ORIGINS, ...) are configured in
+  # the Railway service settings — see the Deployment section of README.md.
+  # The legacy AAU doco-cd/SSH flow is retained only for historical reference.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -104,22 +104,8 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  deploy:
-    name: Deploy to server
-    runs-on: ubuntu-latest
-    needs: build-and-push
-    if: github.ref == 'refs/heads/main'
-
-    steps:
-      - name: SSH deploy
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.DEPLOY_HOST }}
-          username: ${{ secrets.DEPLOY_USER }}
-          key: ${{ secrets.DEPLOY_SSH_KEY }}
-          port: 53200
-          # Pull new image and restart only the backend; .env lives next to compose.yaml
-          script: |
-            cd ~/machi-koro-server-deploy
-            docker compose pull backend
-            docker compose up -d --no-deps backend
+  # Production deployment is handled by Railway (https://railway.app), which
+  # watches the GHCR image (pull_policy: always) and auto-redeploys the backend
+  # on every new push to ghcr.io/se2-machi-koro/server:latest. No CI deploy step
+  # is required. The previous appleboy/ssh-action job that deployed to the AAU
+  # shared server (port 53200) was removed when production moved to Railway.


### PR DESCRIPTION
Closes #396

## What changed

Now that production runs on **Railway**, this PR updates the remaining docs/CI that still described the legacy AAU doco-cd/SSH deployment as if current:

- **`.env.example`** — reworded the `PUBLIC_PORT` comment so it no longer presents the AAU shared server as the production target; clarifies it's for local/legacy use since Railway injects its own port/domain.
- **`.github/workflows/ci.yml`** — replaced the doco-cd/AAU deployment comment block with the Railway flow (GHCR image push → Railway auto-redeploy).
- **`.github/workflows/docker-publish.yml`** — removed the obsolete `deploy` job (`appleboy/ssh-action` → AAU port 53200), replaced with a short comment noting Railway handles redeploys from the GHCR image.

## Why

The README was already migrated to Railway (with a clearly-marked "Legacy AAU Deployment" historical section), but these three spots still described the old flow as active. The `deploy` job in particular was still SSHing into the old AAU server on every push to `main`, which contradicts the Railway model where the platform auto-pulls the latest GHCR image.

## Notes for reviewer

- The `DEPLOY_HOST`, `DEPLOY_USER`, and `DEPLOY_SSH_KEY` repository secrets are now unused and can be deleted from the repo settings.
- No application code changed — docs/CI only.