### PR TITLE
fix(#427): register WebSocket exception handler as @ControllerAdvice

### DIFF
--- a/src/main/kotlin/org/machikoro/server/handler/GlobalWebSocketExceptionHandler.kt
+++ b/src/main/kotlin/org/machikoro/server/handler/GlobalWebSocketExceptionHandler.kt
@@ -4,7 +4,8 @@ import org.machikoro.server.dto.WebSocketErrorDto
 import org.machikoro.server.exception.CustomWebSocketException
 import org.slf4j.LoggerFactory
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler
-import org.springframework.messaging.simp.annotation.SendToUser
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor
+import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.web.bind.annotation.ControllerAdvice
 
 /**
@@ -16,22 +17,51 @@ import org.springframework.web.bind.annotation.ControllerAdvice
  * methods, these handlers caught nothing — domain exceptions were logged at
  * ERROR with a stack trace by Spring's fallback and the error reply never
  * reached the client. See issue #427.
+ *
+ * The error frame is sent to the caller's session-scoped queue directly rather
+ * than via `@SendToUser`. `@SendToUser` resolves the target through the
+ * `SimpUserRegistry`, which this app does not populate — it authenticates with a
+ * token in the STOMP CONNECT body instead of Spring Security — so the resolver
+ * would find no sessions and silently drop the reply. Targeting
+ * `/queue/errors-user{sessionId}` (the destination Spring rewrites a
+ * `/user/queue/errors` subscription to) sidesteps the registry, mirroring
+ * [org.machikoro.server.controller.WebSocketController.publishSync].
  */
 @ControllerAdvice
-class GlobalWebSocketExceptionHandler {
+class GlobalWebSocketExceptionHandler(
+    private val messagingTemplate: SimpMessagingTemplate,
+) {
     private val logger = LoggerFactory.getLogger(GlobalWebSocketExceptionHandler::class.java)
 
     @MessageExceptionHandler(CustomWebSocketException::class)
-    @SendToUser("/queue/errors", broadcast = false)
-    fun handleCustomException(ex: CustomWebSocketException): WebSocketErrorDto {
+    fun handleCustomException(ex: CustomWebSocketException, headerAccessor: SimpMessageHeaderAccessor) {
         logger.warn("Handled WebSocket exception [{}]: {}", ex.errorCode, ex.message)
-        return WebSocketErrorDto.from(ex)
+        sendError(headerAccessor.sessionId, WebSocketErrorDto.from(ex))
     }
 
     @MessageExceptionHandler(Exception::class)
-    @SendToUser("/queue/errors", broadcast = false)
-    fun handleGenericException(ex: Exception): WebSocketErrorDto {
+    fun handleGenericException(ex: Exception, headerAccessor: SimpMessageHeaderAccessor) {
         logger.error("Unhandled WebSocket exception", ex)
-        return WebSocketErrorDto.internal()
+        sendError(headerAccessor.sessionId, WebSocketErrorDto.internal())
+    }
+
+    /**
+     * Delivers [dto] to the originating session's private error queue. No-op when
+     * the session id is absent (e.g. the exception did not originate from a client
+     * frame), since there is no session to reply to.
+     */
+    private fun sendError(sessionId: String?, dto: WebSocketErrorDto) {
+        if (sessionId == null) {
+            logger.warn("Dropping WebSocket error [{}]: no session id on the originating message", dto.code)
+            return
+        }
+        messagingTemplate.convertAndSend(sessionScopedErrorDestination(sessionId), dto)
+    }
+
+    private fun sessionScopedErrorDestination(sessionId: String): String =
+        "$USER_ERROR_QUEUE-user$sessionId"
+
+    private companion object {
+        private const val USER_ERROR_QUEUE = "/queue/errors"
     }
 }

--- a/src/main/kotlin/org/machikoro/server/handler/GlobalWebSocketExceptionHandler.kt
+++ b/src/main/kotlin/org/machikoro/server/handler/GlobalWebSocketExceptionHandler.kt
@@ -5,9 +5,19 @@ import org.machikoro.server.exception.CustomWebSocketException
 import org.slf4j.LoggerFactory
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler
 import org.springframework.messaging.simp.annotation.SendToUser
-import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.ControllerAdvice
 
-@Controller
+/**
+ * Global handler for exceptions thrown by `@MessageMapping` controllers.
+ *
+ * Must be `@ControllerAdvice` (not `@Controller`): Spring only applies
+ * `@MessageExceptionHandler` methods across other controllers when the bean is
+ * registered as advice. As a plain `@Controller` with no `@MessageMapping`
+ * methods, these handlers caught nothing — domain exceptions were logged at
+ * ERROR with a stack trace by Spring's fallback and the error reply never
+ * reached the client. See issue #427.
+ */
+@ControllerAdvice
 class GlobalWebSocketExceptionHandler {
     private val logger = LoggerFactory.getLogger(GlobalWebSocketExceptionHandler::class.java)
 

--- a/src/test/kotlin/org/machikoro/server/controller/RestErrorHandlingRegressionTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/RestErrorHandlingRegressionTest.kt
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.http.MediaType
+import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
@@ -60,6 +61,9 @@ class RestErrorHandlingRegressionTest {
 
     @MockitoBean
     private lateinit var userDao: UserDao
+
+    @MockitoBean
+    private lateinit var messagingTemplate: SimpMessagingTemplate
 
     @Test
     fun `login failure returns structured credentials error without account details`() {

--- a/src/test/kotlin/org/machikoro/server/handler/GlobalWebSocketExceptionHandlerTests.kt
+++ b/src/test/kotlin/org/machikoro/server/handler/GlobalWebSocketExceptionHandlerTests.kt
@@ -5,10 +5,22 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.machikoro.server.exception.CustomWebSocketException
+import org.springframework.web.bind.annotation.ControllerAdvice
 
 class GlobalWebSocketExceptionHandlerTests {
 
     private val handler = GlobalWebSocketExceptionHandler()
+
+    @Test
+    fun shouldBeRegisteredAsControllerAdviceSoHandlersApplyGlobally() {
+        // Regression guard for #427: as a plain @Controller, the
+        // @MessageExceptionHandler methods are scoped to this bean only and
+        // never catch exceptions from other @MessageMapping controllers.
+        assertTrue(
+            GlobalWebSocketExceptionHandler::class.java.isAnnotationPresent(ControllerAdvice::class.java),
+            "GlobalWebSocketExceptionHandler must be @ControllerAdvice for its handlers to apply globally",
+        )
+    }
 
     @Test
     fun handleCustomExceptionShouldReturnDomainErrorPayload() {

--- a/src/test/kotlin/org/machikoro/server/handler/GlobalWebSocketExceptionHandlerTests.kt
+++ b/src/test/kotlin/org/machikoro/server/handler/GlobalWebSocketExceptionHandlerTests.kt
@@ -1,15 +1,21 @@
 package org.machikoro.server.handler
 
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.machikoro.server.dto.WebSocketErrorDto
 import org.machikoro.server.exception.CustomWebSocketException
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor
+import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.web.bind.annotation.ControllerAdvice
 
 class GlobalWebSocketExceptionHandlerTests {
 
-    private val handler = GlobalWebSocketExceptionHandler()
+    private val messagingTemplate = mock<SimpMessagingTemplate>()
+    private val handler = GlobalWebSocketExceptionHandler(messagingTemplate)
 
     @Test
     fun shouldBeRegisteredAsControllerAdviceSoHandlersApplyGlobally() {
@@ -23,33 +29,52 @@ class GlobalWebSocketExceptionHandlerTests {
     }
 
     @Test
-    fun handleCustomExceptionShouldReturnDomainErrorPayload() {
+    fun handleCustomExceptionSendsDomainErrorToCallersSessionQueue() {
         val exception = CustomWebSocketException(
             errorCode = "INVALID_MESSAGE",
-            message = "Message content cannot be empty"
+            message = "Message content cannot be empty",
         )
 
-        val start = System.currentTimeMillis()
-        val response = handler.handleCustomException(exception)
-        val end = System.currentTimeMillis()
+        handler.handleCustomException(exception, accessorFor("sess-123"))
 
-        assertEquals("INVALID_MESSAGE", response.code)
-        assertEquals("Message content cannot be empty", response.message)
-        assertTrue(response.timestamp in start..end)
+        val payload = captureSentPayload("/queue/errors-usersess-123")
+        assertEquals("INVALID_MESSAGE", payload.code)
+        assertEquals("Message content cannot be empty", payload.message)
     }
 
     @Test
-    fun handleGenericExceptionShouldReturnInternalErrorPayload() {
+    fun handleGenericExceptionSendsSanitizedInternalErrorToCallersSessionQueue() {
         val exception = IllegalStateException("jdbc:postgresql://prod.internal password=secret")
 
-        val start = System.currentTimeMillis()
-        val response = handler.handleGenericException(exception)
-        val end = System.currentTimeMillis()
+        handler.handleGenericException(exception, accessorFor("sess-999"))
 
-        assertEquals("INTERNAL_ERROR", response.code)
-        assertEquals("Unexpected error while processing WebSocket message", response.message)
-        assertFalse(response.message.contains("prod.internal"))
-        assertFalse(response.message.contains("password=secret"))
-        assertTrue(response.timestamp in start..end)
+        val payload = captureSentPayload("/queue/errors-usersess-999")
+        assertEquals("INTERNAL_ERROR", payload.code)
+        assertEquals("Unexpected error while processing WebSocket message", payload.message)
+        assertTrue(!payload.message.contains("prod.internal"))
+        assertTrue(!payload.message.contains("password=secret"))
+    }
+
+    @Test
+    fun handleCustomExceptionWithoutSessionIdDoesNotSend() {
+        val exception = CustomWebSocketException(errorCode = "NO_SESSION", message = "no session")
+
+        handler.handleCustomException(exception, accessorFor(sessionId = null))
+
+        verify(messagingTemplate, org.mockito.kotlin.never()).convertAndSend(
+            org.mockito.kotlin.any<String>(),
+            org.mockito.kotlin.any<Any>(),
+        )
+    }
+
+    private fun accessorFor(sessionId: String?): SimpMessageHeaderAccessor =
+        SimpMessageHeaderAccessor.create().apply { this.sessionId = sessionId }
+
+    private fun captureSentPayload(expectedDestination: String): WebSocketErrorDto {
+        val destinationCaptor = argumentCaptor<String>()
+        val payloadCaptor = argumentCaptor<WebSocketErrorDto>()
+        verify(messagingTemplate).convertAndSend(destinationCaptor.capture(), payloadCaptor.capture())
+        assertEquals(expectedDestination, destinationCaptor.firstValue)
+        return payloadCaptor.firstValue
     }
 }

--- a/src/test/kotlin/org/machikoro/server/handler/WebSocketExceptionAdviceIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/handler/WebSocketExceptionAdviceIntegrationTest.kt
@@ -1,0 +1,220 @@
+package org.machikoro.server.handler
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.machikoro.server.auth.UserPrincipal
+import org.machikoro.server.dao.UserDao
+import org.machikoro.server.domain.models.UserModel
+import org.machikoro.server.exception.CustomWebSocketException
+import org.machikoro.server.service.AccusationService
+import org.machikoro.server.service.DiceService
+import org.machikoro.server.service.GamePhaseService
+import org.machikoro.server.service.GameStateGuard
+import org.machikoro.server.service.GameSyncService
+import org.machikoro.server.service.LobbyService
+import org.machikoro.server.service.PurchaseService
+import org.machikoro.server.service.interfaces.EarningsService
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.messaging.converter.MappingJackson2MessageConverter
+import org.springframework.messaging.simp.stomp.StompFrameHandler
+import org.springframework.messaging.simp.stomp.StompHeaders
+import org.springframework.messaging.simp.stomp.StompSession
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.util.MimeTypeUtils
+import org.springframework.web.socket.WebSocketHttpHeaders
+import org.springframework.web.socket.client.standard.StandardWebSocketClient
+import org.springframework.web.socket.messaging.WebSocketStompClient
+import java.lang.reflect.Type
+import java.util.UUID
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+
+/**
+ * End-to-end proof for #427: a [CustomWebSocketException] thrown by a
+ * `@MessageMapping` handler must be caught by [GlobalWebSocketExceptionHandler]
+ * (registered as `@ControllerAdvice`) and delivered to the originating client on
+ * its user-scoped `/queue/errors` destination.
+ *
+ * Before the fix the handler was a plain `@Controller`, so its
+ * `@MessageExceptionHandler` methods applied to nothing: the exception was
+ * logged as unhandled and no error frame reached the client — this test would
+ * time out waiting for the frame.
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = [
+        "spring.docker.compose.enabled=false",
+        "spring.flyway.enabled=false",
+        "machikoro.db.init.enabled=false",
+        "spring.autoconfigure.exclude=org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration",
+    ],
+)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class WebSocketExceptionAdviceIntegrationTest {
+    private companion object {
+        private const val ERROR_TIMEOUT_SECONDS = 20L
+        private const val RESEND_POLL_MILLIS = 500L
+        private const val USER_ERROR_QUEUE = "/user/queue/errors"
+    }
+
+    @LocalServerPort
+    private var port: Int = 0
+
+    @Autowired
+    private lateinit var mapper: ObjectMapper
+
+    private val activeSessions = mutableListOf<StompSession>()
+
+    // Mocked so a CONNECT can authenticate without a database.
+    @MockitoBean
+    private lateinit var userDao: UserDao
+
+    // Mocked so endTurn deterministically rejects the caller as a non-active player.
+    @MockitoBean
+    private lateinit var gameStateGuard: GameStateGuard
+
+    // Remaining controller collaborators that would otherwise touch the (excluded)
+    // DataSource at runtime; mocked so the context loads, mirroring the broadcast IT.
+    @MockitoBean
+    private lateinit var lobbyService: LobbyService
+
+    @MockitoBean
+    private lateinit var gamePhaseService: GamePhaseService
+
+    @MockitoBean
+    private lateinit var gameSyncService: GameSyncService
+
+    @MockitoBean
+    private lateinit var purchaseService: PurchaseService
+
+    @MockitoBean
+    private lateinit var diceService: DiceService
+
+    @MockitoBean
+    private lateinit var earningsService: EarningsService
+
+    @MockitoBean
+    private lateinit var accusationService: AccusationService
+
+    @AfterEach
+    fun disconnectSessions() {
+        activeSessions.filter { it.isConnected }.forEach(StompSession::disconnect)
+        activeSessions.clear()
+    }
+
+    @Test
+    fun `not-your-turn is delivered to the caller's user error queue`() {
+        val suffix = UUID.randomUUID().toString().replace("-", "").take(10)
+        val token = "tok-$suffix"
+        val username = "ws_user_$suffix"
+        val userId = 909
+        val gameId = 404
+
+        whenever(userDao.findBySessionToken(token)).thenReturn(user(userId, username, token))
+        whenever(gameStateGuard.ensureSenderIsActivePlayer(eq(gameId), any<UserPrincipal>()))
+            .thenThrow(CustomWebSocketException(errorCode = "NOT_YOUR_TURN", message = "It is not your turn"))
+
+        val session = connect(token)
+        val errorQueue = LinkedBlockingQueue<JsonNode>()
+        // The handler replies to the session-scoped destination that Spring
+        // rewrites this `/user/queue/errors` subscription to.
+        session.subscribe(USER_ERROR_QUEUE, queueHandler(errorQueue))
+
+        val error = sendEndTurnUntilErrorReceived(session, gameId, errorQueue)
+        assertEquals("NOT_YOUR_TURN", error["code"].asText())
+        assertEquals("It is not your turn", error["message"].asText())
+    }
+
+    private fun connect(sessionToken: String): StompSession {
+        val connectHeaders = StompHeaders().apply {
+            add("Authorization", "Bearer $sessionToken")
+        }
+        return stompClient()
+            .connectAsync(
+                "ws://localhost:$port/ws",
+                WebSocketHttpHeaders(),
+                connectHeaders,
+                object : StompSessionHandlerAdapter() {},
+            )
+            .get(10, TimeUnit.SECONDS)
+            .also(activeSessions::add)
+    }
+
+    private fun stompClient(): WebSocketStompClient =
+        WebSocketStompClient(StandardWebSocketClient()).apply {
+            messageConverter = MappingJackson2MessageConverter().apply {
+                objectMapper = mapper
+            }
+        }
+
+    private fun queueHandler(queue: BlockingQueue<JsonNode>): StompFrameHandler =
+        object : StompFrameHandler {
+            override fun getPayloadType(headers: StompHeaders): Type = JsonNode::class.java
+
+            override fun handleFrame(headers: StompHeaders, payload: Any?) {
+                queue.offer(payload as JsonNode)
+            }
+        }
+
+    private fun sendJson(session: StompSession, destination: String, value: Any) {
+        val headers = StompHeaders().apply {
+            this.destination = destination
+            contentType = MimeTypeUtils.APPLICATION_JSON
+        }
+        session.send(headers, value)
+    }
+
+    /**
+     * Sends `/app/game.endTurn` (which the stubbed guard always rejects) and waits
+     * for the resulting error frame on the caller's user queue, resending on a
+     * short interval until one arrives.
+     *
+     * Resending defeats the STOMP subscription race: a subscription registers
+     * asynchronously, and the broker silently drops a reply sent before it is
+     * live. Each send re-exercises the real production path — handler throws →
+     * `@ControllerAdvice` catches → `@SendToUser` replies to this session — so the
+     * first frame received proves the advice is wired in.
+     */
+    private fun sendEndTurnUntilErrorReceived(
+        session: StompSession,
+        gameId: Int,
+        queue: BlockingQueue<JsonNode>,
+    ): JsonNode {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(ERROR_TIMEOUT_SECONDS)
+        while (System.nanoTime() < deadline) {
+            sendJson(session, "/app/game.endTurn", mapOf("gameId" to gameId))
+
+            val pollDeadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(RESEND_POLL_MILLIS)
+            while (System.nanoTime() < pollDeadline) {
+                val remaining = pollDeadline - System.nanoTime()
+                val message = queue.poll(remaining, TimeUnit.NANOSECONDS) ?: break
+                if (message.hasNonNull("code")) {
+                    return message
+                }
+            }
+        }
+        error("Timed out waiting for an error frame on $USER_ERROR_QUEUE")
+    }
+
+    private fun user(userId: Int, username: String, token: String): UserModel =
+        UserModel(
+            id = userId,
+            username = username,
+            passwordHash = null,
+            sessionToken = token,
+            totalWins = 0,
+            totalGamesPlayed = 0,
+            isAdmin = false,
+        )
+}

--- a/src/test/kotlin/org/machikoro/server/handler/WebSocketExceptionAdviceIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/handler/WebSocketExceptionAdviceIntegrationTest.kt
@@ -183,7 +183,7 @@ class WebSocketExceptionAdviceIntegrationTest {
      * Resending defeats the STOMP subscription race: a subscription registers
      * asynchronously, and the broker silently drops a reply sent before it is
      * live. Each send re-exercises the real production path — handler throws →
-     * `@ControllerAdvice` catches → `@SendToUser` replies to this session — so the
+     * `@ControllerAdvice` catches → session-scoped send replies to this session — so the
      * first frame received proves the advice is wired in.
      */
     private fun sendEndTurnUntilErrorReceived(


### PR DESCRIPTION
## What & why

WebSocket domain errors (e.g. `NOT_YOUR_TURN`) were both **mislogged** and **never delivered to the client**. Two distinct root causes, fixed here in sequence:

### 1. The handler wasn't wired in (`@Controller` → `@ControllerAdvice`)

`GlobalWebSocketExceptionHandler` was `@Controller`. In Spring's messaging layer, `@MessageExceptionHandler` methods only handle exceptions from `@MessageMapping` methods **in the same bean** unless the bean is `@ControllerAdvice`. This bean has no `@MessageMapping` methods, so its handlers caught nothing — exceptions thrown by `GameController` etc. were treated as unhandled and logged at **ERROR with a full stack trace** by Spring's fallback (`WebSocketAnnotationMethodMessageHandler`). Mirrors the REST side, which already uses `@RestControllerAdvice`.

### 2. The reply was silently dropped (`@SendToUser` → session-scoped send)

Making the handler run surfaced a second bug: its `@SendToUser("/queue/errors")` reply went nowhere. `@SendToUser` resolves the target through Spring's `SimpUserRegistry`, which **this app does not populate** — it authenticates with a token in the STOMP CONNECT body, not Spring Security — so the resolver finds no sessions and drops the message. This is the same limitation `WebSocketController.publishSync` already works around for game-sync.

Fix: send the error frame to the session-scoped destination `/queue/errors-user{sessionId}` directly (the destination Spring rewrites a `/user/queue/errors` subscription to), reading the originating session id from the message. `SimpMessagingTemplate` is injected for this.

Fixes #427.

## Evidence (production logs, 2026-06-28)

```
ERROR ... .WebSocketAnnotationMethodMessageHandler : Unhandled exception from message handler method
org.machikoro.server.exception.CustomWebSocketException: It is not your turn
    at org.machikoro.server.service.GameStateGuard.ensureSenderIsActivePlayer(GameStateGuard.kt:82)
    at org.machikoro.server.controller.GameController.endTurn(GameController.kt:266)
```
During development I confirmed the fix end-to-end: with `@ControllerAdvice` the handler logs `WARN "Handled WebSocket exception [NOT_YOUR_TURN]"`, and with the session-scoped send the integration test receives the error frame on `/user/queue/errors` (both previously failed/were silent).

## Testing

- **New end-to-end integration test** `WebSocketExceptionAdviceIntegrationTest`: drives a real `WebSocketStompClient`, triggers `NOT_YOUR_TURN` via `/app/game.endTurn`, and asserts the `WebSocketErrorDto` (`code=NOT_YOUR_TURN`, `message="It is not your turn"`) arrives on the caller's `/user/queue/errors`. This test fails on `main` (no frame delivered) and passes here.
- **Handler unit tests** updated for the send-based behavior: assert the DTO is sent to `/queue/errors-user{sessionId}`, that the internal-error message is sanitized (no DB URL / password leak), that a missing session id is a no-op, and a regression guard asserting the `@ControllerAdvice` annotation.
- Re-ran `GameWebSocketBroadcastIntegrationTest` to confirm the now-active global handler does not disturb the existing purchase-rejection-to-topic broadcast path. All green.

## Scope

- Independent of #425 / PR #426 (WebSocket heartbeats); branched off `main`.
- The other secondary observation from PR #426 — duplicate sessions per user — is primarily client-side and intentionally **not** addressed here.
