### PR TITLE
Optimize Railway deployment: JVM heap, health check, and dynamic port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,11 +27,17 @@ EXPOSE 8080
 FROM runtime-base AS runtime-from-workspace
 COPY --chown=app:app --from=packaged-jar /app.jar /app/app.jar
 USER app
+# Make the JVM container-memory-aware: default heap is only ~25% of the
+# container limit, which wastes most of the platform's RAM (e.g. on Railway).
+ENV JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=75.0"
 ENTRYPOINT ["java", "-jar", "app.jar"]
 
 FROM runtime-base AS runtime-from-builder
 COPY --chown=app:app --from=builder /app/build/libs/*.jar /app/app.jar
 USER app
+# Make the JVM container-memory-aware: default heap is only ~25% of the
+# container limit, which wastes most of the platform's RAM (e.g. on Railway).
+ENV JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=75.0"
 ENTRYPOINT ["java", "-jar", "app.jar"]
 
 FROM runtime-from-builder AS final

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,20 +24,38 @@ RUN apt-get update \
 RUN groupadd --system app && useradd --no-log-init --system --create-home --home-dir /app --gid app app
 EXPOSE 8080
 
+# Explode the layered bootJar so Docker can cache slow-changing layers
+# (dependencies) separately from fast-changing ones (application code).
+FROM runtime-base AS extract-from-workspace
+COPY --from=packaged-jar /app.jar /app/app.jar
+RUN java -Djarmode=tools -jar /app/app.jar extract --layers --launcher --destination /app/extracted
+
+FROM runtime-base AS extract-from-builder
+COPY --from=builder /app/build/libs/*.jar /app/app.jar
+RUN java -Djarmode=tools -jar /app/app.jar extract --layers --launcher --destination /app/extracted
+
 FROM runtime-base AS runtime-from-workspace
-COPY --chown=app:app --from=packaged-jar /app.jar /app/app.jar
-USER app
 # Make the JVM container-memory-aware: default heap is only ~25% of the
 # container limit, which wastes most of the platform's RAM (e.g. on Railway).
 ENV JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=75.0"
-ENTRYPOINT ["java", "-jar", "app.jar"]
+# Copy layers least-to-most likely to change so the cache survives code-only rebuilds.
+COPY --chown=app:app --from=extract-from-workspace /app/extracted/dependencies/ ./
+COPY --chown=app:app --from=extract-from-workspace /app/extracted/spring-boot-loader/ ./
+COPY --chown=app:app --from=extract-from-workspace /app/extracted/snapshot-dependencies/ ./
+COPY --chown=app:app --from=extract-from-workspace /app/extracted/application/ ./
+USER app
+ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]
 
 FROM runtime-base AS runtime-from-builder
-COPY --chown=app:app --from=builder /app/build/libs/*.jar /app/app.jar
-USER app
 # Make the JVM container-memory-aware: default heap is only ~25% of the
 # container limit, which wastes most of the platform's RAM (e.g. on Railway).
 ENV JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=75.0"
-ENTRYPOINT ["java", "-jar", "app.jar"]
+# Copy layers least-to-most likely to change so the cache survives code-only rebuilds.
+COPY --chown=app:app --from=extract-from-builder /app/extracted/dependencies/ ./
+COPY --chown=app:app --from=extract-from-builder /app/extracted/spring-boot-loader/ ./
+COPY --chown=app:app --from=extract-from-builder /app/extracted/snapshot-dependencies/ ./
+COPY --chown=app:app --from=extract-from-builder /app/extracted/application/ ./
+USER app
+ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]
 
 FROM runtime-from-builder AS final

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ GET http://localhost:8080/actuator/health
 
 ## Deployment
 
-The server is deployed to **Railway** (`https://railway.app`), a cloud platform that runs Docker containers and manages PostgreSQL databases automatically. The production backend automatically pulls the latest image from the GitHub Container Registry (GHCR) on every push to `main`.
+The server is deployed to **Railway** (`https://railway.app`), a cloud platform that runs Docker containers and manages PostgreSQL databases automatically. Railway is connected to this GitHub repository and **builds the backend from the `Dockerfile`** on every push to `main` — the deploy configuration is codified in [`railway.toml`](railway.toml) (`builder = "DOCKERFILE"`). The separate GHCR publish workflow (below) still runs to produce versioned, multi-arch images for rollback and other consumers, but Railway does **not** pull those images.
 
 Previously deployed to the AAU shared infrastructure (`se2-demo.aau.at`, group 6) via
 [doco-cd](https://github.com/kimdre/doco-cd) — see [Legacy AAU Deployment](#legacy-aau-deployment) below for historical reference.
@@ -353,31 +353,31 @@ Previously deployed to the AAU shared infrastructure (`se2-demo.aau.at`, group 6
 
 ```mermaid
 flowchart LR
-    Push(Push to main) --> Action[GitHub Actions CI/CD]
-    Action --> Test[Build & Test]
-    Action --> Docker[Build Multi-Arch Docker Image]
-    Docker --> GHCR[(GHCR Image Registry)]
-    GHCR --> Railway[Railway Platform]
-    Railway --> Backend[Machi Koro Backend]
+    Push(Push to main) --> Railway[Railway Platform]
+    Railway --> Build[Build from Dockerfile]
+    Build --> Backend[Machi Koro Backend]
     Railway --> DB[(PostgreSQL)]
+    Push -. parallel .-> Action[GitHub Actions]
+    Action --> GHCR[(GHCR Image Registry<br/>rollback / other consumers)]
 ```
 
-1. A push to `main` triggers the [`Publish Docker image to GHCR`](.github/workflows/docker-publish.yml) workflow.
-2. The workflow first runs a `build-jar` job on `ubuntu-latest`, sets up JDK 21 with Gradle dependency caching, and executes `./gradlew bootJar -x test` exactly once. The resulting application jar is uploaded as a short-lived workflow artifact.
-3. The `build-and-push` job downloads that artifact and uses Docker Buildx to package and push the multi-architecture runtime image for `linux/amd64` and `linux/arm64` without recompiling the application per architecture.
-4. The published image is pushed to `ghcr.io/se2-machi-koro/server` with the tags:
-   - `latest` (only on `main`)
-   - `sha-<short-commit>` (every build, used for rollback)
-   - `v*` (when a Git tag matching `v*` is pushed)
-5. Railway detects the new image (via pull_policy: always) and automatically redeploys the backend service.
-6. The PostgreSQL database and backend run together in Railway; the backend is published on Railway's auto-generated HTTPS domain.
+1. A push to `main` triggers a Railway deploy. Railway builds the backend directly from the [`Dockerfile`](Dockerfile) (`builder = "DOCKERFILE"` in [`railway.toml`](railway.toml)); with no target override it builds the `final` stage (`runtime-from-builder`), which compiles the jar from source inside the image.
+2. Railway runs the new container, waits for the `healthcheckPath` (`/actuator/health`) to pass, then cuts over traffic. On failure it applies the `ON_FAILURE` restart policy (up to 10 retries).
+3. The PostgreSQL database and backend run together in Railway; the backend is published on Railway's auto-generated HTTPS domain.
+
+In parallel — and independently of the Railway deploy — the [`Publish Docker image to GHCR`](.github/workflows/docker-publish.yml) workflow builds and pushes a versioned, multi-arch image (`linux/amd64`, `linux/arm64`) to `ghcr.io/se2-machi-koro/server` with the tags:
+- `latest` (only on `main`)
+- `sha-<short-commit>` (every build, used for rollback)
+- `v*` (when a Git tag matching `v*` is pushed)
+
+These images are for rollback and other consumers; Railway does not pull them.
 
 ### Setting up Railway (First Time)
 
 1. Go to [railway.app](https://railway.app) and sign up with your GitHub account.
 2. Create a new project.
 3. Add a PostgreSQL database to the project (Railway provides automatic hosting and backup).
-4. Create an empty service and deploy from Docker image: `ghcr.io/se2-machi-koro/server:latest`
+4. Create a service connected to this GitHub repository. The committed [`railway.toml`](railway.toml) tells Railway to build from the `Dockerfile`, so no manual build settings are needed.
 5. In the backend service settings, configure the following environment variables:
    ```
    DB_HOST=${{Postgres.PGHOST}}
@@ -385,12 +385,12 @@ flowchart LR
    DB_NAME=${{Postgres.PGDATABASE}}
    DB_USERNAME=${{Postgres.PGUSER}}
    DB_PASSWORD=${{Postgres.PGPASSWORD}}
-   SERVER_PORT=8080
    SPRING_DOCKER_COMPOSE_ENABLED=false
    WEBSOCKET_ALLOWED_ORIGINS=<your-railway-domain>
    DEBUG_ENABLED=false
    ADMIN_PASSWORD=
    ```
+   The app binds to Railway's injected `PORT` automatically (falling back to `SERVER_PORT`, then `8080`), so no port variable is required.
 6. Generate a public domain in the networking settings and update `WEBSOCKET_ALLOWED_ORIGINS` with that domain.
 7. The backend is now live and will auto-update on every push to `main`.
 

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,15 @@
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "/Dockerfile"
+buildEnvironment = "V3"
+
+[deploy]
+runtime = "V2"
+numReplicas = 1
+healthcheckPath = "/actuator/health"
+sleepApplication = false
+useLegacyStacker = false
+ipv6EgressEnabled = false
+multiRegionConfig = {"europe-west4-drams3a":{"numReplicas":1}}
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,7 @@
 spring.application.name=server
-spring.docker.compose.enabled=true
+# Docker Compose support is a local-dev convenience (auto-starts the dev DB).
+# Defaults to true for local runs; production (e.g. Railway) sets it to false.
+spring.docker.compose.enabled=${SPRING_DOCKER_COMPOSE_ENABLED:true}
 spring.docker.compose.file=compose-dev.yaml
 
 # Bind to the platform-injected PORT (e.g. Railway) when present, else SERVER_PORT, else 8080.
@@ -29,7 +31,7 @@ management.endpoint.health.show-details=when-authorized
 spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration
 spring.flyway.baseline-on-migrate=true
-logging.level.org.flywaydb=DEBUG
+logging.level.org.flywaydb=INFO
 
 # Springwolf
 springwolf.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,8 @@ spring.application.name=server
 spring.docker.compose.enabled=true
 spring.docker.compose.file=compose-dev.yaml
 
-server.port=${SERVER_PORT:8080}
+# Bind to the platform-injected PORT (e.g. Railway) when present, else SERVER_PORT, else 8080.
+server.port=${PORT:${SERVER_PORT:8080}}
 
 # Swagger/Open API documentation
 springdoc.api-docs.path=/api-docs


### PR DESCRIPTION
Closes #415.

This PR addresses **all** items from #415 — the three Railway-readiness fixes and the three cleanups.

## Railway readiness

- **JVM heap (Dockerfile)** — `ENV JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=75.0"` on both runtime stages. The default container heap is only ~25% of the limit, leaving most of the platform's RAM unused.
- **Dynamic port (`application.properties`)** — `server.port` now resolves `${PORT:${SERVER_PORT:8080}}`, honoring Railway's injected `PORT` with `SERVER_PORT` then `8080` as fallbacks.
- **Deploy config (`railway.toml`)** — codified in-repo: `DOCKERFILE` builder, `healthcheckPath=/actuator/health`, `ON_FAILURE` restart policy (10 retries). Previously lived only in the Railway dashboard.

## Cleanups

- **Layered Docker image (Dockerfile)** — explode the layered bootJar with the Spring Boot `tools` jarmode and copy layers in least-to-most-likely-to-change order (`dependencies` → `spring-boot-loader` → `snapshot-dependencies` → `application`), launching via `JarLauncher`. Docker now reuses the heavy dependency layer on code-only rebuilds, speeding up Railway builds.
- **Docker Compose flag (`application.properties`)** — `spring.docker.compose.enabled` is now env-driven (`${SPRING_DOCKER_COMPOSE_ENABLED:true}`): defaults to `true` for local dev convenience, production sets it `false`. Makes the override point explicit.
- **Flyway logging (`application.properties`)** — lowered from `DEBUG` to `INFO` to quiet production logs.

## README

Corrected the Deployment section: Railway **builds from the `Dockerfile`** (per `railway.toml`); it does **not** pull the GHCR image as previously documented. The GHCR publish workflow still runs in parallel for versioned/rollback images.

## Verification

- Built the `runtime-from-workspace` image locally and ran it: image builds clean, app boots via `JarLauncher` (`LaunchedClassLoader`), Tomcat starts on 8080, `JAVA_TOOL_OPTIONS` is picked up, and it runs as the non-root `app` user. (Boot proceeds to the DB connection, as expected without a database.)
- Other changes are config/docs only — no Kotlin touched.

## Reviewer notes

- `railway.toml` mirrors exactly what the Railway dashboard generated.
- Spring Boot 4.0 uses the `tools` jarmode (`extract --layers --launcher`) and the `org.springframework.boot.loader.launch.JarLauncher` entry point — both verified against the built jar.
