### PR TITLE
434 business center does nothing income 0 paymentsourcenone unhandled

### DIFF
--- a/src/main/kotlin/org/machikoro/server/config/OpenApiConfig.kt
+++ b/src/main/kotlin/org/machikoro/server/config/OpenApiConfig.kt
@@ -45,6 +45,7 @@ class OpenApiConfig {
     | `/app/game.start` | `StartGameRequest` | `GAME_STARTED`, `GAME_ACTION` to `/topic/game/{gameId}` |
     | `/app/game.rollDice` | `RollDiceRequest` | `ROLL_DICE`, `GAME_ACTION` to `/topic/game/{gameId}` |
     | `/app/game.resolveEffects` | `ResolveEffectsRequest` | `GAME_ACTION` to `/topic/game/{gameId}` |
+    | `/app/game.businessCenter.swap` | `BusinessCenterSwapRequest` | `GAME_ACTION`, or `ERROR` with `payload.context.event = BUSINESS_CENTER_SWAP_FAILED`, to `/topic/game/{gameId}` |
     | `/app/game.advancePhase` | `AdvancePhaseRequest` | `DIRECT_PHASE_ADVANCE_FORBIDDEN` to `/user/queue/errors`; no state changes |
     | `/app/game.purchase` | `PurchaseRequest` | `GAME_ACTION`, or `ERROR` with `payload.context.event = PURCHASE_FAILED`, to `/topic/game/{gameId}` |
     | `/app/game.endTurn` | `EndTurnRequest` | `GAME_ACTION` or `GAME_END` to `/topic/game/{gameId}` |

--- a/src/main/kotlin/org/machikoro/server/controller/EarningsController.kt
+++ b/src/main/kotlin/org/machikoro/server/controller/EarningsController.kt
@@ -3,6 +3,7 @@ package org.machikoro.server.controller
 import io.github.springwolf.core.asyncapi.annotations.AsyncListener
 import io.github.springwolf.core.asyncapi.annotations.AsyncOperation
 import org.machikoro.server.auth.requireUserPrincipal
+import org.machikoro.server.dto.BusinessCenterSwapRequest
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.ResolveEffectsRequest
 import org.machikoro.server.dto.WebSocketErrorDto
@@ -75,6 +76,59 @@ class EarningsController(
                     type = MessageType.ERROR,
                     sender = "server",
                     payload = WebSocketErrorDto.from(e, mapOf("event" to "EFFECTS_FAILED")),
+                    gameId = request.gameId,
+                )
+            )
+        }
+    }
+
+    /**
+     * Applies Business Center's one-card exchange action and broadcasts the updated state.
+     */
+    @MessageMapping("/game.businessCenter.swap")
+    @AsyncListener(
+        operation = AsyncOperation(
+            channelName = "/game.businessCenter.swap",
+            description = "Exchanges one non-major establishment with another player after Business Center activates."
+        )
+    )
+    fun swapBusinessCenterCard(@Payload request: BusinessCenterSwapRequest, headerAccessor: SimpMessageHeaderAccessor) {
+        val user = headerAccessor.requireUserPrincipal()
+        val activePlayer = gameStateGuard.ensureSenderIsActivePlayer(request.gameId, user)
+        val gameTopic = "/topic/game/${request.gameId}"
+        try {
+            earningsService.swapBusinessCenterCard(
+                gameId = request.gameId,
+                activePlayerId = activePlayer.id,
+                targetPlayerId = request.targetPlayerId,
+                offeredCardType = request.offeredCardType,
+                requestedCardType = request.requestedCardType,
+            )
+            val state = gameSyncService.buildSnapshot(request.gameId)
+            logger.info("Applied Business Center swap for game ${request.gameId}")
+            messagingTemplate.convertAndSend(
+                gameTopic,
+                WebSocketMessage(
+                    type = MessageType.GAME_ACTION,
+                    sender = "server",
+                    payload = mapOf(
+                        "event" to "BUSINESS_CENTER_SWAP_APPLIED",
+                        "gameId" to request.gameId,
+                        "turnPhase" to state.game.turnPhase.name,
+                        "activePlayerId" to state.activePlayerId,
+                        "state" to state,
+                    ),
+                    gameId = request.gameId,
+                )
+            )
+        } catch (e: CustomWebSocketException) {
+            logger.warn("Business Center swap rejected for game {} [{}]: {}", request.gameId, e.errorCode, e.message)
+            messagingTemplate.convertAndSend(
+                gameTopic,
+                WebSocketMessage(
+                    type = MessageType.ERROR,
+                    sender = "server",
+                    payload = WebSocketErrorDto.from(e, mapOf("event" to "BUSINESS_CENTER_SWAP_FAILED")),
                     gameId = request.gameId,
                 )
             )

--- a/src/main/kotlin/org/machikoro/server/dao/GameDao.kt
+++ b/src/main/kotlin/org/machikoro/server/dao/GameDao.kt
@@ -35,6 +35,7 @@ class GameDao {
         lastDiceCount = this[Games.lastDiceCount],
         roundNumber = this[Games.roundNumber],
         hasPurchasedThisTurn = this[Games.hasPurchasedThisTurn],
+        businessCenterUsedThisTurn = this[Games.businessCenterUsedThisTurn],
         extraTurnPlayerId = this[Games.extraTurnPlayerId],
         extraTurnRoundNumber = this[Games.extraTurnRoundNumber],
         extraTurnConsumed = this[Games.extraTurnConsumed],
@@ -76,6 +77,7 @@ class GameDao {
             it[Games.roundNumber] = 1
             it[Games.lastDiceRoll] = null
             it[Games.hasPurchasedThisTurn] = false
+            it[Games.businessCenterUsedThisTurn] = false
             it[Games.lobbyCode] = lobbyCode
             it[Games.maxPlayers] = maxPlayers
             it[Games.rerolledThisTurn] = false
@@ -265,6 +267,18 @@ class GameDao {
     }
 
     /**
+     * Atomically marks the current turn as having used Business Center.
+     */
+    fun tryMarkBusinessCenterUsedThisTurn(id: Int): Boolean = transaction {
+        Games.update({
+            (Games.id eq id) and
+                (Games.businessCenterUsedThisTurn eq false)
+        }) {
+            it[businessCenterUsedThisTurn] = true
+        } > 0
+    }
+
+    /**
      * Advances the game to the next player's turn
      * - Resets phase to ROLL_DICE
      * - Clears last dice roll
@@ -277,6 +291,7 @@ class GameDao {
             it[Games.lastDiceRoll] = null
             it[Games.lastDiceCount] = null
             it[Games.hasPurchasedThisTurn] = false
+            it[Games.businessCenterUsedThisTurn] = false
             it[Games.rerolledThisTurn] = false
         }
         if (updatedRows == 0) throw GameNotFoundException("Game $id not found")

--- a/src/main/kotlin/org/machikoro/server/dao/PlayerDao.kt
+++ b/src/main/kotlin/org/machikoro/server/dao/PlayerDao.kt
@@ -48,6 +48,7 @@ class PlayerDao {
         lastDiceRoll = this[Games.lastDiceRoll],
         roundNumber = this[Games.roundNumber],
         hasPurchasedThisTurn = this[Games.hasPurchasedThisTurn],
+        businessCenterUsedThisTurn = this[Games.businessCenterUsedThisTurn],
         rerolledThisTurn = this[Games.rerolledThisTurn]
     )
 

--- a/src/main/kotlin/org/machikoro/server/database/DataSeeder.kt
+++ b/src/main/kotlin/org/machikoro/server/database/DataSeeder.kt
@@ -129,7 +129,7 @@ class DataSeeder : CommandLineRunner {
                 0,
                 CardColor.PURPLE,
                 EstablishmentType.MAJOR,
-                PaymentSource.CHOSEN_PLAYER,
+                PaymentSource.NONE,
                 listOf(6)
             ),
         )

--- a/src/main/kotlin/org/machikoro/server/database/Tables.kt
+++ b/src/main/kotlin/org/machikoro/server/database/Tables.kt
@@ -98,6 +98,7 @@ object Games : IntIdTable("games") {
     val rerolledThisTurn = bool("rerolled_this_turn").default(false)
     val roundNumber = integer("round_number").default(1)
     val hasPurchasedThisTurn = bool("has_purchased_this_turn").default(false)
+    val businessCenterUsedThisTurn = bool("business_center_used_this_turn").default(false)
     val extraTurnPlayerId = integer("extra_turn_player_id").nullable()
     val extraTurnRoundNumber = integer("extra_turn_round_number").nullable()
     // True once the pending extra turn has been consumed; prevents re-grant in the same round

--- a/src/main/kotlin/org/machikoro/server/domain/models/GameModel.kt
+++ b/src/main/kotlin/org/machikoro/server/domain/models/GameModel.kt
@@ -15,6 +15,7 @@ data class GameModel(
     val lastDiceCount: Int? = null,
     val roundNumber: Int,
     val hasPurchasedThisTurn: Boolean,
+    val businessCenterUsedThisTurn: Boolean = false,
     val extraTurnPlayerId: Int? = null,
     val extraTurnRoundNumber: Int? = null,
     val extraTurnConsumed: Boolean = false,

--- a/src/main/kotlin/org/machikoro/server/dto/BusinessCenterSwapRequest.kt
+++ b/src/main/kotlin/org/machikoro/server/dto/BusinessCenterSwapRequest.kt
@@ -1,0 +1,10 @@
+package org.machikoro.server.dto
+
+import org.machikoro.server.domain.enums.CardType
+
+data class BusinessCenterSwapRequest(
+    val gameId: Int,
+    val targetPlayerId: Int,
+    val offeredCardType: CardType,
+    val requestedCardType: CardType,
+)

--- a/src/main/kotlin/org/machikoro/server/service/EarningsServiceImpl.kt
+++ b/src/main/kotlin/org/machikoro/server/service/EarningsServiceImpl.kt
@@ -6,6 +6,7 @@ import org.machikoro.server.dao.PlayerCardDao
 import org.machikoro.server.dao.PlayerDao
 import org.machikoro.server.dao.PlayerLandmarkDao
 import org.machikoro.server.domain.enums.CardColor
+import org.machikoro.server.domain.enums.CardType
 import org.machikoro.server.domain.enums.EstablishmentType
 import org.machikoro.server.domain.enums.LandmarkType
 import org.machikoro.server.domain.enums.PaymentSource
@@ -166,7 +167,9 @@ class EarningsServiceImpl(
             .filter { (_, card) -> card.color == CardColor.PURPLE }
 
         val bankEarned = purpleCards
-            .filter { (_, card) -> card.paymentSource != PaymentSource.ALL_PLAYERS }
+            .filter { (_, card) ->
+                card.paymentSource == PaymentSource.BANK || card.paymentSource == PaymentSource.CHOSEN_PLAYER
+            }
             .sumOf { (playerCard, card) -> playerCard.quantity * card.income }
 
         if (bankEarned > 0) {
@@ -225,5 +228,83 @@ class EarningsServiceImpl(
             ?: throw CustomWebSocketException("NO_ACTIVE_PLAYER", "Game $gameId has no active player")
 
         processEarnings(gameId, diceRoll, activePlayer.id)
+    }
+
+    override fun swapBusinessCenterCard(
+        gameId: Int,
+        activePlayerId: Int,
+        targetPlayerId: Int,
+        offeredCardType: CardType,
+        requestedCardType: CardType,
+    ): Unit = gameTransactionRunner.inTransaction {
+        val game = gameStateGuard.ensureGameIsRunning(gameId)
+        if (game.turnPhase != TurnPhase.BUY_OR_BUILD || game.lastDiceRoll != 6) {
+            throw CustomWebSocketException(
+                "BUSINESS_CENTER_NOT_ACTIVE",
+                "Business Center can only be used after resolving a roll of 6",
+            )
+        }
+
+        val players = playerDao.getPlayers(gameId)
+        val activePlayer = players.getOrNull(game.currentTurnIndex)
+            ?: throw CustomWebSocketException("NO_ACTIVE_PLAYER", "Game $gameId has no active player")
+        if (activePlayer.id != activePlayerId) {
+            throw CustomWebSocketException("NOT_YOUR_TURN", "It is not your turn")
+        }
+        if (players.none { it.id == targetPlayerId } || targetPlayerId == activePlayerId) {
+            throw CustomWebSocketException(
+                "INVALID_SWAP_TARGET",
+                "Business Center requires a different target player in the same game",
+            )
+        }
+        if (offeredCardType == requestedCardType) {
+            throw CustomWebSocketException(
+                "INVALID_BUSINESS_CENTER_CARD",
+                "Business Center must exchange two different card types",
+            )
+        }
+
+        val activeCards = playerCardDao.findByPlayerId(activePlayerId)
+        val targetCards = playerCardDao.findByPlayerId(targetPlayerId)
+        val businessCenterQuantity = activeCards.firstOrNull { it.cardType == CardType.BUSINESS_CENTER }?.quantity ?: 0
+        if (businessCenterQuantity <= 0) {
+            throw CustomWebSocketException(
+                "BUSINESS_CENTER_NOT_OWNED",
+                "Active player does not own Business Center",
+            )
+        }
+
+        val offeredCard = cardDao.findByCardType(offeredCardType)
+            ?: throw CustomWebSocketException("CARD_NOT_FOUND", "Offered card $offeredCardType not found")
+        val requestedCard = cardDao.findByCardType(requestedCardType)
+            ?: throw CustomWebSocketException("CARD_NOT_FOUND", "Requested card $requestedCardType not found")
+        if (offeredCard.establishmentType == EstablishmentType.MAJOR || requestedCard.establishmentType == EstablishmentType.MAJOR) {
+            throw CustomWebSocketException(
+                "INVALID_BUSINESS_CENTER_CARD",
+                "Business Center cannot exchange major establishments",
+            )
+        }
+
+        val offeredQuantity = activeCards.firstOrNull { it.cardType == offeredCardType }?.quantity ?: 0
+        val requestedQuantity = targetCards.firstOrNull { it.cardType == requestedCardType }?.quantity ?: 0
+        if (offeredQuantity <= 0 || requestedQuantity <= 0) {
+            throw CustomWebSocketException(
+                "CARD_NOT_OWNED",
+                "Both players must own the cards being exchanged",
+            )
+        }
+
+        playerCardDao.upsert(activePlayerId, offeredCardType, offeredQuantity - 1)
+        playerCardDao.upsert(targetPlayerId, requestedCardType, requestedQuantity - 1)
+        playerCardDao.upsert(
+            activePlayerId,
+            requestedCardType,
+            activeCards.firstOrNull { it.cardType == requestedCardType }?.quantity?.plus(1) ?: 1,
+        )
+        playerCardDao.upsert(
+            targetPlayerId,
+            offeredCardType,
+            targetCards.firstOrNull { it.cardType == offeredCardType }?.quantity?.plus(1) ?: 1,
+        )
     }
 }

--- a/src/main/kotlin/org/machikoro/server/service/EarningsServiceImpl.kt
+++ b/src/main/kotlin/org/machikoro/server/service/EarningsServiceImpl.kt
@@ -167,9 +167,7 @@ class EarningsServiceImpl(
             .filter { (_, card) -> card.color == CardColor.PURPLE }
 
         val bankEarned = purpleCards
-            .filter { (_, card) ->
-                card.paymentSource == PaymentSource.BANK || card.paymentSource == PaymentSource.CHOSEN_PLAYER
-            }
+            .filter { (_, card) -> card.paymentSource == PaymentSource.BANK }
             .sumOf { (playerCard, card) -> playerCard.quantity * card.income }
 
         if (bankEarned > 0) {
@@ -244,6 +242,12 @@ class EarningsServiceImpl(
                 "Business Center can only be used after resolving a roll of 6",
             )
         }
+        if (game.businessCenterUsedThisTurn) {
+            throw CustomWebSocketException(
+                "BUSINESS_CENTER_ALREADY_USED",
+                "Business Center has already been used this turn",
+            )
+        }
 
         val players = playerDao.getPlayers(gameId)
         val activePlayer = players.getOrNull(game.currentTurnIndex)
@@ -291,6 +295,12 @@ class EarningsServiceImpl(
             throw CustomWebSocketException(
                 "CARD_NOT_OWNED",
                 "Both players must own the cards being exchanged",
+            )
+        }
+        if (!gameDao.tryMarkBusinessCenterUsedThisTurn(gameId)) {
+            throw CustomWebSocketException(
+                "BUSINESS_CENTER_ALREADY_USED",
+                "Business Center has already been used this turn",
             )
         }
 

--- a/src/main/kotlin/org/machikoro/server/service/EarningsServiceImpl.kt
+++ b/src/main/kotlin/org/machikoro/server/service/EarningsServiceImpl.kt
@@ -155,6 +155,12 @@ class EarningsServiceImpl(
      * - BANK-sourced: active player receives income from the bank.
      * - ALL_PLAYERS-sourced (e.g. Stadium): active player steals from each opponent,
      *   capped at each opponent's actual balance to avoid creating coins.
+     * - CHOSEN_PLAYER-sourced (TV Station): currently credited from the bank here,
+     *   matching pre-existing behaviour. The proper "steal from a chosen player"
+     *   resolution is handled separately by #433; this card is intentionally left
+     *   untouched by the Business Center change so the two PRs don't conflict.
+     * - NONE-sourced (Business Center): no coin movement; its effect is the card
+     *   swap handled by [swapBusinessCenterCard], so it is excluded from bank income.
      */
     private fun processPurpleCards(
         players: List<PlayerModel>,
@@ -167,7 +173,9 @@ class EarningsServiceImpl(
             .filter { (_, card) -> card.color == CardColor.PURPLE }
 
         val bankEarned = purpleCards
-            .filter { (_, card) -> card.paymentSource == PaymentSource.BANK }
+            .filter { (_, card) ->
+                card.paymentSource == PaymentSource.BANK || card.paymentSource == PaymentSource.CHOSEN_PLAYER
+            }
             .sumOf { (playerCard, card) -> playerCard.quantity * card.income }
 
         if (bankEarned > 0) {

--- a/src/main/kotlin/org/machikoro/server/service/interfaces/EarningsService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/interfaces/EarningsService.kt
@@ -1,5 +1,7 @@
 package org.machikoro.server.service.interfaces
 
+import org.machikoro.server.domain.enums.CardType
+
 interface EarningsService {
     /**
      * Applies the dice-roll earnings and returns the per-player coin change as
@@ -14,4 +16,15 @@ interface EarningsService {
      * players only) so the broadcast can carry sound-relevant metadata (#389).
      */
     fun resolveEffects(gameId: Int): Map<Int, Int>
+
+    /**
+     * Applies the Business Center card-swap action for the active player.
+     */
+    fun swapBusinessCenterCard(
+        gameId: Int,
+        activePlayerId: Int,
+        targetPlayerId: Int,
+        offeredCardType: CardType,
+        requestedCardType: CardType,
+    )
 }

--- a/src/main/resources/db/migration/V8__business_center_payment_source_none.sql
+++ b/src/main/resources/db/migration/V8__business_center_payment_source_none.sql
@@ -1,0 +1,3 @@
+UPDATE cards
+SET payment_source = 'NONE'
+WHERE card_type = 'BUSINESS_CENTER';

--- a/src/main/resources/db/migration/V9__add_business_center_used_to_games.sql
+++ b/src/main/resources/db/migration/V9__add_business_center_used_to_games.sql
@@ -1,0 +1,2 @@
+ALTER TABLE games
+ADD COLUMN business_center_used_this_turn BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/test/kotlin/org/machikoro/server/controller/EarningsControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/EarningsControllerTest.kt
@@ -236,4 +236,43 @@ class EarningsControllerTest {
         assertEquals("INVALID_BUSINESS_CENTER_CARD", payload.code)
         assertEquals("BUSINESS_CENTER_SWAP_FAILED", payload.context["event"])
     }
+
+    @Test
+    fun `businessCenter swap propagates NOT_YOUR_TURN and does not call service or broadcast`() {
+        val request = BusinessCenterSwapRequest(
+            gameId = 1,
+            targetPlayerId = 2,
+            offeredCardType = CardType.BAKERY,
+            requestedCardType = CardType.RANCH,
+        )
+        whenever(gameStateGuard.ensureSenderIsActivePlayer(1, alice))
+            .thenThrow(CustomWebSocketException("NOT_YOUR_TURN", "It is not your turn"))
+
+        val ex = assertThrows<CustomWebSocketException> {
+            controller.swapBusinessCenterCard(request, authedAccessor())
+        }
+
+        assertEquals("NOT_YOUR_TURN", ex.errorCode)
+        verify(earningsService, never()).swapBusinessCenterCard(any(), any(), any(), any(), any())
+        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<WebSocketMessage>())
+    }
+
+    @Test
+    fun `businessCenter swap throws UNAUTHENTICATED when accessor has no principal`() {
+        val request = BusinessCenterSwapRequest(
+            gameId = 1,
+            targetPlayerId = 2,
+            offeredCardType = CardType.BAKERY,
+            requestedCardType = CardType.RANCH,
+        )
+        val unauthed = SimpMessageHeaderAccessor.create()
+
+        val ex = assertThrows<CustomWebSocketException> {
+            controller.swapBusinessCenterCard(request, unauthed)
+        }
+
+        assertEquals("UNAUTHENTICATED", ex.errorCode)
+        verify(gameStateGuard, never()).ensureSenderIsActivePlayer(any(), any())
+        verify(earningsService, never()).swapBusinessCenterCard(any(), any(), any(), any(), any())
+    }
 }

--- a/src/test/kotlin/org/machikoro/server/controller/EarningsControllerTest.kt
+++ b/src/test/kotlin/org/machikoro/server/controller/EarningsControllerTest.kt
@@ -3,10 +3,12 @@ package org.machikoro.server.controller
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.machikoro.server.auth.UserPrincipal
+import org.machikoro.server.domain.enums.CardType
 import org.machikoro.server.domain.enums.GameStatus
 import org.machikoro.server.domain.enums.TurnPhase
 import org.machikoro.server.domain.models.GameModel
 import org.machikoro.server.domain.models.PlayerModel
+import org.machikoro.server.dto.BusinessCenterSwapRequest
 import org.machikoro.server.dto.GameStateDto
 import org.machikoro.server.dto.MessageType
 import org.machikoro.server.dto.ResolveEffectsRequest
@@ -183,5 +185,55 @@ class EarningsControllerTest {
         assertEquals("UNAUTHENTICATED", ex.errorCode)
         verify(gameStateGuard, never()).ensureSenderIsActivePlayer(any(), any())
         verify(earningsService, never()).resolveEffects(any())
+    }
+
+    @Test
+    fun `businessCenter swap calls service and broadcasts success`() {
+        val request = BusinessCenterSwapRequest(
+            gameId = 1,
+            targetPlayerId = 2,
+            offeredCardType = CardType.BAKERY,
+            requestedCardType = CardType.RANCH,
+        )
+        val activePlayer = PlayerModel(id = 1, gameId = 1, userId = 1, turnOrder = 0, coins = 5, lastSeenAt = null)
+        val snapshot = gameStateDto(1)
+        whenever(gameStateGuard.ensureSenderIsActivePlayer(1, alice)).thenReturn(activePlayer)
+        whenever(gameSyncService.buildSnapshot(1)).thenReturn(snapshot)
+
+        controller.swapBusinessCenterCard(request, authedAccessor())
+
+        verify(earningsService).swapBusinessCenterCard(1, 1, 2, CardType.BAKERY, CardType.RANCH)
+        val captor = argumentCaptor<WebSocketMessage>()
+        verify(messagingTemplate).convertAndSend(eq("/topic/game/1"), captor.capture())
+
+        val message = captor.firstValue
+        assertEquals(MessageType.GAME_ACTION, message.type)
+        val payload = message.payload as Map<*, *>
+        assertEquals("BUSINESS_CENTER_SWAP_APPLIED", payload["event"])
+        assertEquals(snapshot, payload["state"])
+    }
+
+    @Test
+    fun `businessCenter swap broadcasts domain rejection`() {
+        val request = BusinessCenterSwapRequest(
+            gameId = 1,
+            targetPlayerId = 2,
+            offeredCardType = CardType.BAKERY,
+            requestedCardType = CardType.STADIUM,
+        )
+        val activePlayer = PlayerModel(id = 1, gameId = 1, userId = 1, turnOrder = 0, coins = 5, lastSeenAt = null)
+        whenever(gameStateGuard.ensureSenderIsActivePlayer(1, alice)).thenReturn(activePlayer)
+        doThrow(CustomWebSocketException("INVALID_BUSINESS_CENTER_CARD", "Business Center cannot exchange major establishments"))
+            .whenever(earningsService).swapBusinessCenterCard(1, 1, 2, CardType.BAKERY, CardType.STADIUM)
+
+        controller.swapBusinessCenterCard(request, authedAccessor())
+
+        val captor = argumentCaptor<WebSocketMessage>()
+        verify(messagingTemplate).convertAndSend(eq("/topic/game/1"), captor.capture())
+        val message = captor.firstValue
+        assertEquals(MessageType.ERROR, message.type)
+        val payload = message.payload as WebSocketErrorDto
+        assertEquals("INVALID_BUSINESS_CENTER_CARD", payload.code)
+        assertEquals("BUSINESS_CENTER_SWAP_FAILED", payload.context["event"])
     }
 }

--- a/src/test/kotlin/org/machikoro/server/dao/GameDaoTest.kt
+++ b/src/test/kotlin/org/machikoro/server/dao/GameDaoTest.kt
@@ -48,6 +48,7 @@ class GameDaoTest : AbstractDBSetup() {
         assertEquals(0, game.currentTurnIndex)
         assertNull(game.lastDiceRoll)
         assertFalse(game.hasPurchasedThisTurn)
+        assertFalse(game.businessCenterUsedThisTurn)
     }
 
     @Test
@@ -169,6 +170,15 @@ class GameDaoTest : AbstractDBSetup() {
     }
 
     @Test
+    fun `tryMarkBusinessCenterUsedThisTurn succeeds once and then rejects repeats`() {
+        val id = gameDao.create(hostId)
+
+        assertTrue(gameDao.tryMarkBusinessCenterUsedThisTurn(id))
+        assertFalse(gameDao.tryMarkBusinessCenterUsedThisTurn(id))
+        assertTrue(gameDao.findById(id)!!.businessCenterUsedThisTurn)
+    }
+
+    @Test
     fun `updateHasPurchasedThisTurn throws when game does not exist`() {
         assertThrows<GameNotFoundException> {
             gameDao.updateHasPurchasedThisTurn(999999, true)
@@ -180,6 +190,7 @@ class GameDaoTest : AbstractDBSetup() {
         val id = gameDao.create(hostId)
         gameDao.updateAfterRoll(id, diceRoll = 4, phase = TurnPhase.RESOLVE_EFFECTS)
         gameDao.updateHasPurchasedThisTurn(id, true)
+        assertTrue(gameDao.tryMarkBusinessCenterUsedThisTurn(id))
         gameDao.advanceTurn(id, nextTurnIndex = 1, roundNumber = 2)
         val game = gameDao.findById(id)!!
         assertEquals(1, game.currentTurnIndex)
@@ -187,6 +198,7 @@ class GameDaoTest : AbstractDBSetup() {
         assertEquals(TurnPhase.ROLL_DICE, game.turnPhase)
         assertNull(game.lastDiceRoll)
         assertFalse(game.hasPurchasedThisTurn)
+        assertFalse(game.businessCenterUsedThisTurn)
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/database/DataSeederTest.kt
+++ b/src/test/kotlin/org/machikoro/server/database/DataSeederTest.kt
@@ -113,6 +113,14 @@ class DataSeederTest : AbstractDBSetup() {
     }
 
     @Test
+    fun `business center has no payment source for swap action`() {
+        val card = cardDao.findByCardType(CardType.BUSINESS_CENTER)
+        assertNotNull(card)
+        assertEquals(0, card!!.income)
+        assertEquals(PaymentSource.NONE, card.paymentSource)
+    }
+
+    @Test
     fun `red cards take payment from active player`() {
         val redCards = cardDao.findByColor(CardColor.RED)
         assertTrue(redCards.isNotEmpty())

--- a/src/test/kotlin/org/machikoro/server/database/TestDataSeeder.kt
+++ b/src/test/kotlin/org/machikoro/server/database/TestDataSeeder.kt
@@ -121,7 +121,7 @@ object TestDataSeeder {
                 0,
                 CardColor.PURPLE,
                 EstablishmentType.MAJOR,
-                PaymentSource.CHOSEN_PLAYER,
+                PaymentSource.NONE,
                 listOf(6)
             ),
         )

--- a/src/test/kotlin/org/machikoro/server/service/BackendContainerRestartRecoverySmokeTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/BackendContainerRestartRecoverySmokeTest.kt
@@ -321,7 +321,7 @@ class BackendContainerRestartRecoverySmokeTest {
             CardSeed(CardType.FAMILY_RESTAURANT, 3, 2, "RED", "CUP", "ACTIVE_PLAYER", listOf(9, 10)),
             CardSeed(CardType.STADIUM, 6, 2, "PURPLE", "MAJOR", "ALL_PLAYERS", listOf(6)),
             CardSeed(CardType.TV_STATION, 7, 5, "PURPLE", "MAJOR", "CHOSEN_PLAYER", listOf(6)),
-            CardSeed(CardType.BUSINESS_CENTER, 8, 0, "PURPLE", "MAJOR", "CHOSEN_PLAYER", listOf(6)),
+            CardSeed(CardType.BUSINESS_CENTER, 8, 0, "PURPLE", "MAJOR", "NONE", listOf(6)),
         )
         val landmarks = mapOf(
             LandmarkType.TRAIN_STATION to 4,

--- a/src/test/kotlin/org/machikoro/server/service/EarningsServiceImplTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/EarningsServiceImplTest.kt
@@ -256,6 +256,93 @@ class EarningsServiceImplTest {
         verify(playerDao).updateCoins(3, 0)
     }
 
+    @Test
+    fun `purple none payment source does not award coins`() {
+        val players = listOf(
+            player(1, 3),
+            player(2, 3)
+        )
+
+        val businessCenter = card(
+            cardType = CardType.BUSINESS_CENTER,
+            color = CardColor.PURPLE,
+            income = 0,
+            paymentSource = PaymentSource.NONE
+        )
+
+        whenever(cardDao.findByActivationNumber(6)).thenReturn(listOf(businessCenter))
+        whenever(playerDao.getPlayers(1)).thenReturn(players)
+        whenever(playerCardDao.findByPlayerId(1)).thenReturn(listOf(playerCard(CardType.BUSINESS_CENTER, 1)))
+        whenever(playerCardDao.findByPlayerId(2)).thenReturn(emptyList())
+
+        val deltas = service.processEarnings(1, 6, 1)
+
+        assertEquals(emptyMap<Int, Int>(), deltas)
+        verify(playerDao, never()).updateCoins(anyInt(), anyInt())
+    }
+
+    @Test
+    fun `business center swaps one non-major card with target player`() {
+        val game = GameModel(
+            id = 1, status = GameStatus.IN_PROGRESS, hostUserId = 1, lobbyCode = "TEST",
+            maxPlayers = 4, currentTurnIndex = 0, turnPhase = TurnPhase.BUY_OR_BUILD,
+            lastDiceRoll = 6, roundNumber = 1, hasPurchasedThisTurn = false, rerolledThisTurn = false
+        )
+        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(game)
+        whenever(playerDao.getPlayers(1)).thenReturn(listOf(player(1, 3), player(2, 3)))
+        whenever(playerCardDao.findByPlayerId(1)).thenReturn(
+            listOf(
+                playerCard(CardType.BUSINESS_CENTER, 1),
+                playerCard(CardType.BAKERY, 1),
+            )
+        )
+        whenever(playerCardDao.findByPlayerId(2)).thenReturn(listOf(playerCard(CardType.RANCH, 2)))
+        whenever(cardDao.findByCardType(CardType.BAKERY)).thenReturn(
+            card(CardType.BAKERY, CardColor.GREEN, 1).copy(establishmentType = EstablishmentType.BREAD)
+        )
+        whenever(cardDao.findByCardType(CardType.RANCH)).thenReturn(
+            card(CardType.RANCH, CardColor.BLUE, 1).copy(establishmentType = EstablishmentType.COW)
+        )
+
+        service.swapBusinessCenterCard(1, 1, 2, CardType.BAKERY, CardType.RANCH)
+
+        verify(playerCardDao).upsert(1, CardType.BAKERY, 0)
+        verify(playerCardDao).upsert(2, CardType.RANCH, 1)
+        verify(playerCardDao).upsert(1, CardType.RANCH, 1)
+        verify(playerCardDao).upsert(2, CardType.BAKERY, 1)
+    }
+
+    @Test
+    fun `business center rejects major establishment swaps`() {
+        val game = GameModel(
+            id = 1, status = GameStatus.IN_PROGRESS, hostUserId = 1, lobbyCode = "TEST",
+            maxPlayers = 4, currentTurnIndex = 0, turnPhase = TurnPhase.BUY_OR_BUILD,
+            lastDiceRoll = 6, roundNumber = 1, hasPurchasedThisTurn = false, rerolledThisTurn = false
+        )
+        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(game)
+        whenever(playerDao.getPlayers(1)).thenReturn(listOf(player(1, 3), player(2, 3)))
+        whenever(playerCardDao.findByPlayerId(1)).thenReturn(
+            listOf(
+                playerCard(CardType.BUSINESS_CENTER, 1),
+                playerCard(CardType.BAKERY, 1),
+            )
+        )
+        whenever(playerCardDao.findByPlayerId(2)).thenReturn(listOf(playerCard(CardType.STADIUM, 1)))
+        whenever(cardDao.findByCardType(CardType.BAKERY)).thenReturn(
+            card(CardType.BAKERY, CardColor.GREEN, 1).copy(establishmentType = EstablishmentType.BREAD)
+        )
+        whenever(cardDao.findByCardType(CardType.STADIUM)).thenReturn(
+            card(CardType.STADIUM, CardColor.PURPLE, 2).copy(establishmentType = EstablishmentType.MAJOR)
+        )
+
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            service.swapBusinessCenterCard(1, 1, 2, CardType.BAKERY, CardType.STADIUM)
+        }
+
+        assertEquals("INVALID_BUSINESS_CENTER_CARD", ex.errorCode)
+        verify(playerCardDao, never()).upsert(anyInt(), any(), anyInt())
+    }
+
     // After resolving effects the game should enter buy phase
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/service/EarningsServiceImplTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/EarningsServiceImplTest.kt
@@ -282,7 +282,11 @@ class EarningsServiceImplTest {
     }
 
     @Test
-    fun `purple chosen player payment source does not award bank coins`() {
+    fun `purple chosen player payment source still credits bank pending tv station steal`() {
+        // TV Station (CHOSEN_PLAYER) is intentionally left on the pre-existing
+        // bank-credit path here; the proper steal is handled by #433. Business
+        // Center must not regress this card, so it keeps awarding the active
+        // player from the bank.
         val players = listOf(
             player(1, 3),
             player(2, 3)
@@ -302,8 +306,9 @@ class EarningsServiceImplTest {
 
         val deltas = service.processEarnings(1, 6, 1)
 
-        assertEquals(emptyMap<Int, Int>(), deltas)
-        verify(playerDao, never()).updateCoins(anyInt(), anyInt())
+        assertEquals(mapOf(1 to 5), deltas)
+        verify(playerDao).updateCoins(1, 8)
+        verify(playerDao, never()).updateCoins(eq(2), anyInt())
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/service/EarningsServiceImplTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/EarningsServiceImplTest.kt
@@ -282,13 +282,33 @@ class EarningsServiceImplTest {
     }
 
     @Test
-    fun `business center swaps one non-major card with target player`() {
-        val game = GameModel(
-            id = 1, status = GameStatus.IN_PROGRESS, hostUserId = 1, lobbyCode = "TEST",
-            maxPlayers = 4, currentTurnIndex = 0, turnPhase = TurnPhase.BUY_OR_BUILD,
-            lastDiceRoll = 6, roundNumber = 1, hasPurchasedThisTurn = false, rerolledThisTurn = false
+    fun `purple chosen player payment source does not award bank coins`() {
+        val players = listOf(
+            player(1, 3),
+            player(2, 3)
         )
-        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(game)
+
+        val tvStation = card(
+            cardType = CardType.TV_STATION,
+            color = CardColor.PURPLE,
+            income = 5,
+            paymentSource = PaymentSource.CHOSEN_PLAYER
+        )
+
+        whenever(cardDao.findByActivationNumber(6)).thenReturn(listOf(tvStation))
+        whenever(playerDao.getPlayers(1)).thenReturn(players)
+        whenever(playerCardDao.findByPlayerId(1)).thenReturn(listOf(playerCard(CardType.TV_STATION, 1)))
+        whenever(playerCardDao.findByPlayerId(2)).thenReturn(emptyList())
+
+        val deltas = service.processEarnings(1, 6, 1)
+
+        assertEquals(emptyMap<Int, Int>(), deltas)
+        verify(playerDao, never()).updateCoins(anyInt(), anyInt())
+    }
+
+    @Test
+    fun `business center swaps one non-major card with target player`() {
+        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(businessCenterGame())
         whenever(playerDao.getPlayers(1)).thenReturn(listOf(player(1, 3), player(2, 3)))
         whenever(playerCardDao.findByPlayerId(1)).thenReturn(
             listOf(
@@ -303,9 +323,11 @@ class EarningsServiceImplTest {
         whenever(cardDao.findByCardType(CardType.RANCH)).thenReturn(
             card(CardType.RANCH, CardColor.BLUE, 1).copy(establishmentType = EstablishmentType.COW)
         )
+        whenever(gameDao.tryMarkBusinessCenterUsedThisTurn(1)).thenReturn(true)
 
         service.swapBusinessCenterCard(1, 1, 2, CardType.BAKERY, CardType.RANCH)
 
+        verify(gameDao).tryMarkBusinessCenterUsedThisTurn(1)
         verify(playerCardDao).upsert(1, CardType.BAKERY, 0)
         verify(playerCardDao).upsert(2, CardType.RANCH, 1)
         verify(playerCardDao).upsert(1, CardType.RANCH, 1)
@@ -314,12 +336,7 @@ class EarningsServiceImplTest {
 
     @Test
     fun `business center rejects major establishment swaps`() {
-        val game = GameModel(
-            id = 1, status = GameStatus.IN_PROGRESS, hostUserId = 1, lobbyCode = "TEST",
-            maxPlayers = 4, currentTurnIndex = 0, turnPhase = TurnPhase.BUY_OR_BUILD,
-            lastDiceRoll = 6, roundNumber = 1, hasPurchasedThisTurn = false, rerolledThisTurn = false
-        )
-        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(game)
+        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(businessCenterGame())
         whenever(playerDao.getPlayers(1)).thenReturn(listOf(player(1, 3), player(2, 3)))
         whenever(playerCardDao.findByPlayerId(1)).thenReturn(
             listOf(
@@ -341,6 +358,249 @@ class EarningsServiceImplTest {
 
         assertEquals("INVALID_BUSINESS_CENTER_CARD", ex.errorCode)
         verify(playerCardDao, never()).upsert(anyInt(), any(), anyInt())
+    }
+
+    @Test
+    fun `business center rejects already used turn flag`() {
+        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(
+            businessCenterGame(businessCenterUsedThisTurn = true)
+        )
+
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            service.swapBusinessCenterCard(1, 1, 2, CardType.BAKERY, CardType.RANCH)
+        }
+
+        assertEquals("BUSINESS_CENTER_ALREADY_USED", ex.errorCode)
+        verify(playerDao, never()).getPlayers(anyInt())
+        verify(gameDao, never()).tryMarkBusinessCenterUsedThisTurn(anyInt())
+    }
+
+    @Test
+    fun `business center rejects swap before it is active`() {
+        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(
+            businessCenterGame(turnPhase = TurnPhase.RESOLVE_EFFECTS, lastDiceRoll = 6)
+        )
+
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            service.swapBusinessCenterCard(1, 1, 2, CardType.BAKERY, CardType.RANCH)
+        }
+
+        assertEquals("BUSINESS_CENTER_NOT_ACTIVE", ex.errorCode)
+        verify(playerDao, never()).getPlayers(anyInt())
+    }
+
+    @Test
+    fun `business center rejects swap when roll was not six`() {
+        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(businessCenterGame(lastDiceRoll = 5))
+
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            service.swapBusinessCenterCard(1, 1, 2, CardType.BAKERY, CardType.RANCH)
+        }
+
+        assertEquals("BUSINESS_CENTER_NOT_ACTIVE", ex.errorCode)
+        verify(playerDao, never()).getPlayers(anyInt())
+    }
+
+    @Test
+    fun `business center rejects missing active player`() {
+        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(businessCenterGame(currentTurnIndex = 2))
+        whenever(playerDao.getPlayers(1)).thenReturn(listOf(player(1, 3), player(2, 3)))
+
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            service.swapBusinessCenterCard(1, 1, 2, CardType.BAKERY, CardType.RANCH)
+        }
+
+        assertEquals("NO_ACTIVE_PLAYER", ex.errorCode)
+        verify(playerCardDao, never()).findByPlayerId(anyInt())
+    }
+
+    @Test
+    fun `business center rejects non active player caller`() {
+        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(businessCenterGame())
+        whenever(playerDao.getPlayers(1)).thenReturn(listOf(player(1, 3), player(2, 3)))
+
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            service.swapBusinessCenterCard(1, 2, 1, CardType.BAKERY, CardType.RANCH)
+        }
+
+        assertEquals("NOT_YOUR_TURN", ex.errorCode)
+        verify(playerCardDao, never()).findByPlayerId(anyInt())
+    }
+
+    @Test
+    fun `business center rejects target outside game`() {
+        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(businessCenterGame())
+        whenever(playerDao.getPlayers(1)).thenReturn(listOf(player(1, 3), player(2, 3)))
+
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            service.swapBusinessCenterCard(1, 1, 99, CardType.BAKERY, CardType.RANCH)
+        }
+
+        assertEquals("INVALID_SWAP_TARGET", ex.errorCode)
+        verify(playerCardDao, never()).findByPlayerId(anyInt())
+    }
+
+    @Test
+    fun `business center rejects active player as target`() {
+        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(businessCenterGame())
+        whenever(playerDao.getPlayers(1)).thenReturn(listOf(player(1, 3), player(2, 3)))
+
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            service.swapBusinessCenterCard(1, 1, 1, CardType.BAKERY, CardType.RANCH)
+        }
+
+        assertEquals("INVALID_SWAP_TARGET", ex.errorCode)
+        verify(playerCardDao, never()).findByPlayerId(anyInt())
+    }
+
+    @Test
+    fun `business center rejects same card type exchange`() {
+        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(businessCenterGame())
+        whenever(playerDao.getPlayers(1)).thenReturn(listOf(player(1, 3), player(2, 3)))
+
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            service.swapBusinessCenterCard(1, 1, 2, CardType.BAKERY, CardType.BAKERY)
+        }
+
+        assertEquals("INVALID_BUSINESS_CENTER_CARD", ex.errorCode)
+        verify(playerCardDao, never()).findByPlayerId(anyInt())
+    }
+
+    @Test
+    fun `business center rejects player without business center`() {
+        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(businessCenterGame())
+        whenever(playerDao.getPlayers(1)).thenReturn(listOf(player(1, 3), player(2, 3)))
+        whenever(playerCardDao.findByPlayerId(1)).thenReturn(listOf(playerCard(CardType.BAKERY, 1)))
+        whenever(playerCardDao.findByPlayerId(2)).thenReturn(listOf(playerCard(CardType.RANCH, 1)))
+
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            service.swapBusinessCenterCard(1, 1, 2, CardType.BAKERY, CardType.RANCH)
+        }
+
+        assertEquals("BUSINESS_CENTER_NOT_OWNED", ex.errorCode)
+        verify(cardDao, never()).findByCardType(any())
+        verify(playerCardDao, never()).upsert(anyInt(), any(), anyInt())
+    }
+
+    @Test
+    fun `business center rejects unknown offered card definition`() {
+        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(businessCenterGame())
+        whenever(playerDao.getPlayers(1)).thenReturn(listOf(player(1, 3), player(2, 3)))
+        whenever(playerCardDao.findByPlayerId(1)).thenReturn(
+            listOf(playerCard(CardType.BUSINESS_CENTER, 1), playerCard(CardType.BAKERY, 1))
+        )
+        whenever(playerCardDao.findByPlayerId(2)).thenReturn(listOf(playerCard(CardType.RANCH, 1)))
+        whenever(cardDao.findByCardType(CardType.BAKERY)).thenReturn(null)
+
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            service.swapBusinessCenterCard(1, 1, 2, CardType.BAKERY, CardType.RANCH)
+        }
+
+        assertEquals("CARD_NOT_FOUND", ex.errorCode)
+        verify(playerCardDao, never()).upsert(anyInt(), any(), anyInt())
+    }
+
+    @Test
+    fun `business center rejects unknown requested card definition`() {
+        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(businessCenterGame())
+        whenever(playerDao.getPlayers(1)).thenReturn(listOf(player(1, 3), player(2, 3)))
+        whenever(playerCardDao.findByPlayerId(1)).thenReturn(
+            listOf(playerCard(CardType.BUSINESS_CENTER, 1), playerCard(CardType.BAKERY, 1))
+        )
+        whenever(playerCardDao.findByPlayerId(2)).thenReturn(listOf(playerCard(CardType.RANCH, 1)))
+        whenever(cardDao.findByCardType(CardType.BAKERY)).thenReturn(
+            card(CardType.BAKERY, CardColor.GREEN, 1).copy(establishmentType = EstablishmentType.BREAD)
+        )
+        whenever(cardDao.findByCardType(CardType.RANCH)).thenReturn(null)
+
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            service.swapBusinessCenterCard(1, 1, 2, CardType.BAKERY, CardType.RANCH)
+        }
+
+        assertEquals("CARD_NOT_FOUND", ex.errorCode)
+        verify(playerCardDao, never()).upsert(anyInt(), any(), anyInt())
+    }
+
+    @Test
+    fun `business center rejects cards not owned by both players`() {
+        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(businessCenterGame())
+        whenever(playerDao.getPlayers(1)).thenReturn(listOf(player(1, 3), player(2, 3)))
+        whenever(playerCardDao.findByPlayerId(1)).thenReturn(listOf(playerCard(CardType.BUSINESS_CENTER, 1)))
+        whenever(playerCardDao.findByPlayerId(2)).thenReturn(listOf(playerCard(CardType.RANCH, 1)))
+        whenever(cardDao.findByCardType(CardType.BAKERY)).thenReturn(
+            card(CardType.BAKERY, CardColor.GREEN, 1).copy(establishmentType = EstablishmentType.BREAD)
+        )
+        whenever(cardDao.findByCardType(CardType.RANCH)).thenReturn(
+            card(CardType.RANCH, CardColor.BLUE, 1).copy(establishmentType = EstablishmentType.COW)
+        )
+
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            service.swapBusinessCenterCard(1, 1, 2, CardType.BAKERY, CardType.RANCH)
+        }
+
+        assertEquals("CARD_NOT_OWNED", ex.errorCode)
+        verify(playerCardDao, never()).upsert(anyInt(), any(), anyInt())
+        verify(gameDao, never()).tryMarkBusinessCenterUsedThisTurn(anyInt())
+    }
+
+    @Test
+    fun `business center rejects second swap when mark fails`() {
+        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(businessCenterGame())
+        whenever(playerDao.getPlayers(1)).thenReturn(listOf(player(1, 3), player(2, 3)))
+        whenever(playerCardDao.findByPlayerId(1)).thenReturn(
+            listOf(
+                playerCard(CardType.BUSINESS_CENTER, 1),
+                playerCard(CardType.BAKERY, 1),
+            )
+        )
+        whenever(playerCardDao.findByPlayerId(2)).thenReturn(listOf(playerCard(CardType.RANCH, 1)))
+        whenever(cardDao.findByCardType(CardType.BAKERY)).thenReturn(
+            card(CardType.BAKERY, CardColor.GREEN, 1).copy(establishmentType = EstablishmentType.BREAD)
+        )
+        whenever(cardDao.findByCardType(CardType.RANCH)).thenReturn(
+            card(CardType.RANCH, CardColor.BLUE, 1).copy(establishmentType = EstablishmentType.COW)
+        )
+        whenever(gameDao.tryMarkBusinessCenterUsedThisTurn(1)).thenReturn(false)
+
+        val ex = assertThrows(CustomWebSocketException::class.java) {
+            service.swapBusinessCenterCard(1, 1, 2, CardType.BAKERY, CardType.RANCH)
+        }
+
+        assertEquals("BUSINESS_CENTER_ALREADY_USED", ex.errorCode)
+        verify(playerCardDao, never()).upsert(anyInt(), any(), anyInt())
+    }
+
+    @Test
+    fun `business center increments existing swapped card quantities`() {
+        whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(businessCenterGame())
+        whenever(playerDao.getPlayers(1)).thenReturn(listOf(player(1, 3), player(2, 3)))
+        whenever(playerCardDao.findByPlayerId(1)).thenReturn(
+            listOf(
+                playerCard(CardType.BUSINESS_CENTER, 1),
+                playerCard(CardType.BAKERY, 2),
+                playerCard(CardType.RANCH, 3),
+            )
+        )
+        whenever(playerCardDao.findByPlayerId(2)).thenReturn(
+            listOf(
+                playerCard(CardType.RANCH, 4),
+                playerCard(CardType.BAKERY, 5),
+            )
+        )
+        whenever(cardDao.findByCardType(CardType.BAKERY)).thenReturn(
+            card(CardType.BAKERY, CardColor.GREEN, 1).copy(establishmentType = EstablishmentType.BREAD)
+        )
+        whenever(cardDao.findByCardType(CardType.RANCH)).thenReturn(
+            card(CardType.RANCH, CardColor.BLUE, 1).copy(establishmentType = EstablishmentType.COW)
+        )
+        whenever(gameDao.tryMarkBusinessCenterUsedThisTurn(1)).thenReturn(true)
+
+        service.swapBusinessCenterCard(1, 1, 2, CardType.BAKERY, CardType.RANCH)
+
+        verify(playerCardDao).upsert(1, CardType.BAKERY, 1)
+        verify(playerCardDao).upsert(2, CardType.RANCH, 3)
+        verify(playerCardDao).upsert(1, CardType.RANCH, 4)
+        verify(playerCardDao).upsert(2, CardType.BAKERY, 6)
     }
 
     // After resolving effects the game should enter buy phase
@@ -753,6 +1013,27 @@ class EarningsServiceImplTest {
 
     private fun playerCard(cardType: CardType, quantity: Int): PlayerCardModel =
         PlayerCardModel(playerId = 1, cardType = cardType, quantity = quantity)
+
+    private fun businessCenterGame(
+        currentTurnIndex: Int = 0,
+        turnPhase: TurnPhase = TurnPhase.BUY_OR_BUILD,
+        lastDiceRoll: Int? = 6,
+        businessCenterUsedThisTurn: Boolean = false,
+    ): GameModel =
+        GameModel(
+            id = 1,
+            status = GameStatus.IN_PROGRESS,
+            hostUserId = 1,
+            lobbyCode = "TEST",
+            maxPlayers = 4,
+            currentTurnIndex = currentTurnIndex,
+            turnPhase = turnPhase,
+            lastDiceRoll = lastDiceRoll,
+            roundNumber = 1,
+            hasPurchasedThisTurn = false,
+            businessCenterUsedThisTurn = businessCenterUsedThisTurn,
+            rerolledThisTurn = false,
+        )
 
     private fun card(
         cardType: CardType,


### PR DESCRIPTION
## Summary

Fixes the `BUSINESS_CENTER` card behavior so it no longer acts as a no-op after activation.

Previously, `BUSINESS_CENTER` was seeded with `income = 0` and treated like a normal purple income card path. Because its effect is a card swap rather than a coin transfer, resolving effects after rolling a 6 did not produce any useful gameplay behavior.

This PR adds a dedicated Business Center swap action, corrects the card metadata, and covers the new behavior with focused tests.

## What Changed

- Added a new WebSocket action:
  - `/app/game.businessCenter.swap`

- Added `BusinessCenterSwapRequest` with:
  - `gameId`
  - `targetPlayerId`
  - `offeredCardType`
  - `requestedCardType`

- Implemented Business Center swap logic in `EarningsServiceImpl`.
  - Only usable by the active player.
  - Only usable after effects have been resolved for a dice roll of `6`.
  - Requires the active player to own `BUSINESS_CENTER`.
  - Requires the target player to be a different player in the same game.
  - Requires both players to own the cards being exchanged.
  - Rejects swaps involving major establishments.
  - Rejects swapping the same card type with itself.

- Updated purple-card earnings resolution so `PaymentSource.NONE` is not treated as bank income.

- Corrected `BUSINESS_CENTER` seed data:
  - Changed `paymentSource` from `CHOSEN_PLAYER` to `NONE`.

- Added a Flyway migration:
  - `V8__business_center_payment_source_none.sql`
  - Updates existing databases so `BUSINESS_CENTER` uses `payment_source = 'NONE'`.

- Updated WebSocket API documentation in `OpenApiConfig`.

## Tests Added / Updated

- Added service tests for:
  - `PaymentSource.NONE` purple cards not awarding coins.
  - Successful Business Center card swap.
  - Rejecting swaps involving major establishments.

- Added controller tests for:
  - Successful Business Center swap broadcast.
  - Business Center swap rejection broadcast.

- Updated seed-related tests and test seed data to expect `PaymentSource.NONE`.

## Verification

Ran successfully:

```bash
./gradlew test --tests org.machikoro.server.service.EarningsServiceImplTest --tests org.machikoro.server.controller.EarningsControllerTest
./gradlew compileKotlin compileTestKotlin