### PR TITLE
test: extract shared game-phase fixture helpers (#443)

### DIFF
--- a/src/test/kotlin/org/machikoro/server/dao/GameDaoTest.kt
+++ b/src/test/kotlin/org/machikoro/server/dao/GameDaoTest.kt
@@ -171,9 +171,7 @@ class GameDaoTest : AbstractDBSetup() {
     @Test
     fun `advanceTurn resets to ROLL_DICE clears dice roll and purchase state`() {
         val id = gameDao.create(hostId)
-        check(gameDao.tryRecordDiceRoll(id, diceRoll = 4, diceCount = 1)) {
-            "fixture: game not in ROLL_DICE"
-        }
+        gameDao.advanceToResolveEffects(id, diceRoll = 4, diceCount = 1)
         gameDao.updateHasPurchasedThisTurn(id, true)
         assertTrue(gameDao.tryMarkBusinessCenterUsedThisTurn(id))
         gameDao.advanceTurn(id, nextTurnIndex = 1, roundNumber = 2)
@@ -337,9 +335,7 @@ class GameDaoTest : AbstractDBSetup() {
     fun `tryMarkRerolledThisTurn succeeds once and then rejects repeats`() {
         val id = gameDao.create(hostId)
 
-        check(gameDao.tryRecordDiceRoll(id, diceRoll = 4, diceCount = 1)) {
-            "fixture: game not in ROLL_DICE"
-        }
+        gameDao.advanceToResolveEffects(id, diceRoll = 4, diceCount = 1)
         // First attempt should flip false -> true
         assertTrue(gameDao.tryRerollThisTurn(id, 5))
         // Subsequent attempts should fail (already true)

--- a/src/test/kotlin/org/machikoro/server/dao/GamePhaseFixtures.kt
+++ b/src/test/kotlin/org/machikoro/server/dao/GamePhaseFixtures.kt
@@ -1,0 +1,32 @@
+package org.machikoro.server.dao
+
+import org.machikoro.server.domain.enums.TurnPhase
+
+/**
+ * Shared test fixtures for advancing a freshly-created game through its turn
+ * phases via the guarded production path. PR #439 removed the `updateAfterRoll`
+ * bypass, so fixtures must drive [GameDao.tryRecordDiceRoll] /
+ * [GameDao.tryTransitionPhase] directly. Centralising the `check(...)`
+ * incantation here keeps future phase-transition guard changes in one place.
+ */
+
+/**
+ * Advances a game from ROLL_DICE into RESOLVE_EFFECTS by recording a dice roll.
+ * Fails fast if the game is not in ROLL_DICE.
+ */
+fun GameDao.advanceToResolveEffects(gameId: Int, diceRoll: Int, diceCount: Int) {
+    check(tryRecordDiceRoll(gameId, diceRoll = diceRoll, diceCount = diceCount)) {
+        "fixture: game not in ROLL_DICE"
+    }
+}
+
+/**
+ * Advances a game from ROLL_DICE through RESOLVE_EFFECTS into BUY_OR_BUILD.
+ * Fails fast if either guarded transition is rejected.
+ */
+fun GameDao.advanceToBuyOrBuild(gameId: Int, diceRoll: Int, diceCount: Int) {
+    advanceToResolveEffects(gameId, diceRoll = diceRoll, diceCount = diceCount)
+    check(tryTransitionPhase(gameId, TurnPhase.RESOLVE_EFFECTS, TurnPhase.BUY_OR_BUILD)) {
+        "fixture: game not in RESOLVE_EFFECTS"
+    }
+}

--- a/src/test/kotlin/org/machikoro/server/service/GameSyncServiceIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GameSyncServiceIntegrationTest.kt
@@ -12,6 +12,7 @@ import org.machikoro.server.dao.GameMarketplaceDao
 import org.machikoro.server.dao.PlayerCardDao
 import org.machikoro.server.dao.PlayerDao
 import org.machikoro.server.dao.PlayerLandmarkDao
+import org.machikoro.server.dao.advanceToBuyOrBuild
 import org.machikoro.server.database.AbstractDBSetup
 import org.machikoro.server.database.Cards
 import org.machikoro.server.database.TestDataSeeder
@@ -109,12 +110,7 @@ class GameSyncServiceIntegrationTest : AbstractDBSetup() {
         // clears hasPurchasedThisTurn — so apply it FIRST, then layer the
         // roll / phase / purchase state on top.
         gameDao.advanceTurn(gameId, nextTurnIndex = 1, roundNumber = 3)
-        check(gameDao.tryRecordDiceRoll(gameId, diceRoll = 8, diceCount = 2)) {
-            "fixture: game not in ROLL_DICE"
-        }
-        check(gameDao.tryTransitionPhase(gameId, TurnPhase.RESOLVE_EFFECTS, TurnPhase.BUY_OR_BUILD)) {
-            "fixture: game not in RESOLVE_EFFECTS"
-        }
+        gameDao.advanceToBuyOrBuild(gameId, diceRoll = 8, diceCount = 2)
         gameDao.updateHasPurchasedThisTurn(gameId, hasPurchasedThisTurn = true)
 
         // Simulate the first player buying a BAKERY: decrement marketplace,

--- a/src/test/kotlin/org/machikoro/server/service/PurchaseServiceIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/PurchaseServiceIntegrationTest.kt
@@ -15,6 +15,7 @@ import org.machikoro.server.dao.GameMarketplaceDao
 import org.machikoro.server.dao.PlayerCardDao
 import org.machikoro.server.dao.PlayerDao
 import org.machikoro.server.dao.PlayerLandmarkDao
+import org.machikoro.server.dao.advanceToResolveEffects
 import org.machikoro.server.database.AbstractDBSetup
 import org.machikoro.server.database.CardActivationNumbers
 import org.machikoro.server.database.Cards
@@ -201,9 +202,7 @@ class PurchaseServiceIntegrationTest : AbstractDBSetup() {
         // cycle back to active player's turn
         gameDao.advanceTurn(gameId, nextTurnIndex = 1, roundNumber = 1)
         gameDao.advanceTurn(gameId, nextTurnIndex = 0, roundNumber = 2)
-        check(gameDao.tryRecordDiceRoll(gameId, diceRoll = 2, diceCount = 1)) {
-            "fixture: game not in ROLL_DICE"
-        }
+        gameDao.advanceToResolveEffects(gameId, diceRoll = 2, diceCount = 1)
 
         val coinsBefore = playerDao.findById(activePlayerId)!!.coins
         earningsService.resolveEffects(gameId)
@@ -218,9 +217,7 @@ class PurchaseServiceIntegrationTest : AbstractDBSetup() {
 
         gameDao.advanceTurn(gameId, nextTurnIndex = 1, roundNumber = 1)
         gameDao.advanceTurn(gameId, nextTurnIndex = 0, roundNumber = 2)
-        check(gameDao.tryRecordDiceRoll(gameId, diceRoll = 2, diceCount = 1)) {
-            "fixture: game not in ROLL_DICE"
-        }
+        gameDao.advanceToResolveEffects(gameId, diceRoll = 2, diceCount = 1)
 
         val inactiveBefore = playerDao.findById(inactivePlayerId)!!.coins
         earningsService.resolveEffects(gameId)

--- a/src/test/kotlin/org/machikoro/server/service/SpringContextRestartRecoveryIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/SpringContextRestartRecoveryIntegrationTest.kt
@@ -16,6 +16,7 @@ import org.machikoro.server.dao.GameMarketplaceDao
 import org.machikoro.server.dao.PlayerCardDao
 import org.machikoro.server.dao.PlayerDao
 import org.machikoro.server.dao.PlayerLandmarkDao
+import org.machikoro.server.dao.advanceToBuyOrBuild
 import org.machikoro.server.database.Cards
 import org.machikoro.server.database.GameMarketplace
 import org.machikoro.server.database.Games
@@ -136,13 +137,8 @@ class SpringContextRestartRecoveryIntegrationTest {
         
         playerDao.updateCoins(firstPlayerId, 42)
         gameDao.advanceTurn(sharedGameId, nextTurnIndex = 1, roundNumber = 5)
-        check(gameDao.tryRecordDiceRoll(sharedGameId, diceRoll = 9, diceCount = 2)) {
-            "fixture: game not in ROLL_DICE"
-        }
-        check(gameDao.tryTransitionPhase(sharedGameId, TurnPhase.RESOLVE_EFFECTS, TurnPhase.BUY_OR_BUILD)) {
-            "fixture: game not in RESOLVE_EFFECTS"
-        }
-        
+        gameDao.advanceToBuyOrBuild(sharedGameId, diceRoll = 9, diceCount = 2)
+
         gameMarketplaceDao.decrementQuantity(sharedGameId, CardType.CAFE)
         playerCardDao.upsert(firstPlayerId, CardType.CAFE, quantity = 3)
         playerLandmarkDao.markBuilt(firstPlayerId, LandmarkType.AMUSEMENT_PARK)


### PR DESCRIPTION
## Summary

Extracts the copy-pasted game-phase fixture setup into a small shared helper, as proposed in #443.

PR #439 migrated test fixtures off the removed `updateAfterRoll` bypass onto the guarded production path (`tryRecordDiceRoll` / `tryTransitionPhase`). That left the same `check(...) { "fixture: ..." }` incantation duplicated across four test files. This PR centralises it so future phase-transition guard changes live in one place.

## Changes

**New** — [`GamePhaseFixtures.kt`](https://github.com/SE2-Machi-Koro/Server/blob/refactor/443-extract-game-phase-fixture-helper/src/test/kotlin/org/machikoro/server/dao/GamePhaseFixtures.kt): two `GameDao` test extension functions

| Helper | Drives | Lands game in |
| --- | --- | --- |
| `advanceToResolveEffects(gameId, diceRoll, diceCount)` | `tryRecordDiceRoll` | `RESOLVE_EFFECTS` |
| `advanceToBuyOrBuild(gameId, diceRoll, diceCount)` | the above **+** `tryTransitionPhase(RESOLVE_EFFECTS → BUY_OR_BUILD)` | `BUY_OR_BUILD` |

Each wraps the `check(...)` guard, so the fail-fast messages (`"fixture: game not in ROLL_DICE"` / `"...RESOLVE_EFFECTS"`) are defined once.

**Call sites routed through the helpers:**
- `GameDaoTest` ×2 → `advanceToResolveEffects`
- `PurchaseServiceIntegrationTest` ×2 → `advanceToResolveEffects`
- `GameSyncServiceIntegrationTest` ×1 → `advanceToBuyOrBuild`
- `SpringContextRestartRecoveryIntegrationTest` ×1 → `advanceToBuyOrBuild`

### Before / after

```kotlin
// before
check(gameDao.tryRecordDiceRoll(gameId, diceRoll = 8, diceCount = 2)) {
    "fixture: game not in ROLL_DICE"
}
check(gameDao.tryTransitionPhase(gameId, TurnPhase.RESOLVE_EFFECTS, TurnPhase.BUY_OR_BUILD)) {
    "fixture: game not in RESOLVE_EFFECTS"
}

// after
gameDao.advanceToBuyOrBuild(gameId, diceRoll = 8, diceCount = 2)
```

## Design notes

- **Extension functions on `GameDao`** rather than free functions — the call site stays `gameDao.advanceToBuyOrBuild(...)`, matching how the fixtures already read.
- Placed in the **`org.machikoro.server.dao`** test package, so `GameDaoTest` needs no import while the service tests import them like any other `dao` symbol.
- Kept parameter names **`diceRoll` / `diceCount`** (not the issue sketch's `roll` / `count`) to match the existing `GameDao` signatures and the named-argument style already in use.
- Net **−25 / +10** lines in the test bodies; behaviour-only — **no production code touched**.

## Testing

`./gradlew test` for the four affected classes — all green:

| Class | Tests | Failures |
| --- | --- | --- |
| `GameDaoTest` | 31 | 0 |
| `PurchaseServiceIntegrationTest` | 24 | 0 |
| `GameSyncServiceIntegrationTest` | 1 | 0 |
| `SpringContextRestartRecoveryIntegrationTest` | 2 | 0 |

Closes #443

