### PR TITLE
fix: multiply factory/market income by owned establishments (#432)

### DIFF
--- a/src/main/kotlin/org/machikoro/server/service/EarningsServiceImpl.kt
+++ b/src/main/kotlin/org/machikoro/server/service/EarningsServiceImpl.kt
@@ -6,6 +6,7 @@ import org.machikoro.server.dao.PlayerCardDao
 import org.machikoro.server.dao.PlayerDao
 import org.machikoro.server.dao.PlayerLandmarkDao
 import org.machikoro.server.domain.enums.CardColor
+import org.machikoro.server.domain.enums.CardType
 import org.machikoro.server.domain.enums.EstablishmentType
 import org.machikoro.server.domain.enums.LandmarkType
 import org.machikoro.server.domain.enums.PaymentSource
@@ -46,18 +47,33 @@ class EarningsServiceImpl(
         val players = playerDao.getPlayers(gameId)
         val finalCoins = players.associate { it.id to it.coins }.toMutableMap()
 
-        val matchedCardsByPlayer = players.associate { player ->
+        val inventoryByPlayer = players.associate { player ->
             player.id to playerCardDao.findByPlayerId(player.id)
-                .mapNotNull { playerCard -> activatingCards[playerCard.cardType]?.let { playerCard to it } }
+        }
+
+        val matchedCardsByPlayer = inventoryByPlayer.mapValues { (_, cards) ->
+            cards.mapNotNull { playerCard -> activatingCards[playerCard.cardType]?.let { playerCard to it } }
         }
 
         val hasShoppingMallByPlayerId = players.associate { player ->
             player.id to (playerLandmarkDao.findByPlayerIdAndType(player.id, LandmarkType.SHOPPING_MALL)?.isBuilt == true)
         }
 
+        // Cheese/Furniture Factory and Fruit & Vegetable Market pay per matching
+        // establishment the active player owns (issue #432), so we need a count of
+        // every establishment type in the active player's full inventory.
+        val activeEstablishmentCounts = establishmentCounts(inventoryByPlayer[activePlayerId].orEmpty())
+
         processRedCards(players, activePlayerId, matchedCardsByPlayer, finalCoins, hasShoppingMallByPlayerId)
         processBlueCards(players, matchedCardsByPlayer, finalCoins)
-        processGreenCards(players, activePlayerId, matchedCardsByPlayer, finalCoins, hasShoppingMallByPlayerId)
+        processGreenCards(
+            players,
+            activePlayerId,
+            matchedCardsByPlayer,
+            finalCoins,
+            hasShoppingMallByPlayerId,
+            activeEstablishmentCounts,
+        )
         processPurpleCards(players, activePlayerId, matchedCardsByPlayer, finalCoins)
 
         players.forEach { player ->
@@ -127,13 +143,18 @@ class EarningsServiceImpl(
 
     /**
      * GREEN cards (OWN_TURN): only the active player receives income from the bank.
+     *
+     * Most green cards pay a flat `quantity × income`. Cheese Factory, Furniture
+     * Factory and Fruit & Vegetable Market instead pay `income` for each matching
+     * establishment the active player owns (see [factoryMultiplier]).
      */
     private fun processGreenCards(
         players: List<PlayerModel>,
         activePlayerId: Int,
         matchedCardsByPlayer: Map<Int, List<Pair<PlayerCardModel, CardModel>>>,
         finalCoins: MutableMap<Int, Int>,
-        hasShoppingMallByPlayerId: Map<Int, Boolean>
+        hasShoppingMallByPlayerId: Map<Int, Boolean>,
+        activeEstablishmentCounts: Map<EstablishmentType, Int>,
     ) {
         val activePlayer = players.find { it.id == activePlayerId } ?: return
         val earned = matchedCardsByPlayer[activePlayer.id].orEmpty()
@@ -141,12 +162,46 @@ class EarningsServiceImpl(
             .sumOf { (playerCard, card) ->
                 val extra = if (card.establishmentType == EstablishmentType.BREAD && hasShoppingMallByPlayerId[activePlayer.id] == true)
                     1 else 0
-                playerCard.quantity * (card.income + extra)
+                val multiplier = factoryMultiplier(card, activeEstablishmentCounts)
+                playerCard.quantity * (card.income + extra) * multiplier
             }
 
         if (earned > 0) {
             finalCoins[activePlayerId] = finalCoins.getValue(activePlayerId) + earned
         }
+    }
+
+    /**
+     * Per Machi Koro rules, factory/market green cards multiply their income by
+     * the number of a specific other establishment the active player owns:
+     * - Cheese Factory → owned COW cards (Ranch)
+     * - Furniture Factory → owned GEAR cards (Forest, Mine)
+     * - Fruit & Vegetable Market → owned WHEAT cards (Wheat Field, Apple Orchard)
+     *
+     * Every other green card pays its flat income, i.e. a multiplier of 1.
+     */
+    private fun factoryMultiplier(
+        card: CardModel,
+        establishmentCounts: Map<EstablishmentType, Int>,
+    ): Int = when (card.cardType) {
+        CardType.CHEESE_FACTORY -> establishmentCounts[EstablishmentType.COW] ?: 0
+        CardType.FURNITURE_FACTORY -> establishmentCounts[EstablishmentType.GEAR] ?: 0
+        CardType.FRUIT_AND_VEGETABLE_MARKET -> establishmentCounts[EstablishmentType.WHEAT] ?: 0
+        else -> 1
+    }
+
+    /**
+     * Counts how many establishments of each [EstablishmentType] a player owns,
+     * resolving each owned card's symbol from the card definitions. Used to drive
+     * the factory/market income multipliers (issue #432).
+     */
+    private fun establishmentCounts(inventory: List<PlayerCardModel>): Map<EstablishmentType, Int> {
+        if (inventory.isEmpty()) return emptyMap()
+        val establishmentTypeByCard = cardDao.findAll().associate { it.cardType to it.establishmentType }
+        return inventory
+            .groupBy { establishmentTypeByCard[it.cardType] }
+            .mapNotNull { (type, cards) -> type?.let { it to cards.sumOf { card -> card.quantity } } }
+            .toMap()
     }
 
     /**

--- a/src/test/kotlin/org/machikoro/server/service/EarningsServiceImplTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/EarningsServiceImplTest.kt
@@ -661,6 +661,147 @@ class EarningsServiceImplTest {
         verify(playerDao).updateCoins(2, 5) // 3 + 2 = 5
     }
 
+    // Factory / market green cards multiply income by owned establishments (issue #432)
+
+    @Test
+    fun `cheese factory pays three coins per owned cow card`() {
+        val players = listOf(player(1, 0))
+
+        val cheeseFactory = card(
+            cardType = CardType.CHEESE_FACTORY,
+            color = CardColor.GREEN,
+            income = 3
+        ).copy(establishmentType = EstablishmentType.FACTORY)
+
+        whenever(cardDao.findByActivationNumber(7)).thenReturn(listOf(cheeseFactory))
+        whenever(cardDao.findAll()).thenReturn(seededCards)
+        whenever(playerDao.getPlayers(1)).thenReturn(players)
+        // 1 Cheese Factory + 2 Ranch (COW): income = 3 * 2 cows = 6.
+        whenever(playerCardDao.findByPlayerId(1)).thenReturn(
+            listOf(
+                playerCard(CardType.CHEESE_FACTORY, 1),
+                playerCard(CardType.RANCH, 2),
+            )
+        )
+
+        service.processEarnings(1, 7, 1)
+
+        verify(playerDao).updateCoins(1, 6)
+    }
+
+    @Test
+    fun `cheese factory multiplies by both quantity and cow count`() {
+        val players = listOf(player(1, 0))
+
+        val cheeseFactory = card(
+            cardType = CardType.CHEESE_FACTORY,
+            color = CardColor.GREEN,
+            income = 3
+        ).copy(establishmentType = EstablishmentType.FACTORY)
+
+        whenever(cardDao.findByActivationNumber(7)).thenReturn(listOf(cheeseFactory))
+        whenever(cardDao.findAll()).thenReturn(seededCards)
+        whenever(playerDao.getPlayers(1)).thenReturn(players)
+        // 2 Cheese Factories + 3 Ranch (COW): income = 2 * 3 * 3 = 18.
+        whenever(playerCardDao.findByPlayerId(1)).thenReturn(
+            listOf(
+                playerCard(CardType.CHEESE_FACTORY, 2),
+                playerCard(CardType.RANCH, 3),
+            )
+        )
+
+        service.processEarnings(1, 7, 1)
+
+        verify(playerDao).updateCoins(1, 18)
+    }
+
+    @Test
+    fun `cheese factory pays nothing without any cow cards`() {
+        val players = listOf(player(1, 0))
+
+        val cheeseFactory = card(
+            cardType = CardType.CHEESE_FACTORY,
+            color = CardColor.GREEN,
+            income = 3
+        ).copy(establishmentType = EstablishmentType.FACTORY)
+
+        whenever(cardDao.findByActivationNumber(7)).thenReturn(listOf(cheeseFactory))
+        whenever(cardDao.findAll()).thenReturn(seededCards)
+        whenever(playerDao.getPlayers(1)).thenReturn(players)
+        whenever(playerCardDao.findByPlayerId(1)).thenReturn(listOf(playerCard(CardType.CHEESE_FACTORY, 1)))
+
+        val deltas = service.processEarnings(1, 7, 1)
+
+        assertEquals(emptyMap<Int, Int>(), deltas)
+        verify(playerDao, never()).updateCoins(anyInt(), anyInt())
+    }
+
+    @Test
+    fun `furniture factory pays three coins per owned gear card`() {
+        val players = listOf(player(1, 0))
+
+        val furnitureFactory = card(
+            cardType = CardType.FURNITURE_FACTORY,
+            color = CardColor.GREEN,
+            income = 3
+        ).copy(establishmentType = EstablishmentType.FACTORY)
+
+        whenever(cardDao.findByActivationNumber(8)).thenReturn(listOf(furnitureFactory))
+        whenever(cardDao.findAll()).thenReturn(seededCards)
+        whenever(playerDao.getPlayers(1)).thenReturn(players)
+        // 1 Furniture Factory + 1 Forest + 1 Mine (both GEAR): income = 3 * 2 gears = 6.
+        whenever(playerCardDao.findByPlayerId(1)).thenReturn(
+            listOf(
+                playerCard(CardType.FURNITURE_FACTORY, 1),
+                playerCard(CardType.FOREST, 1),
+                playerCard(CardType.MINE, 1),
+            )
+        )
+
+        service.processEarnings(1, 8, 1)
+
+        verify(playerDao).updateCoins(1, 6)
+    }
+
+    @Test
+    fun `fruit and vegetable market pays two coins per owned wheat card`() {
+        val players = listOf(player(1, 0))
+
+        val market = card(
+            cardType = CardType.FRUIT_AND_VEGETABLE_MARKET,
+            color = CardColor.GREEN,
+            income = 2
+        ).copy(establishmentType = EstablishmentType.FRUIT)
+
+        whenever(cardDao.findByActivationNumber(11)).thenReturn(listOf(market))
+        whenever(cardDao.findAll()).thenReturn(seededCards)
+        whenever(playerDao.getPlayers(1)).thenReturn(players)
+        // 1 Market + 1 Wheat Field + 1 Apple Orchard (both WHEAT): income = 2 * 2 wheat = 4.
+        whenever(playerCardDao.findByPlayerId(1)).thenReturn(
+            listOf(
+                playerCard(CardType.FRUIT_AND_VEGETABLE_MARKET, 1),
+                playerCard(CardType.WHEAT_FIELD, 1),
+                playerCard(CardType.APPLE_ORCHARD, 1),
+            )
+        )
+
+        service.processEarnings(1, 11, 1)
+
+        verify(playerDao).updateCoins(1, 4)
+    }
+
+    // Card definitions covering every establishment symbol used by the multiplier tests.
+    private val seededCards: List<CardModel> = listOf(
+        card(CardType.WHEAT_FIELD, CardColor.BLUE, 1).copy(establishmentType = EstablishmentType.WHEAT),
+        card(CardType.RANCH, CardColor.BLUE, 1).copy(establishmentType = EstablishmentType.COW),
+        card(CardType.FOREST, CardColor.BLUE, 1).copy(establishmentType = EstablishmentType.GEAR),
+        card(CardType.MINE, CardColor.BLUE, 5).copy(establishmentType = EstablishmentType.GEAR),
+        card(CardType.APPLE_ORCHARD, CardColor.BLUE, 3).copy(establishmentType = EstablishmentType.WHEAT),
+        card(CardType.CHEESE_FACTORY, CardColor.GREEN, 3).copy(establishmentType = EstablishmentType.FACTORY),
+        card(CardType.FURNITURE_FACTORY, CardColor.GREEN, 3).copy(establishmentType = EstablishmentType.FACTORY),
+        card(CardType.FRUIT_AND_VEGETABLE_MARKET, CardColor.GREEN, 2).copy(establishmentType = EstablishmentType.FRUIT),
+    )
+
     private fun player(id: Int, coins: Int): PlayerModel =
         PlayerModel(id = id, gameId = 1, userId = id, turnOrder = 0, coins = coins, lastSeenAt = null)
 


### PR DESCRIPTION
## Summary

Fixes #432. `CHEESE_FACTORY`, `FURNITURE_FACTORY` and `FRUIT_AND_VEGETABLE_MARKET` were paying a flat `quantity × income`. Per Machi Koro rules these cards must multiply their income by the number of a specific *other* establishment the active player owns.

| Card | Pays | Per |
| --- | --- | --- |
| Cheese Factory | 3 coins | each owned **COW** card (Ranch) |
| Furniture Factory | 3 coins | each owned **GEAR** card (Forest, Mine) |
| Fruit & Vegetable Market | 2 coins | each owned **WHEAT** card (Wheat Field, Apple Orchard) |

## Changes

`EarningsServiceImpl`:
- `processEarnings` now keeps each player's full inventory (`inventoryByPlayer`) and derives `matchedCardsByPlayer` from it — no extra DB round-trips. The active player's per-`EstablishmentType` counts are computed once via the new `establishmentCounts` helper, which resolves each owned card's symbol from the card definitions.
- `processGreenCards` applies a `factoryMultiplier(card, counts)` per card. The multiplier counts the relevant establishment type for the three factory/market cards and is `1` for every other green card, so existing green-card behaviour (Bakery, Convenience Store, Shopping Mall bread bonus) is unchanged.
- The multiplier keys on `CardType` rather than `EstablishmentType`, because Cheese and Furniture Factory share `EstablishmentType.FACTORY` but multiply against different symbols (COW vs GEAR).

## Behaviour notes

- A factory/market card with zero matching establishments now correctly pays **0** (previously it paid its flat income).
- Multipliers stack with card quantity: e.g. 2 Cheese Factories with 3 Ranches pay `2 × 3 × 3 = 18`.
- Only the active player benefits, consistent with green cards being OWN_TURN.

## Tests

Added 5 unit tests to `EarningsServiceImplTest`:
- Cheese Factory pays 3 per owned cow card
- Cheese Factory multiplies by both quantity and cow count
- Cheese Factory pays nothing without any cow cards
- Furniture Factory pays 3 per owned gear card (Forest + Mine)
- Fruit & Vegetable Market pays 2 per owned wheat card (Wheat Field + Apple Orchard)