### PR TITLE
refactor: remove dead atomicity-bypassing GameDao methods

### DIFF
--- a/src/main/kotlin/org/machikoro/server/dao/GameDao.kt
+++ b/src/main/kotlin/org/machikoro/server/dao/GameDao.kt
@@ -141,17 +141,6 @@ class GameDao {
     }
 
     /**
-     * Updates game state after a dice roll
-     */
-    fun updateAfterRoll(id: Int, diceRoll: Int, phase: TurnPhase): Unit = transaction {
-        val updatedRows = Games.update({ Games.id eq id }) {
-            it[Games.lastDiceRoll] = diceRoll
-            it[Games.turnPhase] = phase
-        }
-        if (updatedRows == 0) throw GameNotFoundException("Game $id not found")
-    }
-
-    /**
      * Persists the only legal transition out of ROLL_DICE. The conditional
      * update prevents two simultaneous requests from recording separate rolls.
      */
@@ -207,16 +196,6 @@ class GameDao {
         }) {
             it[Games.turnPhase] = next
         } > 0
-    }
-
-    /**
-     * Updates the rerolled_this_turn flag for a game.
-     */
-    fun updateRerolledThisTurn(id: Int, rerolledThisTurn: Boolean): Unit = transaction {
-        val updatedRows = Games.update({ Games.id eq id }) {
-            it[Games.rerolledThisTurn] = rerolledThisTurn
-        }
-        if (updatedRows == 0) throw GameNotFoundException("Game $id not found")
     }
 
     /**

--- a/src/main/kotlin/org/machikoro/server/dao/GameDao.kt
+++ b/src/main/kotlin/org/machikoro/server/dao/GameDao.kt
@@ -206,6 +206,10 @@ class GameDao {
      *
      * On success, sets the new dice roll and marks rerolledThisTurn = true in a single transaction.
      * Returns true if the update succeeded, false if any condition failed.
+     *
+     * lastDiceCount is intentionally left untouched: a reroll replays the same number of dice as the
+     * initial roll, so the count recorded by [tryRecordDiceRoll] must be preserved (DiceService reads
+     * lastDiceCount at reroll time to know how many dice to roll).
      */
     fun tryRerollThisTurn(id: Int, newDiceRoll: Int): Boolean = transaction {
         Games.update({
@@ -216,6 +220,7 @@ class GameDao {
         }) {
             it[Games.lastDiceRoll] = newDiceRoll
             it[Games.rerolledThisTurn] = true
+            // lastDiceCount deliberately not updated — the reroll keeps the initial roll's dice count.
         } > 0
     }
 

--- a/src/test/kotlin/org/machikoro/server/dao/GameDaoTest.kt
+++ b/src/test/kotlin/org/machikoro/server/dao/GameDaoTest.kt
@@ -116,23 +116,6 @@ class GameDaoTest : AbstractDBSetup() {
     }
 
     @Test
-    fun `updateAfterRoll sets dice result and phase`() {
-        val id = gameDao.create(hostId)
-        gameDao.updateAfterRoll(id, diceRoll = 6, phase = TurnPhase.RESOLVE_EFFECTS)
-        val game = gameDao.findById(id)!!
-        assertEquals(6, game.lastDiceRoll)
-        assertEquals(TurnPhase.RESOLVE_EFFECTS, game.turnPhase)
-        assertFalse(game.hasPurchasedThisTurn)
-    }
-
-    @Test
-    fun `updateAfterRoll throws when game does not exist`() {
-        assertThrows<GameNotFoundException> {
-            gameDao.updateAfterRoll(999999, diceRoll = 6, phase = TurnPhase.RESOLVE_EFFECTS)
-        }
-    }
-
-    @Test
     fun `tryRecordDiceRoll records exactly one roll in a turn`() {
         val id = gameDao.create(hostId)
 
@@ -178,7 +161,7 @@ class GameDaoTest : AbstractDBSetup() {
     @Test
     fun `advanceTurn resets to ROLL_DICE clears dice roll and purchase state`() {
         val id = gameDao.create(hostId)
-        gameDao.updateAfterRoll(id, diceRoll = 4, phase = TurnPhase.RESOLVE_EFFECTS)
+        gameDao.tryRecordDiceRoll(id, diceRoll = 4, diceCount = 1)
         gameDao.updateHasPurchasedThisTurn(id, true)
         gameDao.advanceTurn(id, nextTurnIndex = 1, roundNumber = 2)
         val game = gameDao.findById(id)!!
@@ -337,26 +320,10 @@ class GameDaoTest : AbstractDBSetup() {
     }
 
     @Test
-    fun `updateRerolledThisTurn changes rerolled flag when game exists`() {
-        val id = gameDao.create(hostId)
-        // Initially created game has rerolledThisTurn = false
-        gameDao.updateRerolledThisTurn(id, true)
-        val game = gameDao.findById(id)!!
-        assertTrue(game.rerolledThisTurn)
-    }
-
-    @Test
-    fun `updateRerolledThisTurn throws when game does not exist`() {
-        assertThrows<GameNotFoundException> {
-            gameDao.updateRerolledThisTurn(999999, true)
-        }
-    }
-
-    @Test
     fun `tryMarkRerolledThisTurn succeeds once and then rejects repeats`() {
         val id = gameDao.create(hostId)
 
-        gameDao.updateAfterRoll(id, diceRoll = 4, phase = TurnPhase.RESOLVE_EFFECTS)
+        gameDao.tryRecordDiceRoll(id, diceRoll = 4, diceCount = 1)
         // First attempt should flip false -> true
         assertTrue(gameDao.tryRerollThisTurn(id, 5))
         // Subsequent attempts should fail (already true)

--- a/src/test/kotlin/org/machikoro/server/dao/GameDaoTest.kt
+++ b/src/test/kotlin/org/machikoro/server/dao/GameDaoTest.kt
@@ -171,7 +171,9 @@ class GameDaoTest : AbstractDBSetup() {
     @Test
     fun `advanceTurn resets to ROLL_DICE clears dice roll and purchase state`() {
         val id = gameDao.create(hostId)
-        gameDao.tryRecordDiceRoll(id, diceRoll = 4, diceCount = 1)
+        check(gameDao.tryRecordDiceRoll(id, diceRoll = 4, diceCount = 1)) {
+            "fixture: game not in ROLL_DICE"
+        }
         gameDao.updateHasPurchasedThisTurn(id, true)
         assertTrue(gameDao.tryMarkBusinessCenterUsedThisTurn(id))
         gameDao.advanceTurn(id, nextTurnIndex = 1, roundNumber = 2)
@@ -335,7 +337,9 @@ class GameDaoTest : AbstractDBSetup() {
     fun `tryMarkRerolledThisTurn succeeds once and then rejects repeats`() {
         val id = gameDao.create(hostId)
 
-        gameDao.tryRecordDiceRoll(id, diceRoll = 4, diceCount = 1)
+        check(gameDao.tryRecordDiceRoll(id, diceRoll = 4, diceCount = 1)) {
+            "fixture: game not in ROLL_DICE"
+        }
         // First attempt should flip false -> true
         assertTrue(gameDao.tryRerollThisTurn(id, 5))
         // Subsequent attempts should fail (already true)

--- a/src/test/kotlin/org/machikoro/server/service/GameSyncServiceIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GameSyncServiceIntegrationTest.kt
@@ -109,8 +109,12 @@ class GameSyncServiceIntegrationTest : AbstractDBSetup() {
         // clears hasPurchasedThisTurn — so apply it FIRST, then layer the
         // roll / phase / purchase state on top.
         gameDao.advanceTurn(gameId, nextTurnIndex = 1, roundNumber = 3)
-        gameDao.tryRecordDiceRoll(gameId, diceRoll = 8, diceCount = 2)
-        gameDao.updateTurnPhase(gameId, TurnPhase.BUY_OR_BUILD)
+        check(gameDao.tryRecordDiceRoll(gameId, diceRoll = 8, diceCount = 2)) {
+            "fixture: game not in ROLL_DICE"
+        }
+        check(gameDao.tryTransitionPhase(gameId, TurnPhase.RESOLVE_EFFECTS, TurnPhase.BUY_OR_BUILD)) {
+            "fixture: game not in RESOLVE_EFFECTS"
+        }
         gameDao.updateHasPurchasedThisTurn(gameId, hasPurchasedThisTurn = true)
 
         // Simulate the first player buying a BAKERY: decrement marketplace,

--- a/src/test/kotlin/org/machikoro/server/service/GameSyncServiceIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GameSyncServiceIntegrationTest.kt
@@ -109,7 +109,7 @@ class GameSyncServiceIntegrationTest : AbstractDBSetup() {
         // clears hasPurchasedThisTurn — so apply it FIRST, then layer the
         // roll / phase / purchase state on top.
         gameDao.advanceTurn(gameId, nextTurnIndex = 1, roundNumber = 3)
-        gameDao.tryRecordDiceRoll(gameId, diceRoll = 8, diceCount = 1)
+        gameDao.tryRecordDiceRoll(gameId, diceRoll = 8, diceCount = 2)
         gameDao.updateTurnPhase(gameId, TurnPhase.BUY_OR_BUILD)
         gameDao.updateHasPurchasedThisTurn(gameId, hasPurchasedThisTurn = true)
 

--- a/src/test/kotlin/org/machikoro/server/service/GameSyncServiceIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GameSyncServiceIntegrationTest.kt
@@ -109,7 +109,8 @@ class GameSyncServiceIntegrationTest : AbstractDBSetup() {
         // clears hasPurchasedThisTurn — so apply it FIRST, then layer the
         // roll / phase / purchase state on top.
         gameDao.advanceTurn(gameId, nextTurnIndex = 1, roundNumber = 3)
-        gameDao.updateAfterRoll(gameId, diceRoll = 8, phase = TurnPhase.BUY_OR_BUILD)
+        gameDao.tryRecordDiceRoll(gameId, diceRoll = 8, diceCount = 1)
+        gameDao.updateTurnPhase(gameId, TurnPhase.BUY_OR_BUILD)
         gameDao.updateHasPurchasedThisTurn(gameId, hasPurchasedThisTurn = true)
 
         // Simulate the first player buying a BAKERY: decrement marketplace,

--- a/src/test/kotlin/org/machikoro/server/service/PurchaseServiceIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/PurchaseServiceIntegrationTest.kt
@@ -201,7 +201,9 @@ class PurchaseServiceIntegrationTest : AbstractDBSetup() {
         // cycle back to active player's turn
         gameDao.advanceTurn(gameId, nextTurnIndex = 1, roundNumber = 1)
         gameDao.advanceTurn(gameId, nextTurnIndex = 0, roundNumber = 2)
-        gameDao.tryRecordDiceRoll(gameId, diceRoll = 2, diceCount = 1)
+        check(gameDao.tryRecordDiceRoll(gameId, diceRoll = 2, diceCount = 1)) {
+            "fixture: game not in ROLL_DICE"
+        }
 
         val coinsBefore = playerDao.findById(activePlayerId)!!.coins
         earningsService.resolveEffects(gameId)
@@ -216,7 +218,9 @@ class PurchaseServiceIntegrationTest : AbstractDBSetup() {
 
         gameDao.advanceTurn(gameId, nextTurnIndex = 1, roundNumber = 1)
         gameDao.advanceTurn(gameId, nextTurnIndex = 0, roundNumber = 2)
-        gameDao.tryRecordDiceRoll(gameId, diceRoll = 2, diceCount = 1)
+        check(gameDao.tryRecordDiceRoll(gameId, diceRoll = 2, diceCount = 1)) {
+            "fixture: game not in ROLL_DICE"
+        }
 
         val inactiveBefore = playerDao.findById(inactivePlayerId)!!.coins
         earningsService.resolveEffects(gameId)

--- a/src/test/kotlin/org/machikoro/server/service/PurchaseServiceIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/PurchaseServiceIntegrationTest.kt
@@ -201,7 +201,7 @@ class PurchaseServiceIntegrationTest : AbstractDBSetup() {
         // cycle back to active player's turn
         gameDao.advanceTurn(gameId, nextTurnIndex = 1, roundNumber = 1)
         gameDao.advanceTurn(gameId, nextTurnIndex = 0, roundNumber = 2)
-        gameDao.updateAfterRoll(gameId, diceRoll = 2, phase = TurnPhase.RESOLVE_EFFECTS)
+        gameDao.tryRecordDiceRoll(gameId, diceRoll = 2, diceCount = 1)
 
         val coinsBefore = playerDao.findById(activePlayerId)!!.coins
         earningsService.resolveEffects(gameId)
@@ -216,7 +216,7 @@ class PurchaseServiceIntegrationTest : AbstractDBSetup() {
 
         gameDao.advanceTurn(gameId, nextTurnIndex = 1, roundNumber = 1)
         gameDao.advanceTurn(gameId, nextTurnIndex = 0, roundNumber = 2)
-        gameDao.updateAfterRoll(gameId, diceRoll = 2, phase = TurnPhase.RESOLVE_EFFECTS)
+        gameDao.tryRecordDiceRoll(gameId, diceRoll = 2, diceCount = 1)
 
         val inactiveBefore = playerDao.findById(inactivePlayerId)!!.coins
         earningsService.resolveEffects(gameId)

--- a/src/test/kotlin/org/machikoro/server/service/SpringContextRestartRecoveryIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/SpringContextRestartRecoveryIntegrationTest.kt
@@ -136,8 +136,12 @@ class SpringContextRestartRecoveryIntegrationTest {
         
         playerDao.updateCoins(firstPlayerId, 42)
         gameDao.advanceTurn(sharedGameId, nextTurnIndex = 1, roundNumber = 5)
-        gameDao.tryRecordDiceRoll(sharedGameId, diceRoll = 9, diceCount = 2)
-        gameDao.updateTurnPhase(sharedGameId, TurnPhase.BUY_OR_BUILD)
+        check(gameDao.tryRecordDiceRoll(sharedGameId, diceRoll = 9, diceCount = 2)) {
+            "fixture: game not in ROLL_DICE"
+        }
+        check(gameDao.tryTransitionPhase(sharedGameId, TurnPhase.RESOLVE_EFFECTS, TurnPhase.BUY_OR_BUILD)) {
+            "fixture: game not in RESOLVE_EFFECTS"
+        }
         
         gameMarketplaceDao.decrementQuantity(sharedGameId, CardType.CAFE)
         playerCardDao.upsert(firstPlayerId, CardType.CAFE, quantity = 3)

--- a/src/test/kotlin/org/machikoro/server/service/SpringContextRestartRecoveryIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/SpringContextRestartRecoveryIntegrationTest.kt
@@ -136,7 +136,8 @@ class SpringContextRestartRecoveryIntegrationTest {
         
         playerDao.updateCoins(firstPlayerId, 42)
         gameDao.advanceTurn(sharedGameId, nextTurnIndex = 1, roundNumber = 5)
-        gameDao.updateAfterRoll(sharedGameId, diceRoll = 9, phase = TurnPhase.BUY_OR_BUILD)
+        gameDao.tryRecordDiceRoll(sharedGameId, diceRoll = 9, diceCount = 1)
+        gameDao.updateTurnPhase(sharedGameId, TurnPhase.BUY_OR_BUILD)
         
         gameMarketplaceDao.decrementQuantity(sharedGameId, CardType.CAFE)
         playerCardDao.upsert(firstPlayerId, CardType.CAFE, quantity = 3)

--- a/src/test/kotlin/org/machikoro/server/service/SpringContextRestartRecoveryIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/SpringContextRestartRecoveryIntegrationTest.kt
@@ -136,7 +136,7 @@ class SpringContextRestartRecoveryIntegrationTest {
         
         playerDao.updateCoins(firstPlayerId, 42)
         gameDao.advanceTurn(sharedGameId, nextTurnIndex = 1, roundNumber = 5)
-        gameDao.tryRecordDiceRoll(sharedGameId, diceRoll = 9, diceCount = 1)
+        gameDao.tryRecordDiceRoll(sharedGameId, diceRoll = 9, diceCount = 2)
         gameDao.updateTurnPhase(sharedGameId, TurnPhase.BUY_OR_BUILD)
         
         gameMarketplaceDao.decrementQuantity(sharedGameId, CardType.CAFE)


### PR DESCRIPTION
## Summary

Closes #435.

`GameDao.updateAfterRoll` and `GameDao.updateRerolledThisTurn` were **dead production code** — neither was called anywhere outside of tests, and both wrote game state with an unconditional `UPDATE ... WHERE id = ?` that bypassed the atomicity guards used everywhere else in the DAO:

- `updateAfterRoll` set `lastDiceRoll` + `turnPhase` directly, sidestepping `tryRecordDiceRoll`, which only allows the `ROLL_DICE → RESOLVE_EFFECTS` transition once (`turnPhase = ROLL_DICE AND lastDiceRoll IS NULL`).
- `updateRerolledThisTurn` flipped `rerolledThisTurn` directly, sidestepping `tryRerollThisTurn`, which guards the one-reroll-per-turn rule.

Leaving them in the production DAO meant a future caller could accidentally bypass those concurrency guards and reintroduce the double-roll / double-reroll races the guarded methods exist to prevent.

## Changes

**Production (`GameDao.kt`)**
- Removed `updateAfterRoll(id, diceRoll, phase)`.
- Removed `updateRerolledThisTurn(id, rerolledThisTurn)`.

**Tests** — migrated every setup usage to the guarded production path so fixtures now exercise the real transition logic:
- `RESOLVE_EFFECTS` setup → `tryRecordDiceRoll(id, diceRoll, diceCount = 1)` (sets the dice roll and advances the phase exactly as production does).
- `BUY_OR_BUILD` setup → `tryRecordDiceRoll(...)` followed by `updateTurnPhase(id, BUY_OR_BUILD)`.
- Affected files: `GameDaoTest.kt`, `PurchaseServiceIntegrationTest.kt`, `GameSyncServiceIntegrationTest.kt`, `SpringContextRestartRecoveryIntegrationTest.kt`.
- Dropped the four tests in `GameDaoTest` that only existed to exercise the removed methods (`updateAfterRoll sets dice result and phase`, `updateAfterRoll throws when game does not exist`, `updateRerolledThisTurn changes rerolled flag when game exists`, `updateRerolledThisTurn throws when game does not exist`).

## Why this approach

Rather than restrict the methods to test scope, the test fixtures already had a guarded equivalent available (`tryRecordDiceRoll`), so the bypass could be removed entirely. Setups now go through the same code path production uses, which is both safer and more representative.