### PR TITLE
fix: make WinConditionService.detectWinner phase-agnostic (#437)

### DIFF
--- a/src/main/kotlin/org/machikoro/server/service/WinConditionService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/WinConditionService.kt
@@ -5,7 +5,6 @@ import org.machikoro.server.dao.PlayerDao
 import org.machikoro.server.dao.PlayerLandmarkDao
 import org.machikoro.server.domain.enums.TurnPhase
 import org.machikoro.server.domain.models.PlayerModel
-import org.machikoro.server.exception.CustomWebSocketException
 import org.machikoro.server.exception.GameNotFoundException
 import org.springframework.stereotype.Service
 
@@ -20,17 +19,17 @@ class WinConditionService(
     private fun hasPlayerWon(playerId: Int): Boolean =
         playerLandmarkDao.allBuilt(playerId)
 
-    /** Returns the winner in the given game, or null if nobody has won yet. */
+    /**
+     * Returns the winner in the given game, or null if nobody has won yet.
+     *
+     * This check is phase-agnostic: a winner is whoever has built all landmarks,
+     * regardless of the game's current [TurnPhase]. It is typically invoked right
+     * after transitioning to [TurnPhase.END_TURN], but may also be called from
+     * other paths (e.g. a debug or mid-turn check) without restriction.
+     */
     fun detectWinner(gameId: Int): PlayerModel? {
-        val game = gameDao.findById(gameId)
+        gameDao.findById(gameId)
             ?: throw GameNotFoundException("Game $gameId not found")
-
-        if (game.turnPhase != TurnPhase.END_TURN) {
-            throw CustomWebSocketException(
-                errorCode = "NOT_END_TURN_PHASE",
-                message = "Game ${game.id} must be in END_TURN State to determine a winner",
-            )
-        }
 
         return playerDao.getPlayers(gameId)
             .firstOrNull {

--- a/src/test/kotlin/org/machikoro/server/service/WinConditionServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/WinConditionServiceTest.kt
@@ -10,7 +10,6 @@ import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.enums.TurnPhase
 import org.machikoro.server.domain.models.GameModel
 import org.machikoro.server.domain.models.PlayerModel
-import org.machikoro.server.exception.CustomWebSocketException
 import org.machikoro.server.exception.GameNotFoundException
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -111,17 +110,20 @@ class WinConditionServiceTest {
     }
 
     @Test
-    fun `detectWinner throws if not in END_TURN phase`() {
+    fun `detectWinner is phase-agnostic and detects a winner outside END_TURN`() {
         val gameId = 1
+        val winner = player(2)
 
         whenever(gameDao.findById(gameId))
             .thenReturn(gameInPhase(TurnPhase.BUY_OR_BUILD))
+        whenever(playerDao.getPlayers(gameId))
+            .thenReturn(listOf(player(1), winner))
+        whenever(playerLandmarkDao.allBuilt(1)).thenReturn(false)
+        whenever(playerLandmarkDao.allBuilt(2)).thenReturn(true)
 
-        val ex = assertThrows<CustomWebSocketException> {
-            service.detectWinner(gameId)
-        }
+        val result = service.detectWinner(gameId)
 
-        assertEquals("NOT_END_TURN_PHASE", ex.errorCode)
+        assertEquals(winner, result)
         verify(gameDao).findById(gameId)
     }
 


### PR DESCRIPTION
## Summary

`WinConditionService.detectWinner` unnecessarily enforced the `END_TURN` turn phase, throwing `CustomWebSocketException("NOT_END_TURN_PHASE")` whenever it was called in any other phase. That guard was redundant — a winner is simply whoever has built all landmarks, which is independent of the current `TurnPhase` — and `detectWinner` is already invoked right after transitioning to `END_TURN`. Worse, the guard actively broke any future non-`END_TURN` call path (e.g. a debug or mid-turn win check).

This PR makes `detectWinner` **phase-agnostic** by removing the guard.

Closes #437

## Changes

- **`WinConditionService.kt`**
  - Removed the `turnPhase != END_TURN` check and the `NOT_END_TURN_PHASE` exception.
  - The game is still looked up so a missing game continues to throw `GameNotFoundException`.
  - Updated the KDoc to document that the check is phase-agnostic.
  - Dropped the now-unused `CustomWebSocketException` import.
- **`WinConditionServiceTest.kt`**
  - Replaced `detectWinner throws if not in END_TURN phase` with `detectWinner is phase-agnostic and detects a winner outside END_TURN`, which sets the game to `BUY_OR_BUILD` and asserts the winner is still returned.
  - Dropped the now-unused `CustomWebSocketException` import.

## Behaviour

| Scenario | Before | After |
| --- | --- | --- |
| All landmarks built, phase `END_TURN` | returns winner | returns winner |
| All landmarks built, phase `BUY_OR_BUILD` | throws `NOT_END_TURN_PHASE` | returns winner |
| No player has won | returns `null` | returns `null` |
| Game not found | throws `GameNotFoundException` | throws `GameNotFoundException` |

The existing production caller, `GamePhaseService` (`detectWinner(gameId)?.let { ... }`), is unaffected since it always calls after the `END_TURN` transition.

## Testing

- `./gradlew test --tests WinConditionServiceTest --tests GamePhaseServiceTest` — **BUILD SUCCESSFUL**
