### PR TITLE
fix(#421): remove dead ensureSenderOwnsPlayer and phantom /game.leave

### DIFF
--- a/src/main/kotlin/org/machikoro/server/service/GameStateGuard.kt
+++ b/src/main/kotlin/org/machikoro/server/service/GameStateGuard.kt
@@ -87,26 +87,4 @@ class GameStateGuard(
         return active
     }
 
-    /**
-     * Verifies that [user] owns the player identified by [playerId] within
-     * [gameId]. Used for `/game.leave` so a user can only remove their own seat
-     * from a finished game, not another player's.
-     *
-     * Throws [CustomWebSocketException] with one of:
-     *  - `PLAYER_NOT_IN_GAME`  — [playerId] does not exist in [gameId].
-     *  - `NOT_YOUR_PLAYER`     — caller is authenticated but does not own the player.
-     */
-    fun ensureSenderOwnsPlayer(gameId: Int, playerId: Int, user: UserPrincipal) {
-        val player = playerDao.getPlayers(gameId).firstOrNull { it.id == playerId }
-            ?: throw CustomWebSocketException(
-                errorCode = "PLAYER_NOT_IN_GAME",
-                message = "Player $playerId is not in game $gameId",
-            )
-        if (player.userId != user.userId) {
-            throw CustomWebSocketException(
-                errorCode = "NOT_YOUR_PLAYER",
-                message = "You do not own player $playerId",
-            )
-        }
-    }
 }

--- a/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/GameControllerTest.kt
@@ -671,7 +671,6 @@ class GameControllerTest {
         assertEquals(1, actionPayload["roundNumber"])
         assertEquals(snapshot, actionPayload["state"])
         verify(diceService).rollDice(request, activePlayer.id)
-        verify(gameStateGuard, never()).ensureSenderOwnsPlayer(any(), any(), any())
     }
 
     @Test
@@ -687,7 +686,6 @@ class GameControllerTest {
         }
         assertEquals("dice exploded", ex.message)
         verify(diceService).rollDice(request, activePlayer.id)
-        verify(gameStateGuard, never()).ensureSenderOwnsPlayer(any(), any(), any())
         verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
     }
 
@@ -712,7 +710,6 @@ class GameControllerTest {
         assertEquals("Dice have already been rolled for this turn", payload.message)
         assertEquals("ROLL_FAILED", payload.context["event"])
         verify(diceService).rollDice(request, activePlayer.id)
-        verify(gameStateGuard, never()).ensureSenderOwnsPlayer(any(), any(), any())
     }
 
     @Test
@@ -796,7 +793,6 @@ class GameControllerTest {
         assertEquals(true, actionPayload["completed"])
         assertEquals(snapshot, actionPayload["state"])
         verify(diceService).rerollDice(request, activePlayer.id)
-        verify(gameStateGuard, never()).ensureSenderOwnsPlayer(any(), any(), any())
     }
 
     @Test
@@ -813,7 +809,6 @@ class GameControllerTest {
 
         assertEquals("dice exploded", ex.message)
         verify(diceService).rerollDice(request, activePlayer.id)
-        verify(gameStateGuard, never()).ensureSenderOwnsPlayer(any(), any(), any())
         verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
     }
 
@@ -838,7 +833,6 @@ class GameControllerTest {
         assertEquals("Dice have already been rerolled for this turn", payload.message)
         assertEquals("REROLL_FAILED", payload.context["event"])
         verify(diceService).rerollDice(request, activePlayer.id)
-        verify(gameStateGuard, never()).ensureSenderOwnsPlayer(any(), any(), any())
     }
 
     @Test
@@ -879,7 +873,6 @@ class GameControllerTest {
         val ex = assertThrows<CustomWebSocketException> { call(unauthed) }
         assertEquals("UNAUTHENTICATED", ex.errorCode)
         verify(gameStateGuard, never()).ensureSenderIsActivePlayer(any(), any())
-        verify(gameStateGuard, never()).ensureSenderOwnsPlayer(any(), any(), any())
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/service/GameStateGuardTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GameStateGuardTest.kt
@@ -217,46 +217,4 @@ class GameStateGuardTest {
         assertEquals("GAME_NOT_STARTED", ex.errorCode)
     }
 
-    // ── ensureSenderOwnsPlayer ────────────────────────────────────────────────
-
-    @Test
-    fun `ensureSenderOwnsPlayer succeeds when caller owns the player`() {
-        val gameId = 1
-        val playerId = 10
-        whenever(playerDao.getPlayers(gameId)).thenReturn(
-            listOf(player(id = playerId, userId = 7), player(id = 11, userId = 8, turnOrder = 1)),
-        )
-        val user = UserPrincipal(userId = 7, username = "alice")
-
-        guard.ensureSenderOwnsPlayer(gameId, playerId, user)
-    }
-
-    @Test
-    fun `ensureSenderOwnsPlayer throws NOT_YOUR_PLAYER when player belongs to a different user`() {
-        val gameId = 1
-        val playerId = 10
-        whenever(playerDao.getPlayers(gameId)).thenReturn(
-            listOf(player(id = playerId, userId = 7), player(id = 11, userId = 8, turnOrder = 1)),
-        )
-        val user = UserPrincipal(userId = 8, username = "bob")
-
-        val ex = assertThrows(CustomWebSocketException::class.java) {
-            guard.ensureSenderOwnsPlayer(gameId, playerId, user)
-        }
-        assertEquals("NOT_YOUR_PLAYER", ex.errorCode)
-    }
-
-    @Test
-    fun `ensureSenderOwnsPlayer throws PLAYER_NOT_IN_GAME when playerId is not part of this game`() {
-        val gameId = 1
-        whenever(playerDao.getPlayers(gameId)).thenReturn(
-            listOf(player(id = 11, userId = 8, turnOrder = 1)),
-        )
-        val user = UserPrincipal(userId = 7, username = "alice")
-
-        val ex = assertThrows(CustomWebSocketException::class.java) {
-            guard.ensureSenderOwnsPlayer(gameId, playerId = 99, user)
-        }
-        assertEquals("PLAYER_NOT_IN_GAME", ex.errorCode)
-    }
 }


### PR DESCRIPTION
Closes #421

## Summary
- Remove `ensureSenderOwnsPlayer` from `GameStateGuard.kt` — the `/game.leave` feature was dropped and players cannot rejoin a finished lobby
- Remove its 3 unit tests from `GameStateGuardTest.kt`
- Remove 7 `verify(gameStateGuard, never()).ensureSenderOwnsPlayer(...)` assertions from `GameControllerTest.kt`

## Test plan
- [x] Existing test suite passes (`./gradlew test`)
- [x] No references to `ensureSenderOwnsPlayer` remain in the codebase