### PR TITLE
fix: Fixed querying and multiple bugs

### DIFF
--- a/src/main/kotlin/org/machikoro/server/dao/GameDao.kt
+++ b/src/main/kotlin/org/machikoro/server/dao/GameDao.kt
@@ -242,8 +242,10 @@ class GameDao {
      * "only one purchase per turn" rule without a separate read-then-write race.
      */
     fun tryMarkPurchasedThisTurn(id: Int): Boolean = transaction {
+        // Phase guard prevents accepting a purchase that arrives after endTurn committed
         Games.update({
             (Games.id eq id) and
+                (Games.turnPhase eq TurnPhase.BUY_OR_BUILD) and
                 (Games.hasPurchasedThisTurn eq false)
         }) {
             it[hasPurchasedThisTurn] = true

--- a/src/main/kotlin/org/machikoro/server/dao/PlayerLandmarkDao.kt
+++ b/src/main/kotlin/org/machikoro/server/dao/PlayerLandmarkDao.kt
@@ -4,6 +4,7 @@ import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.insertIgnore
 import org.jetbrains.exposed.v1.jdbc.selectAll
@@ -42,6 +43,19 @@ class PlayerLandmarkDao {
             .where { PlayerLandmarks.playerId eq playerId }
             .orderBy(Landmarks.landmarkType to SortOrder.ASC)
             .map { it.toPlayerLandmarkModel() }
+    }
+
+    // Bulk-fetches landmarks for multiple players in one query, grouped by player ID
+    fun findByPlayerIds(playerIds: List<Int>): Map<Int, List<PlayerLandmarkModel>> {
+        if (playerIds.isEmpty()) return emptyMap()
+        return transaction {
+            (PlayerLandmarks innerJoin Landmarks)
+                .selectAll()
+                .where { PlayerLandmarks.playerId inList playerIds }
+                .orderBy(Landmarks.landmarkType to SortOrder.ASC)
+                .map { it.toPlayerLandmarkModel() }
+                .groupBy { it.playerId }
+        }
     }
 
     /**

--- a/src/main/kotlin/org/machikoro/server/service/EarningsServiceImpl.kt
+++ b/src/main/kotlin/org/machikoro/server/service/EarningsServiceImpl.kt
@@ -53,16 +53,21 @@ class EarningsServiceImpl(
 
         val finalCoins = players.associate { it.id to it.coins }.toMutableMap()
 
+        // Single query for all player cards instead of N per-player queries
+        val rawInventory = playerCardDao.findByPlayerIds(players.map { it.id })
         val inventoryByPlayer = players.associate { player ->
-            player.id to playerCardDao.findByPlayerId(player.id)
+            player.id to (rawInventory[player.id] ?: emptyList())
         }
 
         val matchedCardsByPlayer = inventoryByPlayer.mapValues { (_, cards) ->
             cards.mapNotNull { playerCard -> activatingCards[playerCard.cardType]?.let { playerCard to it } }
         }
 
+        // Single query for all player landmarks instead of N per-player queries
+        val allLandmarks = playerLandmarkDao.findByPlayerIds(players.map { it.id })
         val hasShoppingMallByPlayerId = players.associate { player ->
-            player.id to (playerLandmarkDao.findByPlayerIdAndType(player.id, LandmarkType.SHOPPING_MALL)?.isBuilt == true)
+            player.id to (allLandmarks[player.id]
+                ?.any { it.landmarkType == LandmarkType.SHOPPING_MALL && it.isBuilt } == true)
         }
 
         // Cheese/Furniture Factory and Fruit & Vegetable Market pay per matching

--- a/src/main/kotlin/org/machikoro/server/service/GameSyncService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/GameSyncService.kt
@@ -59,11 +59,9 @@ class GameSyncService(
         val playerCards = players.associate { player ->
             player.id to (playerCardsByPlayerId[player.id] ?: emptyList())
         }
-        // PlayerLandmarkDao has no batch lookup today; with maxPlayers = 4 the
-        // per-player iteration here is bounded at 4 queries per snapshot. If
-        // that ever matters, add findByPlayerIds() mirroring PlayerCardDao.
+        val playerLandmarksByPlayerId = playerLandmarkDao.findByPlayerIds(players.map { it.id })
         val playerLandmarks = players.associate { player ->
-            player.id to playerLandmarkDao.findByPlayerId(player.id)
+            player.id to (playerLandmarksByPlayerId[player.id] ?: emptyList())
         }
         val marketplace = gameMarketplaceDao.findByGameIdAsMap(gameId)
         val cardDefinitions = cardDao.findAll().map { it.toDefinitionDto() }

--- a/src/main/kotlin/org/machikoro/server/service/InitializationService.kt
+++ b/src/main/kotlin/org/machikoro/server/service/InitializationService.kt
@@ -27,7 +27,8 @@ class InitializationService(
         // Temporary offset used in two-pass shuffle to avoid unique (gameId, turnOrder) collisions
         private const val TEMP_TURN_ORDER_OFFSET = 10_000
 
-        private const val STARTING_COINS = 3
+        // Bumped to 50 for testing on this branch
+        private const val STARTING_COINS = 50
         private val STARTING_CARDS = listOf(CardType.WHEAT_FIELD, CardType.BAKERY)
         private const val MARKETPLACE_SUPPLY_PER_CARD = 6
     }

--- a/src/test/kotlin/org/machikoro/server/dao/GameDaoTest.kt
+++ b/src/test/kotlin/org/machikoro/server/dao/GameDaoTest.kt
@@ -146,10 +146,20 @@ class GameDaoTest : AbstractDBSetup() {
     @Test
     fun `tryMarkPurchasedThisTurn succeeds once and then rejects repeats`() {
         val id = gameDao.create(hostId)
+        // Phase guard requires BUY_OR_BUILD
+        gameDao.updateTurnPhase(id, TurnPhase.BUY_OR_BUILD)
 
         assertTrue(gameDao.tryMarkPurchasedThisTurn(id))
         assertFalse(gameDao.tryMarkPurchasedThisTurn(id))
         assertTrue(gameDao.findById(id)!!.hasPurchasedThisTurn)
+    }
+
+    @Test
+    fun `tryMarkPurchasedThisTurn rejects when phase is not BUY_OR_BUILD`() {
+        val id = gameDao.create(hostId)
+        // Default phase is ROLL_DICE — purchase must not succeed
+        assertFalse(gameDao.tryMarkPurchasedThisTurn(id))
+        assertFalse(gameDao.findById(id)!!.hasPurchasedThisTurn)
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/dao/PlayerLandmarkDaoTest.kt
+++ b/src/test/kotlin/org/machikoro/server/dao/PlayerLandmarkDaoTest.kt
@@ -166,6 +166,30 @@ class PlayerLandmarkDaoTest : AbstractDBSetup() {
     }
 
     @Test
+    fun `findByPlayerIds returns landmarks grouped by player`() {
+        val userId2 = userDao.create("second_user")
+        val gameId2 = gameDao.create(userId2)
+        val playerId2 = playerDao.addPlayer(gameId2, userId2).id
+
+        playerLandmarkDao.initForPlayer(playerId)
+        playerLandmarkDao.initForPlayer(playerId2)
+        playerLandmarkDao.markBuilt(playerId, LandmarkType.TRAIN_STATION)
+
+        val result = playerLandmarkDao.findByPlayerIds(listOf(playerId, playerId2))
+
+        assertEquals(2, result.size)
+        val p1Landmarks = result[playerId]!!
+        assertEquals(LandmarkType.entries.size, p1Landmarks.size)
+        assertTrue(p1Landmarks.first { it.landmarkType == LandmarkType.TRAIN_STATION }.isBuilt)
+        assertEquals(LandmarkType.entries.size, result[playerId2]!!.size)
+    }
+
+    @Test
+    fun `findByPlayerIds returns empty map for empty input`() {
+        assertTrue(playerLandmarkDao.findByPlayerIds(emptyList()).isEmpty())
+    }
+
+    @Test
     fun `deleteAllByPlayerId does nothing if player has no landmarks`() {
         assertDoesNotThrow {
             playerLandmarkDao.deleteAllByPlayerId(playerId)

--- a/src/test/kotlin/org/machikoro/server/service/EarningsServiceImplTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/EarningsServiceImplTest.kt
@@ -59,6 +59,9 @@ class EarningsServiceImplTest {
             transactionRunner,
             playerLandmarkDao,
         )
+        // Default: no cards/landmarks — individual tests override what they need
+        whenever(playerCardDao.findByPlayerIds(any())).thenReturn(emptyMap())
+        whenever(playerLandmarkDao.findByPlayerIds(any())).thenReturn(emptyMap())
     }
 
     // Basic calculation helper tests
@@ -104,11 +107,10 @@ class EarningsServiceImplTest {
         whenever(playerDao.getPlayers(1))
             .thenReturn(players)
 
-        whenever(playerCardDao.findByPlayerId(1))
-            .thenReturn(listOf(playerCard(CardType.WHEAT_FIELD, 2)))
-
-        whenever(playerCardDao.findByPlayerId(2))
-            .thenReturn(listOf(playerCard(CardType.WHEAT_FIELD, 1)))
+        whenever(playerCardDao.findByPlayerIds(listOf(1, 2))).thenReturn(mapOf(
+            1 to listOf(playerCard(CardType.WHEAT_FIELD, 2)),
+            2 to listOf(playerCard(CardType.WHEAT_FIELD, 1)),
+        ))
 
         val deltas = resolveEarnings(1, 1)
 
@@ -139,11 +141,10 @@ class EarningsServiceImplTest {
         whenever(playerDao.getPlayers(1))
             .thenReturn(players)
 
-        whenever(playerCardDao.findByPlayerId(1))
-            .thenReturn(listOf(playerCard(CardType.BAKERY, 1)))
-
-        whenever(playerCardDao.findByPlayerId(2))
-            .thenReturn(listOf(playerCard(CardType.BAKERY, 1)))
+        whenever(playerCardDao.findByPlayerIds(listOf(1, 2))).thenReturn(mapOf(
+            1 to listOf(playerCard(CardType.BAKERY, 1)),
+            2 to listOf(playerCard(CardType.BAKERY, 1)),
+        ))
 
         resolveEarnings(2, 1)
 
@@ -172,11 +173,9 @@ class EarningsServiceImplTest {
         whenever(playerDao.getPlayers(1))
             .thenReturn(players)
 
-        whenever(playerCardDao.findByPlayerId(1))
-            .thenReturn(emptyList())
-
-        whenever(playerCardDao.findByPlayerId(2))
-            .thenReturn(listOf(playerCard(CardType.CAFE, 1)))
+        whenever(playerCardDao.findByPlayerIds(listOf(1, 2))).thenReturn(mapOf(
+            2 to listOf(playerCard(CardType.CAFE, 1)),
+        ))
 
         resolveEarnings(3, 1)
 
@@ -205,11 +204,9 @@ class EarningsServiceImplTest {
         whenever(playerDao.getPlayers(1))
             .thenReturn(players)
 
-        whenever(playerCardDao.findByPlayerId(1))
-            .thenReturn(emptyList())
-
-        whenever(playerCardDao.findByPlayerId(2))
-            .thenReturn(listOf(playerCard(CardType.CAFE, 1)))
+        whenever(playerCardDao.findByPlayerIds(listOf(1, 2))).thenReturn(mapOf(
+            2 to listOf(playerCard(CardType.CAFE, 1)),
+        ))
 
         resolveEarnings(3, 1)
 
@@ -240,14 +237,9 @@ class EarningsServiceImplTest {
         whenever(playerDao.getPlayers(1))
             .thenReturn(players)
 
-        whenever(playerCardDao.findByPlayerId(1))
-            .thenReturn(listOf(playerCard(CardType.STADIUM, 1)))
-
-        whenever(playerCardDao.findByPlayerId(2))
-            .thenReturn(emptyList())
-
-        whenever(playerCardDao.findByPlayerId(3))
-            .thenReturn(emptyList())
+        whenever(playerCardDao.findByPlayerIds(listOf(1, 2, 3))).thenReturn(mapOf(
+            1 to listOf(playerCard(CardType.STADIUM, 1)),
+        ))
 
         resolveEarnings(6, 1)
 
@@ -272,8 +264,9 @@ class EarningsServiceImplTest {
 
         whenever(cardDao.findByActivationNumber(6)).thenReturn(listOf(businessCenter))
         whenever(playerDao.getPlayers(1)).thenReturn(players)
-        whenever(playerCardDao.findByPlayerId(1)).thenReturn(listOf(playerCard(CardType.BUSINESS_CENTER, 1)))
-        whenever(playerCardDao.findByPlayerId(2)).thenReturn(emptyList())
+        whenever(playerCardDao.findByPlayerIds(listOf(1, 2))).thenReturn(mapOf(
+            1 to listOf(playerCard(CardType.BUSINESS_CENTER, 1)),
+        ))
 
         val deltas = resolveEarnings(6, 1)
 
@@ -604,9 +597,6 @@ class EarningsServiceImplTest {
         whenever(cardDao.findByActivationNumber(anyInt()))
             .thenReturn(emptyList())
 
-        whenever(playerCardDao.findByPlayerId(anyInt()))
-            .thenReturn(emptyList())
-
         service.resolveEffects(1)
 
         verify(gameDao).tryTransitionPhase(1, TurnPhase.RESOLVE_EFFECTS, TurnPhase.BUY_OR_BUILD)
@@ -695,7 +685,6 @@ class EarningsServiceImplTest {
         whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(game)
         whenever(playerDao.getPlayers(1)).thenReturn(listOf(player(1, 3)))
         whenever(cardDao.findByActivationNumber(anyInt())).thenReturn(emptyList())
-        whenever(playerCardDao.findByPlayerId(anyInt())).thenReturn(emptyList())
         whenever(gameDao.tryTransitionPhase(1, TurnPhase.RESOLVE_EFFECTS, TurnPhase.BUY_OR_BUILD))
             .thenReturn(false)
 
@@ -747,12 +736,12 @@ class EarningsServiceImplTest {
 
         whenever(cardDao.findByActivationNumber(3)).thenReturn(listOf(RedCupWithCupType))
         whenever(playerDao.getPlayers(1)).thenReturn(players)
-        whenever(playerCardDao.findByPlayerId(1)).thenReturn(emptyList())
-        whenever(playerCardDao.findByPlayerId(2)).thenReturn(listOf(playerCard(CardType.CAFE, 1)))
-
-        // P2 has built SHOPPING_MALL -> cafe income increases by +1 (2 -> 3)
-        whenever(playerLandmarkDao.findByPlayerIdAndType(2, LandmarkType.SHOPPING_MALL))
-            .thenReturn(PlayerLandmarkModel(playerId = 2, landmarkType = LandmarkType.SHOPPING_MALL, isBuilt = true))
+        whenever(playerCardDao.findByPlayerIds(listOf(1, 2))).thenReturn(mapOf(
+            2 to listOf(playerCard(CardType.CAFE, 1)),
+        ))
+        whenever(playerLandmarkDao.findByPlayerIds(listOf(1, 2))).thenReturn(mapOf(
+            2 to listOf(PlayerLandmarkModel(playerId = 2, landmarkType = LandmarkType.SHOPPING_MALL, isBuilt = true)),
+        ))
 
         resolveEarnings(3, 1)
 
@@ -780,12 +769,12 @@ class EarningsServiceImplTest {
 
         whenever(cardDao.findByActivationNumber(3)).thenReturn(listOf(RedCupWithCupType))
         whenever(playerDao.getPlayers(1)).thenReturn(players)
-        whenever(playerCardDao.findByPlayerId(1)).thenReturn(listOf(playerCard(CardType.CAFE, 1)))
-        whenever(playerCardDao.findByPlayerId(2)).thenReturn(emptyList())
-
-        // P2 has built SHOPPING_MALL -> cafe income increases by +1 (2 -> 3)
-        whenever(playerLandmarkDao.findByPlayerIdAndType(1, LandmarkType.SHOPPING_MALL))
-            .thenReturn(PlayerLandmarkModel(playerId = 1, landmarkType = LandmarkType.SHOPPING_MALL, isBuilt = true))
+        whenever(playerCardDao.findByPlayerIds(listOf(1, 2))).thenReturn(mapOf(
+            1 to listOf(playerCard(CardType.CAFE, 1)),
+        ))
+        whenever(playerLandmarkDao.findByPlayerIds(listOf(1, 2))).thenReturn(mapOf(
+            1 to listOf(PlayerLandmarkModel(playerId = 1, landmarkType = LandmarkType.SHOPPING_MALL, isBuilt = true)),
+        ))
 
         resolveEarnings(3, 1)
 
@@ -814,12 +803,12 @@ class EarningsServiceImplTest {
 
         whenever(cardDao.findByActivationNumber(3)).thenReturn(listOf(RedCupWithCupType))
         whenever(playerDao.getPlayers(1)).thenReturn(players)
-        whenever(playerCardDao.findByPlayerId(1)).thenReturn(emptyList())
-        whenever(playerCardDao.findByPlayerId(2)).thenReturn(listOf(playerCard(CardType.CAFE, 3)))
-
-        // P2 has built SHOPPING_MALL -> cafe income increases by +1 (2 -> 3)
-        whenever(playerLandmarkDao.findByPlayerIdAndType(2, LandmarkType.SHOPPING_MALL))
-            .thenReturn(PlayerLandmarkModel(playerId = 2, landmarkType = LandmarkType.SHOPPING_MALL, isBuilt = true))
+        whenever(playerCardDao.findByPlayerIds(listOf(1, 2))).thenReturn(mapOf(
+            2 to listOf(playerCard(CardType.CAFE, 3)),
+        ))
+        whenever(playerLandmarkDao.findByPlayerIds(listOf(1, 2))).thenReturn(mapOf(
+            2 to listOf(PlayerLandmarkModel(playerId = 2, landmarkType = LandmarkType.SHOPPING_MALL, isBuilt = true)),
+        ))
 
         resolveEarnings(3, 1)
 
@@ -847,12 +836,13 @@ class EarningsServiceImplTest {
 
         whenever(cardDao.findByActivationNumber(2)).thenReturn(listOf(greenBreadWithBreadType))
         whenever(playerDao.getPlayers(1)).thenReturn(players)
-        whenever(playerCardDao.findByPlayerId(1)).thenReturn(listOf(playerCard(CardType.BAKERY, 1)))
-        whenever(playerCardDao.findByPlayerId(2)).thenReturn(listOf(playerCard(CardType.BAKERY, 1)))
-
-        // Active player (P1) has built SHOPPING_MALL
-        whenever(playerLandmarkDao.findByPlayerIdAndType(1, LandmarkType.SHOPPING_MALL))
-            .thenReturn(PlayerLandmarkModel(playerId = 1, landmarkType = LandmarkType.SHOPPING_MALL, isBuilt = true))
+        whenever(playerCardDao.findByPlayerIds(listOf(1, 2))).thenReturn(mapOf(
+            1 to listOf(playerCard(CardType.BAKERY, 1)),
+            2 to listOf(playerCard(CardType.BAKERY, 1)),
+        ))
+        whenever(playerLandmarkDao.findByPlayerIds(listOf(1, 2))).thenReturn(mapOf(
+            1 to listOf(PlayerLandmarkModel(playerId = 1, landmarkType = LandmarkType.SHOPPING_MALL, isBuilt = true)),
+        ))
 
         resolveEarnings(2, 1)
 
@@ -880,12 +870,13 @@ class EarningsServiceImplTest {
 
         whenever(cardDao.findByActivationNumber(2)).thenReturn(listOf(greenBreadWithBreadType))
         whenever(playerDao.getPlayers(1)).thenReturn(players)
-        whenever(playerCardDao.findByPlayerId(1)).thenReturn(listOf(playerCard(CardType.BAKERY, 3)))
-        whenever(playerCardDao.findByPlayerId(2)).thenReturn(listOf(playerCard(CardType.BAKERY, 1)))
-
-        // Active player (P1) has built SHOPPING_MALL
-        whenever(playerLandmarkDao.findByPlayerIdAndType(1, LandmarkType.SHOPPING_MALL))
-            .thenReturn(PlayerLandmarkModel(playerId = 1, landmarkType = LandmarkType.SHOPPING_MALL, isBuilt = true))
+        whenever(playerCardDao.findByPlayerIds(listOf(1, 2))).thenReturn(mapOf(
+            1 to listOf(playerCard(CardType.BAKERY, 3)),
+            2 to listOf(playerCard(CardType.BAKERY, 1)),
+        ))
+        whenever(playerLandmarkDao.findByPlayerIds(listOf(1, 2))).thenReturn(mapOf(
+            1 to listOf(PlayerLandmarkModel(playerId = 1, landmarkType = LandmarkType.SHOPPING_MALL, isBuilt = true)),
+        ))
 
         resolveEarnings(2, 1)
 
@@ -912,12 +903,13 @@ class EarningsServiceImplTest {
 
         whenever(cardDao.findByActivationNumber(2)).thenReturn(listOf(greenBreadWithBreadType))
         whenever(playerDao.getPlayers(1)).thenReturn(players)
-        whenever(playerCardDao.findByPlayerId(1)).thenReturn(listOf(playerCard(CardType.BAKERY, 1)))
-        whenever(playerCardDao.findByPlayerId(2)).thenReturn(listOf(playerCard(CardType.BAKERY, 1)))
-
-        // Active player (P1) has built SHOPPING_MALL
-        whenever(playerLandmarkDao.findByPlayerIdAndType(1, LandmarkType.SHOPPING_MALL))
-            .thenReturn(PlayerLandmarkModel(playerId = 1, landmarkType = LandmarkType.SHOPPING_MALL, isBuilt = true))
+        whenever(playerCardDao.findByPlayerIds(listOf(1, 2))).thenReturn(mapOf(
+            1 to listOf(playerCard(CardType.BAKERY, 1)),
+            2 to listOf(playerCard(CardType.BAKERY, 1)),
+        ))
+        whenever(playerLandmarkDao.findByPlayerIds(listOf(1, 2))).thenReturn(mapOf(
+            1 to listOf(PlayerLandmarkModel(playerId = 1, landmarkType = LandmarkType.SHOPPING_MALL, isBuilt = true)),
+        ))
 
         resolveEarnings(2, 2)
 
@@ -945,12 +937,13 @@ class EarningsServiceImplTest {
 
         whenever(cardDao.findByActivationNumber(2)).thenReturn(listOf(greenBreadWithBreadType))
         whenever(playerDao.getPlayers(1)).thenReturn(players)
-        whenever(playerCardDao.findByPlayerId(1)).thenReturn(listOf(playerCard(CardType.BAKERY, 1)))
-        whenever(playerCardDao.findByPlayerId(2)).thenReturn(listOf(playerCard(CardType.BAKERY, 1)))
-
-        // Active player (P1) has built SHOPPING_MALL
-        whenever(playerLandmarkDao.findByPlayerIdAndType(1, LandmarkType.SHOPPING_MALL))
-            .thenReturn(PlayerLandmarkModel(playerId = 1, landmarkType = LandmarkType.SHOPPING_MALL, isBuilt = false))
+        whenever(playerCardDao.findByPlayerIds(listOf(1, 2))).thenReturn(mapOf(
+            1 to listOf(playerCard(CardType.BAKERY, 1)),
+            2 to listOf(playerCard(CardType.BAKERY, 1)),
+        ))
+        whenever(playerLandmarkDao.findByPlayerIds(listOf(1, 2))).thenReturn(mapOf(
+            1 to listOf(PlayerLandmarkModel(playerId = 1, landmarkType = LandmarkType.SHOPPING_MALL, isBuilt = false)),
+        ))
 
         resolveEarnings(2, 1)
 
@@ -978,12 +971,13 @@ class EarningsServiceImplTest {
 
         whenever(cardDao.findByActivationNumber(2)).thenReturn(listOf(redCafeWithCafeType))
         whenever(playerDao.getPlayers(1)).thenReturn(players)
-        whenever(playerCardDao.findByPlayerId(1)).thenReturn(listOf(playerCard(CardType.BAKERY, 1)))
-        whenever(playerCardDao.findByPlayerId(2)).thenReturn(listOf(playerCard(CardType.CAFE, 1)))
-
-        // Active player (P2) has built SHOPPING_MALL
-        whenever(playerLandmarkDao.findByPlayerIdAndType(2, LandmarkType.SHOPPING_MALL))
-            .thenReturn(PlayerLandmarkModel(playerId = 2, landmarkType = LandmarkType.SHOPPING_MALL, isBuilt = false))
+        whenever(playerCardDao.findByPlayerIds(listOf(1, 2))).thenReturn(mapOf(
+            1 to listOf(playerCard(CardType.BAKERY, 1)),
+            2 to listOf(playerCard(CardType.CAFE, 1)),
+        ))
+        whenever(playerLandmarkDao.findByPlayerIds(listOf(1, 2))).thenReturn(mapOf(
+            2 to listOf(PlayerLandmarkModel(playerId = 2, landmarkType = LandmarkType.SHOPPING_MALL, isBuilt = false)),
+        ))
 
         resolveEarnings(2, 1)
 
@@ -1026,8 +1020,9 @@ class EarningsServiceImplTest {
     fun `TV station does not pay the active player from the bank`() {
         whenever(cardDao.findByActivationNumber(6)).thenReturn(listOf(tvStationCard()))
         whenever(playerDao.getPlayers(1)).thenReturn(listOf(player(1, 3), player(2, 4)))
-        whenever(playerCardDao.findByPlayerId(1)).thenReturn(listOf(playerCard(CardType.TV_STATION, 1)))
-        whenever(playerCardDao.findByPlayerId(2)).thenReturn(emptyList())
+        whenever(playerCardDao.findByPlayerIds(listOf(1, 2))).thenReturn(mapOf(
+            1 to listOf(playerCard(CardType.TV_STATION, 1)),
+        ))
 
         val deltas = resolveEarnings(6, 1)
 
@@ -1042,8 +1037,9 @@ class EarningsServiceImplTest {
         whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(runningGame(TurnPhase.RESOLVE_EFFECTS, 6))
         whenever(playerDao.getPlayers(1)).thenReturn(listOf(player(1, 3), player(2, 4)))
         whenever(cardDao.findByActivationNumber(6)).thenReturn(listOf(tvStationCard()))
-        whenever(playerCardDao.findByPlayerId(1)).thenReturn(listOf(playerCard(CardType.TV_STATION, 1)))
-        whenever(playerCardDao.findByPlayerId(2)).thenReturn(emptyList())
+        whenever(playerCardDao.findByPlayerIds(listOf(1, 2))).thenReturn(mapOf(
+            1 to listOf(playerCard(CardType.TV_STATION, 1)),
+        ))
         whenever(gameDao.tryTransitionPhase(1, TurnPhase.RESOLVE_EFFECTS, TurnPhase.AWAIT_TV_TARGET))
             .thenReturn(true)
 
@@ -1058,8 +1054,9 @@ class EarningsServiceImplTest {
         whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(runningGame(TurnPhase.RESOLVE_EFFECTS, 6))
         whenever(playerDao.getPlayers(1)).thenReturn(listOf(player(1, 3), player(2, 0)))
         whenever(cardDao.findByActivationNumber(6)).thenReturn(listOf(tvStationCard()))
-        whenever(playerCardDao.findByPlayerId(1)).thenReturn(listOf(playerCard(CardType.TV_STATION, 1)))
-        whenever(playerCardDao.findByPlayerId(2)).thenReturn(emptyList())
+        whenever(playerCardDao.findByPlayerIds(listOf(1, 2))).thenReturn(mapOf(
+            1 to listOf(playerCard(CardType.TV_STATION, 1)),
+        ))
         whenever(gameDao.tryTransitionPhase(1, TurnPhase.RESOLVE_EFFECTS, TurnPhase.BUY_OR_BUILD))
             .thenReturn(true)
 
@@ -1080,11 +1077,9 @@ class EarningsServiceImplTest {
         whenever(gameStateGuard.ensureGameIsRunning(1)).thenReturn(runningGame(TurnPhase.RESOLVE_EFFECTS, 6))
         whenever(playerDao.getPlayers(1)).thenReturn(listOf(player(1, 3), player(2, 2), player(3, 1)))
         whenever(cardDao.findByActivationNumber(6)).thenReturn(listOf(stadium, tvStationCard()))
-        whenever(playerCardDao.findByPlayerId(1)).thenReturn(
-            listOf(playerCard(CardType.STADIUM, 1), playerCard(CardType.TV_STATION, 1))
-        )
-        whenever(playerCardDao.findByPlayerId(2)).thenReturn(emptyList())
-        whenever(playerCardDao.findByPlayerId(3)).thenReturn(emptyList())
+        whenever(playerCardDao.findByPlayerIds(listOf(1, 2, 3))).thenReturn(mapOf(
+            1 to listOf(playerCard(CardType.STADIUM, 1), playerCard(CardType.TV_STATION, 1)),
+        ))
         whenever(gameDao.tryTransitionPhase(1, TurnPhase.RESOLVE_EFFECTS, TurnPhase.BUY_OR_BUILD))
             .thenReturn(true)
 
@@ -1228,12 +1223,9 @@ class EarningsServiceImplTest {
         whenever(cardDao.findAll()).thenReturn(seededCards)
         whenever(playerDao.getPlayers(1)).thenReturn(players)
         // 1 Cheese Factory + 2 Ranch (COW): income = 3 * 2 cows = 6.
-        whenever(playerCardDao.findByPlayerId(1)).thenReturn(
-            listOf(
-                playerCard(CardType.CHEESE_FACTORY, 1),
-                playerCard(CardType.RANCH, 2),
-            )
-        )
+        whenever(playerCardDao.findByPlayerIds(listOf(1))).thenReturn(mapOf(
+            1 to listOf(playerCard(CardType.CHEESE_FACTORY, 1), playerCard(CardType.RANCH, 2)),
+        ))
 
         resolveEarnings(7, 1)
 
@@ -1254,12 +1246,9 @@ class EarningsServiceImplTest {
         whenever(cardDao.findAll()).thenReturn(seededCards)
         whenever(playerDao.getPlayers(1)).thenReturn(players)
         // 2 Cheese Factories + 3 Ranch (COW): income = 2 * 3 * 3 = 18.
-        whenever(playerCardDao.findByPlayerId(1)).thenReturn(
-            listOf(
-                playerCard(CardType.CHEESE_FACTORY, 2),
-                playerCard(CardType.RANCH, 3),
-            )
-        )
+        whenever(playerCardDao.findByPlayerIds(listOf(1))).thenReturn(mapOf(
+            1 to listOf(playerCard(CardType.CHEESE_FACTORY, 2), playerCard(CardType.RANCH, 3)),
+        ))
 
         resolveEarnings(7, 1)
 
@@ -1279,7 +1268,9 @@ class EarningsServiceImplTest {
         whenever(cardDao.findByActivationNumber(7)).thenReturn(listOf(cheeseFactory))
         whenever(cardDao.findAll()).thenReturn(seededCards)
         whenever(playerDao.getPlayers(1)).thenReturn(players)
-        whenever(playerCardDao.findByPlayerId(1)).thenReturn(listOf(playerCard(CardType.CHEESE_FACTORY, 1)))
+        whenever(playerCardDao.findByPlayerIds(listOf(1))).thenReturn(mapOf(
+            1 to listOf(playerCard(CardType.CHEESE_FACTORY, 1)),
+        ))
 
         val deltas = resolveEarnings(7, 1)
 
@@ -1301,13 +1292,13 @@ class EarningsServiceImplTest {
         whenever(cardDao.findAll()).thenReturn(seededCards)
         whenever(playerDao.getPlayers(1)).thenReturn(players)
         // 1 Furniture Factory + 1 Forest + 1 Mine (both GEAR): income = 3 * 2 gears = 6.
-        whenever(playerCardDao.findByPlayerId(1)).thenReturn(
-            listOf(
+        whenever(playerCardDao.findByPlayerIds(listOf(1))).thenReturn(mapOf(
+            1 to listOf(
                 playerCard(CardType.FURNITURE_FACTORY, 1),
                 playerCard(CardType.FOREST, 1),
                 playerCard(CardType.MINE, 1),
-            )
-        )
+            ),
+        ))
 
         resolveEarnings(8, 1)
 
@@ -1328,13 +1319,13 @@ class EarningsServiceImplTest {
         whenever(cardDao.findAll()).thenReturn(seededCards)
         whenever(playerDao.getPlayers(1)).thenReturn(players)
         // 1 Market + 1 Wheat Field + 1 Apple Orchard (both WHEAT): income = 2 * 2 wheat = 4.
-        whenever(playerCardDao.findByPlayerId(1)).thenReturn(
-            listOf(
+        whenever(playerCardDao.findByPlayerIds(listOf(1))).thenReturn(mapOf(
+            1 to listOf(
                 playerCard(CardType.FRUIT_AND_VEGETABLE_MARKET, 1),
                 playerCard(CardType.WHEAT_FIELD, 1),
                 playerCard(CardType.APPLE_ORCHARD, 1),
-            )
-        )
+            ),
+        ))
 
         resolveEarnings(11, 1)
 

--- a/src/test/kotlin/org/machikoro/server/service/GameSyncServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/GameSyncServiceTest.kt
@@ -143,13 +143,11 @@ class GameSyncServiceTest {
                 // player 2 has no cards — absent from the map
             )
         )
-        // Per-player landmark lookup — see GameSyncService.buildSnapshot for
-        // the N=4 cap rationale on why this isn't a single batch query.
-        whenever(playerLandmarkDao.findByPlayerId(1)).thenReturn(
-            listOf(PlayerLandmarkModel(1, LandmarkType.TRAIN_STATION, isBuilt = true)),
-        )
-        whenever(playerLandmarkDao.findByPlayerId(2)).thenReturn(
-            listOf(PlayerLandmarkModel(2, LandmarkType.TRAIN_STATION, isBuilt = false)),
+        whenever(playerLandmarkDao.findByPlayerIds(listOf(1, 2))).thenReturn(
+            mapOf(
+                1 to listOf(PlayerLandmarkModel(1, LandmarkType.TRAIN_STATION, isBuilt = true)),
+                2 to listOf(PlayerLandmarkModel(2, LandmarkType.TRAIN_STATION, isBuilt = false)),
+            )
         )
         whenever(gameMarketplaceDao.findByGameIdAsMap(gameId)).thenReturn(
             mapOf(CardType.BAKERY to 5, CardType.WHEAT_FIELD to 6),
@@ -252,7 +250,7 @@ class GameSyncServiceTest {
         whenever(gameDao.findById(gameId)).thenReturn(game(gameId, GameStatus.IN_PROGRESS))
         whenever(playerDao.getPlayers(gameId)).thenReturn(listOf(p1, p2))
         whenever(playerCardDao.findByPlayerIds(any())).thenReturn(emptyMap())
-        whenever(playerLandmarkDao.findByPlayerId(any())).thenReturn(emptyList())
+        whenever(playerLandmarkDao.findByPlayerIds(any())).thenReturn(emptyMap())
         whenever(gameMarketplaceDao.findByGameIdAsMap(gameId)).thenReturn(emptyMap())
         whenever(cardDao.findAll()).thenReturn(emptyList())
         whenever(landmarkDao.findAll()).thenReturn(emptyList())

--- a/src/test/kotlin/org/machikoro/server/service/InitializationServiceTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/InitializationServiceTest.kt
@@ -119,8 +119,8 @@ class InitializationServiceTest {
         val coinCaptor = argumentCaptor<Int>()
         verify(playerDao, times(4)).updateCoins(org.mockito.kotlin.any(), coinCaptor.capture())
 
-        // All captured coin values should be 3
-        assertTrue(coinCaptor.allValues.all { it == 3 })
+        // All captured coin values should be 50
+        assertTrue(coinCaptor.allValues.all { it == 50 })
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/service/LobbyServiceIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/LobbyServiceIntegrationTest.kt
@@ -160,11 +160,11 @@ class LobbyServiceIntegrationTest : AbstractDBSetup() {
             result.playerCards[firstPlayerId]?.map { it.cardType }?.toSet(),
         )
 
-        // Coins - should be 3
+        // Coins - should be 50
         val firstPlayerCoins = playerDao.findById(firstPlayerId)?.coins
         val secondPlayerCoins = playerDao.findById(secondPlayerId)?.coins
-        assertEquals(3, firstPlayerCoins)
-        assertEquals(3, secondPlayerCoins)
+        assertEquals(50, firstPlayerCoins)
+        assertEquals(50, secondPlayerCoins)
     }
 
     @Test

--- a/src/test/kotlin/org/machikoro/server/service/LobbyServiceIntegrationTest.kt
+++ b/src/test/kotlin/org/machikoro/server/service/LobbyServiceIntegrationTest.kt
@@ -186,7 +186,7 @@ class LobbyServiceIntegrationTest : AbstractDBSetup() {
         // Verify coins
         result.players.forEach { player ->
             val playerRecord = playerDao.findById(player.id)
-            assertEquals(3, playerRecord?.coins, "Player ${player.id} should have 3 coins")
+            assertEquals(50, playerRecord?.coins, "Player ${player.id} should have 50 coins")
         }
 
         // Verify starting cards in DB and in the GameStateDto snapshot.


### PR DESCRIPTION
3. GameDao.kt (line ~244)
   File: src/main/kotlin/org/machikoro/server/dao/GameDao.kt

   Problem: tryMarkPurchasedThisTurn() only guarded on hasPurchasedThisTurn = false.
   It did not check the current turnPhase. A purchase arriving after endTurn had
   already committed (phase = ROLL_DICE, hasPurchasedThisTurn reset to false) could
   slip through the CAS and be applied to the wrong turn.

   Fix:
     - Added (Games.turnPhase eq TurnPhase.BUY_OR_BUILD) to the UPDATE WHERE clause
     - Purchase is now atomically rejected if the phase has already advanced

4. PlayerLandmarkDao.kt
   File: src/main/kotlin/org/machikoro/server/dao/PlayerLandmarkDao.kt

   Problem: No batch lookup existed. buildSnapshot() called findByPlayerId() once
   per player in a loop — 4 separate DB queries for a 4-player game, every action.

   Fix:
     - Added findByPlayerIds(playerIds: List<Int>): Map<Int, List<PlayerLandmarkModel>>
     - Single JOIN query with inList, grouped by player ID
     - Added import for inList

5. GameSyncService.kt (line ~65)
   File: src/main/kotlin/org/machikoro/server/service/GameSyncService.kt

   Problem: buildSnapshot() iterated over players to call findByPlayerId() per player
   (N+1). This ran on every single game action.

   Fix:
     - Now calls playerLandmarkDao.findByPlayerIds(players.map { it.id })
     - One query instead of N, result grouped into the same map structure

6. EarningsServiceImpl.kt (lines ~56-66)
   File: src/main/kotlin/org/machikoro/server/service/EarningsServiceImpl.kt

   Problem: calculateEarnings() looped over players calling findByPlayerId() for
   cards AND findByPlayerIdAndType() for the Shopping Mall landmark — 2N queries
   per earnings calculation (up to 8 extra queries for 4 players per dice roll).
   The batch API already existed in PlayerCardDao but was never used here.

   Fix:
     - Player cards: replaced per-player loop with playerCardDao.findByPlayerIds()
     - Player landmarks: replaced per-player loop with playerLandmarkDao.findByPlayerIds()
     - Shopping Mall check now uses .any { it.landmarkType == SHOPPING_MALL && it.isBuilt }
       on the already-fetched landmark list — no extra query