### PR TITLE
feat(#389): carry per-player coin deltas in EFFECTS_RESOLVED for clie…

### DIFF
--- a/src/main/kotlin/org/machikoro/server/controller/EarningsController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/EarningsController.kt
@@ -45,7 +45,7 @@ class EarningsController(
         gameStateGuard.ensureSenderIsActivePlayer(request.gameId, user)
         val gameTopic = "/topic/game/${request.gameId}"
         try {
-            earningsService.resolveEffects(request.gameId)
+            val coinDeltas = earningsService.resolveEffects(request.gameId)
             val state = gameSyncService.buildSnapshot(request.gameId)
             logger.info("Resolved effects for game ${request.gameId}")
             messagingTemplate.convertAndSend(
@@ -58,6 +58,9 @@ class EarningsController(
                         "gameId" to request.gameId,
                         "turnPhase" to state.game.turnPhase.name,
                         "activePlayerId" to state.activePlayerId,
+                        // playerId -> signed coin delta; client uses it for the
+                        // coin / coin-drawer sound effects (issue #389).
+                        "coinDeltas" to coinDeltas,
                         "state" to state,
                     ),
                     gameId = request.gameId,

--- a/src/main/kotlin/org/machikoro/server/service/EarningsServiceImpl.kt
+++ b/src/main/kotlin/org/machikoro/server/service/EarningsServiceImpl.kt
@@ -39,7 +39,7 @@ class EarningsServiceImpl(
         pairs.sumOf { (quantity, income) -> quantity * income }
 
     @Transactional
-    override fun processEarnings(gameId: Int, diceRoll: Int, activePlayerId: Int) {
+    override fun processEarnings(gameId: Int, diceRoll: Int, activePlayerId: Int): Map<Int, Int> {
         val activatingCards = cardDao.findByActivationNumber(diceRoll)
             .associateBy { it.cardType }
 
@@ -65,6 +65,15 @@ class EarningsServiceImpl(
                 playerDao.updateCoins(player.id, finalCoins.getValue(player.id))
             }
         }
+
+        // playerId -> signed coin delta for players whose balance changed; drives
+        // the client coin / coin-drawer sound effects (issue #389).
+        return players
+            .mapNotNull { player ->
+                val delta = finalCoins.getValue(player.id) - player.coins
+                if (delta != 0) player.id to delta else null
+            }
+            .toMap()
     }
 
     /**
@@ -186,7 +195,7 @@ class EarningsServiceImpl(
      * This is the handoff point introduced for the buying-phase flow: earnings
      * are resolved first, and only then does the turn enter BUY_OR_BUILD.
      */
-    override fun resolveEffects(gameId: Int): Unit = gameTransactionRunner.inTransaction {
+    override fun resolveEffects(gameId: Int): Map<Int, Int> = gameTransactionRunner.inTransaction {
         val game = gameStateGuard.ensureGameIsRunning(gameId)
         when (game.turnPhase) {
             TurnPhase.ROLL_DICE -> throw CustomWebSocketException(

--- a/src/main/kotlin/org/machikoro/server/service/interfaces/EarningsService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/interfaces/EarningsService.kt
@@ -1,6 +1,17 @@
 package org.machikoro.server.service.interfaces
 
 interface EarningsService {
-    fun processEarnings(gameId: Int, diceRoll: Int, activePlayerId: Int)
-    fun resolveEffects(gameId: Int)
+    /**
+     * Applies the dice-roll earnings and returns the per-player coin change as
+     * `playerId -> signed delta`, including only players whose balance changed.
+     * Clients use these deltas to drive coin sound effects (issue #389).
+     */
+    fun processEarnings(gameId: Int, diceRoll: Int, activePlayerId: Int): Map<Int, Int>
+
+    /**
+     * Resolves card effects for the current turn and advances to BUY_OR_BUILD.
+     * Returns the per-player coin change as `playerId -> signed delta` (changed
+     * players only) so the broadcast can carry sound-relevant metadata (#389).
+     */
+    fun resolveEffects(gameId: Int): Map<Int, Int>
 }

--- a/src/test/kotlin/org/machikoro/server/controller/EarningsControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/EarningsControllerTest.kt
@@ -70,7 +70,9 @@ class EarningsControllerTest {
     fun `resolveEffects calls service and broadcasts success`() {
         val request = ResolveEffectsRequest(gameId = 1)
         val snapshot = gameStateDto(1)
+        val coinDeltas = mapOf(1 to 3, 2 to -3)
         whenever(gameSyncService.buildSnapshot(1)).thenReturn(snapshot)
+        whenever(earningsService.resolveEffects(1)).thenReturn(coinDeltas)
 
         controller.resolveEffects(request, authedAccessor())
 
@@ -89,6 +91,7 @@ class EarningsControllerTest {
         assertEquals(1, payload["gameId"])
         assertEquals("BUY_OR_BUILD", payload["turnPhase"])
         assertEquals(1, payload["activePlayerId"])
+        assertEquals(coinDeltas, payload["coinDeltas"])
         assertEquals(snapshot, payload["state"])
     }
 

--- a/src/test/kotlin/org/machikoro/server/service/EarningsServiceImplTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/EarningsServiceImplTest.kt
@@ -110,10 +110,12 @@ class EarningsServiceImplTest {
         whenever(playerCardDao.findByPlayerId(2))
             .thenReturn(listOf(playerCard(CardType.WHEAT_FIELD, 1)))
 
-        service.processEarnings(1, 1, 1)
+        val deltas = service.processEarnings(1, 1, 1)
 
         verify(playerDao).updateCoins(1, 5)
         verify(playerDao).updateCoins(2, 6)
+        // Signed per-player coin deltas drive the client coin sounds (#389).
+        assertEquals(mapOf(1 to 2, 2 to 1), deltas)
     }
 
     // Only the current player should earn green income


### PR DESCRIPTION
## Summary

Server side of the in-game sound effects feature (issue #389). Ensures the events the client needs carry the metadata required to drive sound effects, matching the client PR ([Client #362](https://github.com/SE2-Machi-Koro/Client/pull/362)).

## Changes

- `EarningsService.processEarnings` / `resolveEffects` now **return the per-player coin change** as `playerId -> signed delta` (changed players only).
- The `EFFECTS_RESOLVED` broadcast (`GAME_ACTION`) now includes a **`coinDeltas`** map alongside the existing `state`.

The client uses each player's signed delta to play the coin sound (positive = earning) or the coin-drawer sound (negative = paying out). This is more reliable than the client inferring coin changes from the turn phase: `resolveEffects` advances `RESOLVE_EFFECTS → BUY_OR_BUILD` before broadcasting, so by the time the client sees the new coin totals the phase has already moved on.

## Already in place (no change needed)

The **correct-accusation ("SIUUU") sound** needs no server change — `ACCUSATION_RESULT` already carries `accuserPlayerId` and `caught`. The client fix for that lives in the client PR (it was comparing the wrong ID space).

## Testing

- `EarningsServiceImplTest` — asserts `processEarnings` returns the expected signed deltas.
- `EarningsControllerTest` — asserts `coinDeltas` is included in the `EFFECTS_RESOLVED` payload.
- `./gradlew compileKotlin compileTestKotlin` and the earnings unit tests pass.

## Wire contract

`coinDeltas` is keyed by **player ID** (same ID space as `accuserPlayerId`, `playerCards`, etc.), serialized as JSON object string keys. Empty map when no balances changed.
